### PR TITLE
Fix run_tool dropping empty arguments for no-arg downstream tools

### DIFF
--- a/packages/codex/.codex-plugin/plugin.json
+++ b/packages/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-experimental-codex",
-  "version": "0.2.11",
+  "version": "0.2.18",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/packages/codex/dist/index.js
+++ b/packages/codex/dist/index.js
@@ -31152,14 +31152,18 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
     }
     throw err;
   }
-  const remoteArgs = {
+  return callRemoteTool(
+    remoteClient,
+    "run_tool",
+    buildRemoteArgs(serverId, toolName, resolvedArgs)
+  );
+}
+function buildRemoteArgs(serverId, toolName, resolvedArgs) {
+  return {
     server_id: serverId,
-    tool_name: toolName
+    tool_name: toolName,
+    arguments: resolvedArgs
   };
-  if (Object.keys(resolvedArgs).length > 0) {
-    remoteArgs.arguments = resolvedArgs;
-  }
-  return callRemoteTool(remoteClient, "run_tool", remoteArgs);
 }
 
 // src/url-config-store.ts

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-experimental",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-experimental-cursor",
   "displayName": "Glean Cursor",
-  "version": "0.2.15",
+  "version": "0.2.18",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -31152,14 +31152,18 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
     }
     throw err;
   }
-  const remoteArgs = {
+  return callRemoteTool(
+    remoteClient,
+    "run_tool",
+    buildRemoteArgs(serverId, toolName, resolvedArgs)
+  );
+}
+function buildRemoteArgs(serverId, toolName, resolvedArgs) {
+  return {
     server_id: serverId,
-    tool_name: toolName
+    tool_name: toolName,
+    arguments: resolvedArgs
   };
-  if (Object.keys(resolvedArgs).length > 0) {
-    remoteArgs.arguments = resolvedArgs;
-  }
-  return callRemoteTool(remoteClient, "run_tool", remoteArgs);
 }
 
 // src/url-config-store.ts

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -192,12 +192,29 @@ export async function handleRunTool(
     throw err;
   }
 
-  const remoteArgs: Record<string, unknown> = {
+  return callRemoteTool(
+    remoteClient,
+    "run_tool",
+    buildRemoteArgs(serverId, toolName, resolvedArgs),
+  );
+}
+
+/**
+ * Assemble the payload for the backend `run_tool` meta-tool. `arguments` is
+ * ALWAYS included, even when empty: the downstream MCP `tools/call` validates
+ * `params.arguments` as an object, and an absent field serializes to `null`,
+ * which strict downstream servers reject ("Expected: object, given: null").
+ * Sending an explicit `{}` for no-argument tools matches what the MCP SDK
+ * does for direct tool calls.
+ */
+export function buildRemoteArgs(
+  serverId: string,
+  toolName: string,
+  resolvedArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
     server_id: serverId,
     tool_name: toolName,
+    arguments: resolvedArgs,
   };
-  if (Object.keys(resolvedArgs).length > 0) {
-    remoteArgs.arguments = resolvedArgs;
-  }
-  return callRemoteTool(remoteClient, "run_tool", remoteArgs);
 }

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { resolveFileArgs, FileArgsError } from "../src/tools/run-tool.js";
+import {
+  resolveFileArgs,
+  buildRemoteArgs,
+  FileArgsError,
+} from "../src/tools/run-tool.js";
 
 describe("resolveFileArgs", () => {
   let tmpDir: string;
@@ -130,5 +134,28 @@ describe("resolveFileArgs", () => {
     await expect(
       resolveFileArgs({ body: file }, { body: "existing" }),
     ).rejects.toThrow(/conflicts/);
+  });
+});
+
+describe("buildRemoteArgs", () => {
+  // Regression: a no-argument downstream call (e.g. slack_read_user_profile)
+  // must forward `arguments: {}`, not omit the key. An absent field serializes
+  // to null downstream, which strict MCP servers reject.
+  it("always includes arguments, even when empty", () => {
+    expect(buildRemoteArgs("srv", "tool", {})).toEqual({
+      server_id: "srv",
+      tool_name: "tool",
+      arguments: {},
+    });
+  });
+
+  it("forwards populated arguments unchanged", () => {
+    expect(
+      buildRemoteArgs("srv", "tool", { response_format: "detailed" }),
+    ).toEqual({
+      server_id: "srv",
+      tool_name: "tool",
+      arguments: { response_format: "detailed" },
+    });
   });
 });


### PR DESCRIPTION
## Problem

`run_tool` failed for every downstream tool called with no arguments (e.g. `slack_read_user_profile`), returning:

> Expected: object, given: null

## Root cause

In `src/tools/run-tool.ts`, the payload assembly omitted the `arguments` key entirely when the resolved args were empty:

```js
if (Object.keys(resolvedArgs).length > 0) {
  remoteArgs.arguments = resolvedArgs;
}
```

With the key absent, the backend `run_tool` meta-tool forwarded a downstream `tools/call` with no `arguments`, which serializes to `null`. Strict downstream MCP servers validate `params.arguments` as an object and reject `null`.

The key's **presence**, not its value, was the only difference between a failing and succeeding call — passing any non-empty object (the prior workaround) incidentally tripped the guard true.

## Fix

Always include `arguments`, defaulting to an explicit `{}` when empty — matching what the MCP SDK sends for direct tool calls. Extracted the assembly into a pure `buildRemoteArgs()` helper and added regression tests for the empty and populated cases.


## Verification

- `npm run typecheck` — clean
- `npm test` — 134 passed, including 2 new `buildRemoteArgs` tests