### PR TITLE
FEAT: Rename plugins to glean-experimental; point marketplace at gleanwork repo

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "glean-codex",
+      "name": "glean-experimental-codex",
       "source": {
         "source": "local",
         "path": "./packages/codex"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,11 @@
 {
-  "name": "glean-plugins-internal",
+  "name": "glean-experimental-plugins",
   "owner": {
     "name": "Glean"
   },
   "plugins": [
     {
-      "name": "glean",
+      "name": "glean-experimental",
       "source": "./plugins/glean",
       "description": "Glean plugin for discovering skills and running tools."
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
   "enabledPlugins": {
-    "glean@glean-plugins-internal": true
+    "glean-experimental@glean-experimental-plugins": true
   }
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "glean-cursor1",
+      "name": "glean-experimental-cursor",
       "source": "plugins/glean",
       "description": "Glean plugin for discovering skills and running tools."
     }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ marketplace.
 
 Today it ships one plugin:
 
-- **`glean`** — adds two static tools, `find_skills` and `run_tool`, that
+- **`glean-experimental`** — adds two static tools, `find_skills` and `run_tool`, that
   let the agent discover Glean-hosted skills for enterprise apps (Jira, Slack,
   Google Workspace, Salesforce, etc.) and invoke their downstream tools via
   Glean's MCP gateway. Once the user has authenticated, the plugin also
@@ -19,16 +19,16 @@ Today it ships one plugin:
 ### Claude Code (terminal)
 
 ```
-/plugin marketplace add askscio/glean-plugins-internal
-/plugin install glean@glean-plugins-internal
+/plugin marketplace add gleanwork/glean-experimental-plugins
+/plugin install glean-experimental@glean-experimental-plugins
 ```
 
 ### Claude Cowork (desktop)
 
 1. Open the plugin picker.
 2. Click **Add marketplace**, choose **GitHub**, and enter
-   `askscio/glean-plugins-internal`.
-3. Once the marketplace syncs, install the **glean** plugin from it.
+   `gleanwork/glean-experimental-plugins`.
+3. Once the marketplace syncs, install the **glean-experimental** plugin from it.
 
 ## First run
 
@@ -42,7 +42,7 @@ expires.
 
 ```
 # Claude Code
-/plugin marketplace update glean-plugins-internal
+/plugin marketplace update glean-experimental-plugins
 
 # Cowork: the plugin picker has a "Sync" / "Check for updates"
 # button on the marketplace entry.
@@ -54,12 +54,12 @@ You can point the marketplace at a specific git branch, tag, or commit:
 
 ```bash
 # Install from a specific branch (e.g. a PR branch)
-/plugin marketplace add askscio/glean-plugins-internal@branch-name
-/plugin install glean@glean-plugins-internal
+/plugin marketplace add gleanwork/glean-experimental-plugins@branch-name
+/plugin install glean-experimental@glean-experimental-plugins
 
 # Or update an existing marketplace to a different branch
-/plugin marketplace remove glean-plugins-internal
-/plugin marketplace add askscio/glean-plugins-internal@branch-name
+/plugin marketplace remove glean-experimental-plugins
+/plugin marketplace add gleanwork/glean-experimental-plugins@branch-name
 ```
 
 You can also pin to a branch in `settings.json`:
@@ -68,8 +68,8 @@ You can also pin to a branch in `settings.json`:
 {
   "marketplaces": [
     {
-      "name": "glean-plugins-internal",
-      "source": "https://github.com/askscio/glean-plugins-internal",
+      "name": "glean-experimental-plugins",
+      "source": "https://github.com/gleanwork/glean-experimental-plugins",
       "sourceType": "git",
       "branch": "mohit-baseline-marketplace-layout"
     }
@@ -80,7 +80,7 @@ You can also pin to a branch in `settings.json`:
 For local development, point the marketplace at your local checkout instead:
 
 ```bash
-/plugin marketplace add /path/to/glean-plugins-internal
+/plugin marketplace add /path/to/glean-experimental-plugins
 ```
 
 Then just `git checkout` whichever branch you want to test.

--- a/packages/codex/.codex-plugin/plugin.json
+++ b/packages/codex/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "glean-codex",
+  "name": "glean-experimental-codex",
   "version": "0.2.11",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {

--- a/packages/codex/README.md
+++ b/packages/codex/README.md
@@ -18,7 +18,7 @@ This repo ships `.agents/plugins/marketplace.json` pointing at `./packages/codex
 
 1. Open Codex with this repo as the workspace root.
 2. Open the plugin directory — Codex desktop: **Plugins**, Codex CLI: `/plugins`.
-3. Find **Glean for Codex (Local Repo)** and install `glean-codex`.
+3. Find **Glean for Codex (Local Repo)** and install `glean-experimental-codex`.
 4. Restart Codex if the marketplace doesn't appear immediately.
 
 Before the first install from a fresh checkout, run `npm run build` once so

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "glean",
-  "version": "0.2.16",
+  "name": "glean-experimental",
+  "version": "0.2.17",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "glean-cursor-plugin",
+  "name": "glean-experimental-cursor",
   "displayName": "Glean Cursor",
   "version": "0.2.15",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",


### PR DESCRIPTION
## Summary
Renames the plugins to the `glean-experimental` family and repoints the marketplace/install flow at this repo (`gleanwork/glean-experimental-plugins`). **No description text was changed** — only identifiers, the marketplace name, the version bump, and install references.

## Renames
| Platform | Before | After |
|---|---|---|
| Claude/Cowork plugin | `glean` | `glean-experimental` |
| Cursor plugin | `glean-cursor1` / `glean-cursor-plugin` | `glean-experimental-cursor` |
| Codex plugin | `glean-codex` | `glean-experimental-codex` |
| Claude marketplace | `glean-plugins-internal` | `glean-experimental-plugins` |

## README / install
- `/plugin marketplace add gleanwork/glean-experimental-plugins`
- `/plugin install glean-experimental@glean-experimental-plugins`
- Cowork, branch-testing, `settings.json`, and local-checkout examples all updated to the new repo + names.
- `.claude/settings.json` (enabled-plugins key) and the codex `README.md` install reference updated to match.

## Notes
- **Version bump:** `plugins/glean/.claude-plugin/plugin.json` `0.2.16 → 0.2.17` (required by `check-version-bump`).
- **Left unchanged on purpose:** all `description` fields, `displayName`s, MCP server names (`glean` / `glean-local` in `.mcp.json` and `src/`), the `plugins/glean/` folder, and internal/runtime `package.json` names.
