### PR TITLE
Rename plugin to glean-vnext across all harnesses

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "glean-experimental-codex",
+      "name": "glean-vnext",
       "source": {
         "source": "local",
         "path": "./packages/codex"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "glean-experimental-plugins",
+  "name": "glean-plugins-vnext",
   "owner": {
     "name": "Glean"
   },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "glean-experimental",
+      "name": "glean-vnext",
       "source": "./plugins/glean",
       "description": "Glean plugin for discovering skills and running tools."
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
   "enabledPlugins": {
-    "glean-experimental@glean-experimental-plugins": true
+    "glean-vnext@glean-experimental-plugins": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
   "enabledPlugins": {
-    "glean-vnext@glean-experimental-plugins": true
+    "glean-vnext@glean-plugins-vnext": true
   }
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "glean-experimental-cursor",
+      "name": "glean-vnext",
       "source": "plugins/glean",
       "description": "Glean plugin for discovering skills and running tools."
     }

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Today it ships one plugin:
 ### Claude Code (terminal)
 
 ```
-/plugin marketplace add gleanwork/glean-experimental-plugins
-/plugin install glean-vnext@glean-experimental-plugins
+/plugin marketplace add gleanwork/glean-plugins-vnext
+/plugin install glean-vnext@glean-plugins-vnext
 ```
 
 ### Claude Cowork (desktop)
 
 1. Open the plugin picker.
 2. Click **Add marketplace**, choose **GitHub**, and enter
-   `gleanwork/glean-experimental-plugins`.
+   `gleanwork/glean-plugins-vnext`.
 3. Once the marketplace syncs, install the **glean-vnext** plugin from it.
 
 ## First run
@@ -42,7 +42,7 @@ expires.
 
 ```
 # Claude Code
-/plugin marketplace update glean-experimental-plugins
+/plugin marketplace update glean-plugins-vnext
 
 # Cowork: the plugin picker has a "Sync" / "Check for updates"
 # button on the marketplace entry.
@@ -54,12 +54,12 @@ You can point the marketplace at a specific git branch, tag, or commit:
 
 ```bash
 # Install from a specific branch (e.g. a PR branch)
-/plugin marketplace add gleanwork/glean-experimental-plugins@branch-name
-/plugin install glean-vnext@glean-experimental-plugins
+/plugin marketplace add gleanwork/glean-plugins-vnext@branch-name
+/plugin install glean-vnext@glean-plugins-vnext
 
 # Or update an existing marketplace to a different branch
-/plugin marketplace remove glean-experimental-plugins
-/plugin marketplace add gleanwork/glean-experimental-plugins@branch-name
+/plugin marketplace remove glean-plugins-vnext
+/plugin marketplace add gleanwork/glean-plugins-vnext@branch-name
 ```
 
 You can also pin to a branch in `settings.json`:
@@ -68,8 +68,8 @@ You can also pin to a branch in `settings.json`:
 {
   "marketplaces": [
     {
-      "name": "glean-experimental-plugins",
-      "source": "https://github.com/gleanwork/glean-experimental-plugins",
+      "name": "glean-plugins-vnext",
+      "source": "https://github.com/gleanwork/glean-plugins-vnext",
       "sourceType": "git",
       "branch": "mohit-baseline-marketplace-layout"
     }
@@ -80,7 +80,7 @@ You can also pin to a branch in `settings.json`:
 For local development, point the marketplace at your local checkout instead:
 
 ```bash
-/plugin marketplace add /path/to/glean-experimental-plugins
+/plugin marketplace add /path/to/glean-plugins-vnext
 ```
 
 Then just `git checkout` whichever branch you want to test.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ marketplace.
 
 Today it ships one plugin:
 
-- **`glean-experimental`** — adds two static tools, `find_skills` and `run_tool`, that
+- **`glean-vnext`** — adds two static tools, `find_skills` and `run_tool`, that
   let the agent discover Glean-hosted skills for enterprise apps (Jira, Slack,
   Google Workspace, Salesforce, etc.) and invoke their downstream tools via
   Glean's MCP gateway. Once the user has authenticated, the plugin also
@@ -20,7 +20,7 @@ Today it ships one plugin:
 
 ```
 /plugin marketplace add gleanwork/glean-experimental-plugins
-/plugin install glean-experimental@glean-experimental-plugins
+/plugin install glean-vnext@glean-experimental-plugins
 ```
 
 ### Claude Cowork (desktop)
@@ -28,7 +28,7 @@ Today it ships one plugin:
 1. Open the plugin picker.
 2. Click **Add marketplace**, choose **GitHub**, and enter
    `gleanwork/glean-experimental-plugins`.
-3. Once the marketplace syncs, install the **glean-experimental** plugin from it.
+3. Once the marketplace syncs, install the **glean-vnext** plugin from it.
 
 ## First run
 
@@ -55,7 +55,7 @@ You can point the marketplace at a specific git branch, tag, or commit:
 ```bash
 # Install from a specific branch (e.g. a PR branch)
 /plugin marketplace add gleanwork/glean-experimental-plugins@branch-name
-/plugin install glean-experimental@glean-experimental-plugins
+/plugin install glean-vnext@glean-experimental-plugins
 
 # Or update an existing marketplace to a different branch
 /plugin marketplace remove glean-experimental-plugins

--- a/packages/codex/.codex-plugin/plugin.json
+++ b/packages/codex/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "glean-experimental-codex",
+  "name": "glean-vnext",
   "version": "0.2.19",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
@@ -8,7 +8,7 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "Glean Codex",
+    "displayName": "Glean vNext",
     "websiteURL": "https://www.glean.com/home",
     "category": "Productivity",
     "defaultPrompt": [

--- a/packages/codex/README.md
+++ b/packages/codex/README.md
@@ -18,7 +18,7 @@ This repo ships `.agents/plugins/marketplace.json` pointing at `./packages/codex
 
 1. Open Codex with this repo as the workspace root.
 2. Open the plugin directory — Codex desktop: **Plugins**, Codex CLI: `/plugins`.
-3. Find **Glean for Codex (Local Repo)** and install `glean-experimental-codex`.
+3. Find **Glean for Codex (Local Repo)** and install `glean-vnext`.
 4. Restart Codex if the marketplace doesn't appear immediately.
 
 Before the first install from a fresh checkout, run `npm run build` once so

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "glean-experimental",
-  "version": "0.2.19",
+  "name": "glean-vnext",
+  "version": "0.2.20",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "glean-experimental-cursor",
-  "displayName": "Glean Cursor",
+  "name": "glean-vnext",
+  "displayName": "Glean vNext",
   "version": "0.2.19",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {


### PR DESCRIPTION
## Summary

Codex CLI
<img width="1512" height="525" alt="image" src="https://github.com/user-attachments/assets/47c3d2b8-7b70-47d6-9c56-a9aff3acb45d" />
<img width="1512" height="444" alt="image" src="https://github.com/user-attachments/assets/3e954142-82ef-4784-b121-08b3d5941bae" />


Two related renames:

1. **Plugin identity** `glean-experimental` → **`glean-vnext`** across all three harnesses (Claude/Cowork, Cursor, Codex). The name is `glean-vnext` everywhere — no per-platform suffix — and the display names (Cursor `displayName`, Codex `interface.displayName`) read **"Glean vNext"**.
2. **Repo rename** `gleanwork/glean-experimental-plugins` → **`gleanwork/glean-plugins-vnext`**. Repo URLs/paths updated, and the Claude marketplace `name` is aligned to the new repo, so install commands read `glean-vnext@glean-plugins-vnext`.

## Plugin / display names

| File | Field | New value |
|------|-------|-----------|
| `plugins/glean/.claude-plugin/plugin.json` | `name` | `glean-vnext` |
| `plugins/glean/.cursor-plugin/plugin.json` | `name` / `displayName` | `glean-vnext` / `Glean vNext` |
| `packages/codex/.codex-plugin/plugin.json` | `name` / `interface.displayName` | `glean-vnext` / `Glean vNext` |
| `.claude-plugin/marketplace.json` | `plugins[].name` | `glean-vnext` |
| `.cursor-plugin/marketplace.json` | `plugins[].name` | `glean-vnext` |
| `.agents/plugins/marketplace.json` | `plugins[].name` | `glean-vnext` |

Version auto-bumped `0.2.19 → 0.2.20` by the pre-commit hook.

## Repo / marketplace references

| File | Change |
|------|--------|
| `.claude-plugin/marketplace.json` | marketplace `name` → `glean-plugins-vnext` |
| `README.md` | repo URLs/paths + install/update/remove commands → `glean-plugins-vnext`; install → `glean-vnext@glean-plugins-vnext` |
| `.claude/settings.json` | enable key → `glean-vnext@glean-plugins-vnext` |

## Unchanged

- **MCP server segment** (`glean` / `glean-local`) — derived from `.mcp.json`, not the plugin name, so tool prefixes are unaffected by the rename.
- The Cursor (`glean-plugins`) and Codex (`glean-codex-local`) marketplace `name` fields and the local-repo display label ("Glean for Codex (Local Repo)") are left as-is — they don't reference the renamed repo.

## Testing

- `npm run typecheck` — clean
- `npm test` — 142/142 pass
- `npm run build` — clean; `dist/` in sync (no diff)
