### PR TITLE
[Plugin] Mark run_tool read-only when HITL gates it

### DIFF
--- a/packages/codex/.codex-plugin/plugin.json
+++ b/packages/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-experimental-codex",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/packages/codex/dist/index.js
+++ b/packages/codex/dist/index.js
@@ -31199,6 +31199,9 @@ function buildRemoteArgs(serverId, toolName, resolvedArgs) {
     arguments: resolvedArgs
   };
 }
+function runToolAnnotations(enableHitl, clientSupportsElicitation) {
+  return enableHitl && clientSupportsElicitation ? { readOnlyHint: true } : void 0;
+}
 
 // src/url-config-store.ts
 import fs5 from "node:fs";
@@ -31576,7 +31579,14 @@ var SETUP_TOOL = {
   }
 };
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const tools = [FIND_SKILLS_TOOL, RUN_TOOL_TOOL, SETUP_TOOL];
+  const runTool = {
+    ...RUN_TOOL_TOOL,
+    annotations: runToolAnnotations(
+      process.env.ENABLE_HITL === "true",
+      !!server.getClientCapabilities()?.elicitation
+    )
+  };
+  const tools = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];
   const serverUrl = resolveServerUrl();
   if (!serverUrl) {
     return { tools: [...tools, ...cachedRemoteTools] };

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-experimental",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-experimental-cursor",
   "displayName": "Glean Cursor",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -31199,6 +31199,9 @@ function buildRemoteArgs(serverId, toolName, resolvedArgs) {
     arguments: resolvedArgs
   };
 }
+function runToolAnnotations(enableHitl, clientSupportsElicitation) {
+  return enableHitl && clientSupportsElicitation ? { readOnlyHint: true } : void 0;
+}
 
 // src/url-config-store.ts
 import fs5 from "node:fs";
@@ -31576,7 +31579,14 @@ var SETUP_TOOL = {
   }
 };
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const tools = [FIND_SKILLS_TOOL, RUN_TOOL_TOOL, SETUP_TOOL];
+  const runTool = {
+    ...RUN_TOOL_TOOL,
+    annotations: runToolAnnotations(
+      process.env.ENABLE_HITL === "true",
+      !!server.getClientCapabilities()?.elicitation
+    )
+  };
+  const tools = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];
   const serverUrl = resolveServerUrl();
   if (!serverUrl) {
     return { tools: [...tools, ...cachedRemoteTools] };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from "./remote-client.js";
 import { GleanOAuthClientProvider } from "./auth-provider.js";
 import { handleFindSkills } from "./tools/find-skills.js";
-import { handleRunTool } from "./tools/run-tool.js";
+import { handleRunTool, runToolAnnotations } from "./tools/run-tool.js";
 import { evictStaleSkills } from "./skill-writer.js";
 import {
   loadServerUrl,
@@ -273,7 +273,14 @@ const SETUP_TOOL: Tool = {
 };
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const tools: Tool[] = [FIND_SKILLS_TOOL, RUN_TOOL_TOOL, SETUP_TOOL];
+  const runTool: Tool = {
+    ...RUN_TOOL_TOOL,
+    annotations: runToolAnnotations(
+      process.env.ENABLE_HITL === "true",
+      !!server.getClientCapabilities()?.elicitation,
+    ),
+  };
+  const tools: Tool[] = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];
 
   // Pre-auth gate: tokens() is sync. When unauthenticated (or unconfigured)
   // skip the remote round-trip — but keep surfacing whatever we successfully

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -1,6 +1,6 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { callRemoteTool } from "../remote-client.js";
@@ -275,4 +275,20 @@ export function buildRemoteArgs(
     tool_name: toolName,
     arguments: resolvedArgs,
   };
+}
+
+/**
+ * Annotations for the `run_tool` meta-tool. When HITL is active for an
+ * elicitation-capable client, our own approval prompt is the gate, so we mark
+ * the tool `readOnlyHint` to suppress the client's native run-tool confirmation
+ * and avoid a double prompt. Without HITL there is no gate of our own, so we
+ * leave annotations unset and let the client decide.
+ */
+export function runToolAnnotations(
+  enableHitl: boolean,
+  clientSupportsElicitation: boolean,
+): Tool["annotations"] {
+  return enableHitl && clientSupportsElicitation
+    ? { readOnlyHint: true }
+    : undefined;
 }

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -7,6 +7,7 @@ import {
   buildRemoteArgs,
   FileArgsError,
   handleRunTool,
+  runToolAnnotations,
 } from "../src/tools/run-tool.js";
 
 describe("resolveFileArgs", () => {
@@ -338,5 +339,19 @@ describe("handleRunTool (HITL)", () => {
     expect(message).toContain('accept to run "jirasearch"');
     expect(message).not.toContain("Arguments:");
     expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runToolAnnotations", () => {
+  it("marks run_tool read-only when HITL gates an elicitation-capable client", () => {
+    expect(runToolAnnotations(true, true)).toEqual({ readOnlyHint: true });
+  });
+
+  it("leaves annotations unset when HITL is disabled", () => {
+    expect(runToolAnnotations(false, true)).toBeUndefined();
+  });
+
+  it("leaves annotations unset when the client cannot elicit", () => {
+    expect(runToolAnnotations(true, false)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

When `ENABLE_HITL` is on **and** the client supports elicitation, the plugin's own `run_tool` approval prompt is the gate. This PR advertises `run_tool` with `readOnlyHint: true` at list-tools time in that case, so the client (e.g. Codex's *"Allow run_tool?"* / Claude's tool-approval) won't add a **second, redundant** native approval prompt on top of our elicitation.

**Both conditions are required** (`ENABLE_HITL && getClientCapabilities()?.elicitation`):
- If the client **can't** elicit, the HITL gate is skipped at runtime — so `run_tool` must stay gated by the client (no read-only hint). Claiming read-only there would let write actions run with **no approval at all** (fail-open).

Implemented as a pure `runToolAnnotations(enableHitl, clientSupportsElicitation)` helper (in `run-tool.ts`), called from the `list_tools` handler with the live client capabilities; unit-tested.

Independent of #4 (the HITL display/timeout fix) — applies directly on top of `main`.

## Notes / caveats
- `readOnlyHint` is an **advisory hint** — whether a given client actually suppresses its native gate for read-only tools is client-dependent. Worth confirming per client (Codex/Claude) that the double-prompt is gone.
- Version bumped to **0.2.20** assuming #4 (0.2.19) lands first; whichever of {#4, this} merges second may need a version re-bump.

## Test plan
- `npm run typecheck && npm test && npm run build` — 136 tests incl. `runToolAnnotations`.
- Manual: with `ENABLE_HITL=true` in Codex/Claude, run a `run_tool` call and confirm the client's native "Allow run_tool?" prompt no longer appears (only the HITL elicitation does). With HITL off, the client gate still appears.
