### PR TITLE
[Plugin] Fix HITL elicitation approval: display + fail-closed timeout

### DIFF
--- a/packages/codex/.codex-plugin/plugin.json
+++ b/packages/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-experimental-codex",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/packages/codex/.mcp.json
+++ b/packages/codex/.mcp.json
@@ -5,7 +5,8 @@
       "args": ["./start.sh"],
       "cwd": ".",
       "env": {
-        "ENABLE_HITL": "true"
+        "ENABLE_HITL": "true",
+        "HITL_TIMEOUT_MS": "300000"
       }
     }
   }

--- a/packages/codex/dist/index.js
+++ b/packages/codex/dist/index.js
@@ -31018,8 +31018,8 @@ async function handleFindSkills(remoteClient, skillsBaseDir, args) {
 // src/tools/run-tool.ts
 import fs4 from "node:fs/promises";
 import path4 from "node:path";
-var HITL_ENABLED = process.env.ENABLE_HITL === "true";
 var DEFAULT_FILE_ARG_MAX_BYTES = 1 * 1024 * 1024;
+var defaultHitlTimeoutMs = 3e5;
 var FileArgsError = class extends Error {
   constructor(message) {
     super(message);
@@ -31031,6 +31031,12 @@ function fileArgsMaxBytes() {
   if (!raw) return DEFAULT_FILE_ARG_MAX_BYTES;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_FILE_ARG_MAX_BYTES;
+}
+function hitlTimeoutMs() {
+  const raw = process.env.HITL_TIMEOUT_MS;
+  if (!raw) return defaultHitlTimeoutMs;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultHitlTimeoutMs;
 }
 async function resolveFileArgs(fileArgs, baseArgs) {
   if (fileArgs === void 0 || fileArgs === null) return baseArgs;
@@ -31099,6 +31105,25 @@ async function findToolJson(skillsBaseDir, toolName) {
   }
   return null;
 }
+function isCursorClient(mcpServer) {
+  return (mcpServer.getClientVersion()?.name ?? "").toLowerCase().startsWith("cursor");
+}
+function formatArguments(args) {
+  if (args == null || typeof args === "object" && Object.keys(args).length === 0) {
+    return "(none)";
+  }
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch {
+    return String(args);
+  }
+}
+function buildApprovalMessage(mcpServer, toolName, args) {
+  if (isCursorClient(mcpServer)) {
+    return `Review the tool and arguments shown above, then accept to run "${toolName}" or decline to cancel.`;
+  }
+  return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
+}
 async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
@@ -31110,21 +31135,20 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       isError: true
     };
   }
-  if (HITL_ENABLED && mcpServer.getClientCapabilities()?.elicitation) {
+  const hitlEnabled = process.env.ENABLE_HITL === "true";
+  if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
     const toolMeta = await findToolJson(skillsBaseDir, toolName);
     if (toolMeta?.requires_approval) {
-      const message = [
-        `**Action: ${toolName}**`,
-        toolMeta.description ? `${toolMeta.description}` : "",
-        `Server: ${serverId}`,
-        "",
-        "Accept to execute, or decline to cancel."
-      ].filter(Boolean).join("\n");
+      const message = buildApprovalMessage(mcpServer, toolName, args.arguments);
+      const timeout = hitlTimeoutMs();
       try {
-        const result = await mcpServer.elicitInput({
-          message,
-          requestedSchema: { type: "object", properties: {} }
-        });
+        const result = await mcpServer.elicitInput(
+          {
+            message,
+            requestedSchema: { type: "object", properties: {} }
+          },
+          { timeout }
+        );
         if (result.action !== "accept") {
           return {
             content: [
@@ -31135,7 +31159,17 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
             ]
           };
         }
-      } catch {
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Action ${toolName} was not approved \u2014 the approval request failed (${detail}). The action was NOT executed. Ask the user to confirm, then retry.`
+            }
+          ],
+          isError: true
+        };
       }
     }
   }

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-experimental",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-experimental-cursor",
   "displayName": "Glean Cursor",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.mcp.json
+++ b/plugins/glean/.mcp.json
@@ -4,7 +4,8 @@
       "command": "bash",
       "args": ["${CLAUDE_PLUGIN_ROOT}/start.sh"],
       "env": {
-        "ENABLE_HITL": "false"
+        "ENABLE_HITL": "false",
+        "HITL_TIMEOUT_MS": "300000"
       }
     }
   }

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -31018,8 +31018,8 @@ async function handleFindSkills(remoteClient, skillsBaseDir, args) {
 // src/tools/run-tool.ts
 import fs4 from "node:fs/promises";
 import path4 from "node:path";
-var HITL_ENABLED = process.env.ENABLE_HITL === "true";
 var DEFAULT_FILE_ARG_MAX_BYTES = 1 * 1024 * 1024;
+var defaultHitlTimeoutMs = 3e5;
 var FileArgsError = class extends Error {
   constructor(message) {
     super(message);
@@ -31031,6 +31031,12 @@ function fileArgsMaxBytes() {
   if (!raw) return DEFAULT_FILE_ARG_MAX_BYTES;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_FILE_ARG_MAX_BYTES;
+}
+function hitlTimeoutMs() {
+  const raw = process.env.HITL_TIMEOUT_MS;
+  if (!raw) return defaultHitlTimeoutMs;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultHitlTimeoutMs;
 }
 async function resolveFileArgs(fileArgs, baseArgs) {
   if (fileArgs === void 0 || fileArgs === null) return baseArgs;
@@ -31099,6 +31105,25 @@ async function findToolJson(skillsBaseDir, toolName) {
   }
   return null;
 }
+function isCursorClient(mcpServer) {
+  return (mcpServer.getClientVersion()?.name ?? "").toLowerCase().startsWith("cursor");
+}
+function formatArguments(args) {
+  if (args == null || typeof args === "object" && Object.keys(args).length === 0) {
+    return "(none)";
+  }
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch {
+    return String(args);
+  }
+}
+function buildApprovalMessage(mcpServer, toolName, args) {
+  if (isCursorClient(mcpServer)) {
+    return `Review the tool and arguments shown above, then accept to run "${toolName}" or decline to cancel.`;
+  }
+  return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
+}
 async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
@@ -31110,21 +31135,20 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       isError: true
     };
   }
-  if (HITL_ENABLED && mcpServer.getClientCapabilities()?.elicitation) {
+  const hitlEnabled = process.env.ENABLE_HITL === "true";
+  if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
     const toolMeta = await findToolJson(skillsBaseDir, toolName);
     if (toolMeta?.requires_approval) {
-      const message = [
-        `**Action: ${toolName}**`,
-        toolMeta.description ? `${toolMeta.description}` : "",
-        `Server: ${serverId}`,
-        "",
-        "Accept to execute, or decline to cancel."
-      ].filter(Boolean).join("\n");
+      const message = buildApprovalMessage(mcpServer, toolName, args.arguments);
+      const timeout = hitlTimeoutMs();
       try {
-        const result = await mcpServer.elicitInput({
-          message,
-          requestedSchema: { type: "object", properties: {} }
-        });
+        const result = await mcpServer.elicitInput(
+          {
+            message,
+            requestedSchema: { type: "object", properties: {} }
+          },
+          { timeout }
+        );
         if (result.action !== "accept") {
           return {
             content: [
@@ -31135,7 +31159,17 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
             ]
           };
         }
-      } catch {
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Action ${toolName} was not approved \u2014 the approval request failed (${detail}). The action was NOT executed. Ask the user to confirm, then retry.`
+            }
+          ],
+          isError: true
+        };
       }
     }
   }

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -5,8 +5,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { callRemoteTool } from "../remote-client.js";
 
-const HITL_ENABLED = process.env.ENABLE_HITL === "true";
 const DEFAULT_FILE_ARG_MAX_BYTES = 1 * 1024 * 1024;
+
+// How long a user has to respond to an approval prompt. The MCP SDK's own
+// request timeout is 60s and, on expiry, elicitInput REJECTS — so unless we
+// pass an explicit (longer) value the prompt errors out from under the user.
+const defaultHitlTimeoutMs = 300_000;
 
 export class FileArgsError extends Error {
   constructor(message: string) {
@@ -22,6 +26,13 @@ function fileArgsMaxBytes(): number {
   return Number.isFinite(parsed) && parsed > 0
     ? parsed
     : DEFAULT_FILE_ARG_MAX_BYTES;
+}
+
+function hitlTimeoutMs(): number {
+  const raw = process.env.HITL_TIMEOUT_MS;
+  if (!raw) return defaultHitlTimeoutMs;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultHitlTimeoutMs;
 }
 
 /**
@@ -121,6 +132,44 @@ async function findToolJson(
   return null;
 }
 
+// A stdio server's only client signal is clientInfo.name. Cursor reports
+// "cursor-vscode" and already renders the tool name + arguments in its own
+// expandable UI, so its approval prompt only needs a one-line review ask.
+function isCursorClient(mcpServer: Server): boolean {
+  return (mcpServer.getClientVersion()?.name ?? "")
+    .toLowerCase()
+    .startsWith("cursor");
+}
+
+function formatArguments(args: unknown): string {
+  if (
+    args == null ||
+    (typeof args === "object" && Object.keys(args as object).length === 0)
+  ) {
+    return "(none)";
+  }
+  try {
+    return JSON.stringify(args, null, 2);
+  } catch {
+    return String(args);
+  }
+}
+
+// Plain text, NOT Markdown: Claude Code does not reliably render Markdown in
+// elicitation prompts, so bold/headings would leak as literal characters.
+function buildApprovalMessage(
+  mcpServer: Server,
+  toolName: string,
+  args: unknown,
+): string {
+  if (isCursorClient(mcpServer)) {
+    return `Review the tool and arguments shown above, then accept to run "${toolName}" or decline to cancel.`;
+  }
+
+  // Claude Code: action name and arguments only.
+  return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
+}
+
 export async function handleRunTool(
   remoteClient: Client,
   mcpServer: Server,
@@ -139,25 +188,22 @@ export async function handleRunTool(
     };
   }
 
-  if (HITL_ENABLED && mcpServer.getClientCapabilities()?.elicitation) {
+  const hitlEnabled = process.env.ENABLE_HITL === "true";
+  if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
     const toolMeta = await findToolJson(skillsBaseDir, toolName);
 
     if (toolMeta?.requires_approval) {
-      const message = [
-        `**Action: ${toolName}**`,
-        toolMeta.description ? `${toolMeta.description}` : "",
-        `Server: ${serverId}`,
-        "",
-        "Accept to execute, or decline to cancel.",
-      ]
-        .filter(Boolean)
-        .join("\n");
+      const message = buildApprovalMessage(mcpServer, toolName, args.arguments);
+      const timeout = hitlTimeoutMs();
 
       try {
-        const result = await mcpServer.elicitInput({
-          message,
-          requestedSchema: { type: "object", properties: {} } as any,
-        });
+        const result = await mcpServer.elicitInput(
+          {
+            message,
+            requestedSchema: { type: "object", properties: {} } as any,
+          },
+          { timeout },
+        );
 
         if (result.action !== "accept") {
           return {
@@ -169,8 +215,20 @@ export async function handleRunTool(
             ],
           };
         }
-      } catch {
-        // Fall through to execute without approval on elicitation failure
+      } catch (err) {
+        // Fail CLOSED. An approval gate that executes the action when the
+        // prompt times out or errors defeats its own purpose — and the SDK
+        // rejects elicitInput precisely on request timeout.
+        const detail = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Action ${toolName} was not approved — the approval request failed (${detail}). The action was NOT executed. Ask the user to confirm, then retry.`,
+            },
+          ],
+          isError: true,
+        };
       }
     }
   }

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -6,6 +6,7 @@ import {
   resolveFileArgs,
   buildRemoteArgs,
   FileArgsError,
+  handleRunTool,
 } from "../src/tools/run-tool.js";
 
 describe("resolveFileArgs", () => {
@@ -157,5 +158,185 @@ describe("buildRemoteArgs", () => {
       tool_name: "tool",
       arguments: { response_format: "detailed" },
     });
+  });
+});
+
+function makeRemote() {
+  return {
+    callTool: vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    }),
+    close: vi.fn(),
+  } as any;
+}
+
+function makeServer(opts: {
+  elicitation?: boolean;
+  clientName?: string;
+  elicit?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    getClientCapabilities: vi
+      .fn()
+      .mockReturnValue(opts.elicitation ? { elicitation: {} } : {}),
+    getClientVersion: vi
+      .fn()
+      .mockReturnValue({ name: opts.clientName ?? "claude-code", version: "1" }),
+    elicitInput: opts.elicit ?? vi.fn().mockResolvedValue({ action: "accept" }),
+  } as any;
+}
+
+async function writeToolJson(
+  baseDir: string,
+  toolName: string,
+  meta: Record<string, unknown>,
+) {
+  const toolsDir = path.join(baseDir, "some-skill", "tools");
+  await fs.mkdir(toolsDir, { recursive: true });
+  await fs.writeFile(
+    path.join(toolsDir, `${toolName}.json`),
+    JSON.stringify(meta),
+    "utf-8",
+  );
+}
+
+describe("handleRunTool (HITL)", () => {
+  let tmpDir: string;
+  const baseArgs = {
+    server_id: "composio/jira-pack",
+    tool_name: "jirasearch",
+    arguments: { project: "ABC", summary: "fix login" },
+  };
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "run-tool-hitl-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("does not elicit when the client lacks elicitation capability", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const server = makeServer({ elicitation: false });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(server.elicitInput).not.toHaveBeenCalled();
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not elicit when the tool does not require approval", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const server = makeServer({ elicitation: true });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(server.elicitInput).not.toHaveBeenCalled();
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("prompts with action name + arguments and forwards on accept", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "jirasearch", {
+      requires_approval: true,
+      description: "Search Jira issues",
+    });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    const [params, options] = elicit.mock.calls[0];
+    expect(params.message).toContain("Action: jirasearch");
+    expect(params.message).toContain('"project": "ABC"');
+    expect(params.message).not.toContain("Server:");
+    expect(params.message).not.toContain("Search Jira issues");
+    expect(params.message).not.toContain("**");
+    expect(options.timeout).toBe(300_000);
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors the HITL_TIMEOUT_MS override", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    vi.stubEnv("HITL_TIMEOUT_MS", "5000");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(elicit.mock.calls[0][1].timeout).toBe(5000);
+  });
+
+  it("falls back to the default timeout for invalid HITL_TIMEOUT_MS", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    for (const bad of ["0", "-1", "abc", ""]) {
+      vi.stubEnv("HITL_TIMEOUT_MS", bad);
+      const remote = makeRemote();
+      const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+      const server = makeServer({ elicitation: true, elicit });
+
+      await handleRunTool(remote, server, tmpDir, baseArgs);
+
+      expect(elicit.mock.calls[0][1].timeout).toBe(300_000);
+    }
+  });
+
+  it("does not execute when the user declines", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "decline" });
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(remote.callTool).not.toHaveBeenCalled();
+    expect((result.content[0] as { text: string }).text).toContain("declined");
+  });
+
+  it("fails closed and does NOT execute when elicitation times out", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockRejectedValue(new Error("Request timed out"));
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(remote.callTool).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("not approved");
+    expect(text).toContain("NOT executed");
+  });
+
+  it("gives Cursor a one-line prompt without an arguments block", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    const message = elicit.mock.calls[0][0].message as string;
+    expect(message).toContain('accept to run "jirasearch"');
+    expect(message).not.toContain("Arguments:");
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What

Fixes the HITL (human-in-the-loop) approval prompt shown before running a `requires_approval` action via `run_tool`. Gated behind `ENABLE_HITL` (Claude/Cursor default `false`; Codex `true`).

In `src/tools/run-tool.ts` (preserves #3's `buildRemoteArgs`):
- **Display:** the elicitation `message` was Markdown (which Claude Code no longer renders, so it showed literal `**...**`) and the action's arguments were never shown. Now plain text and client-aware: **Claude Code shows action name + arguments only**; **Cursor** gets a one-line review prompt (it already shows tool+args in its own expandable UI).
- **Timeout:** `elicitInput` was called with no timeout → used the SDK's 60s default → on expiry it rejects, and the old `catch {}` swallowed that and fell through to run the action without approval (fail-open). Now passes an explicit, validated timeout via `hitlTimeoutMs()` (`HITL_TIMEOUT_MS`, default 300s; 0/negative/non-numeric fall back to the default).
- **Fail closed:** on timeout or any elicitation error, return "not approved / not executed" instead of running.

Reads `ENABLE_HITL`/`HITL_TIMEOUT_MS` inside the handler for testability; adds a `handleRunTool` test suite. Wires `HITL_TIMEOUT_MS` into both `.mcp.json` files. Bumps version to **0.2.19**.

### Known follow-up (not in this PR)
`run_tool` reads `file_args` from disk and merges them into the arguments **after** approval, so the prompt doesn't surface file-sourced inputs. Deferred pending @roshan / product input.

## Test plan
- `npm run typecheck && npm test && npm run build` — **142 tests** (new HITL suite + existing `buildRemoteArgs` tests), dist in sync, version 0.2.18 → 0.2.19.
- Manual: set `ENABLE_HITL=true`, run a `requires_approval` write tool → prompt shows action+args (Claude Code) / one-liner (Cursor); wait past the timeout → NOT executed; decline → NOT executed. Verified on Claude Code, Cursor, and Codex.
