### PR TITLE
[NI][Plugins] Derive Glean Server URL from work email in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ Today it ships one plugin:
 
 ## First run
 
-The first tool call triggers OAuth sign-in to Glean via the `setup` tool.
-The agent's skill walks the user through the sign-in URL and paste-back
-flow. After sign-in, OAuth credentials are cached to `~/.glean/` and reused
-across sessions — you won't be prompted again until the refresh token
-expires.
+Setup resolves your Glean instance automatically from your work email, then
+triggers OAuth sign-in to Glean via the `setup` tool. 
+
+### Setting the Server URL manually
+
+You normally don't need this — `setup` derives the Server (QE) URL from your
+work email. Set it explicitly only when you're testing a specific deployment
+or your email domain isn't recognized. Two options:
+
+- Pass `server_url` to the `setup` tool with your **Server instance (QE)** URL
+  (e.g. `https://acme-be.glean.com`). Admins can find this at
+  https://app.glean.com/admin/about-glean.
+- Or set the `GLEAN_MCP_SERVER_URL` environment variable.
 
 ## Updates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "esbuild": "^0.28.0",
+        "esbuild": "^0.28.1",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vitest": "^3.0.0"
@@ -899,7 +899,6 @@
       "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1463,7 +1462,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1701,7 +1699,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2012,7 +2009,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2459,7 +2455,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -2641,490 +2636,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
@@ -3241,7 +2752,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -3257,7 +2767,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.28.1",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^3.0.0"
   },
-  "//overrides": "Pin hono>=4.12.25 to bypass CVE-2026-54290 (transitive dep from @modelcontextprotocol/sdk)",
+  "//overrides": "Pin hono>=4.12.25 (CVE-2026-54290, transitive from @modelcontextprotocol/sdk); pin esbuild/vite to clear CVE blocks that prevented install",
   "overrides": {
-    "hono": "^4.12.25"
+    "hono": "^4.12.25",
+    "esbuild": "$esbuild",
+    "vite": "7.3.5"
   }
 }

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26166,6 +26166,66 @@ async function dispatchRemoteTool(toolName, args, ctx) {
   }
 }
 
+// src/config-search.ts
+var CONFIG_SEARCH_URL = "https://app.glean.com/config/search";
+var emailPattern = /^[^@\s]+@([^@\s]+\.[^@\s]+)$/;
+async function resolveServerUrlFromEmail(email2, fetchImpl = fetch) {
+  const trimmed = email2.trim();
+  const match = emailPattern.exec(trimmed);
+  if (!match) {
+    return { ok: false, error: `"${email2}" is not a valid email address.` };
+  }
+  const emailDomain = match[1].toLowerCase();
+  let resp;
+  try {
+    resp = await fetchImpl(CONFIG_SEARCH_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json"
+      },
+      body: JSON.stringify({ email: trimmed, emailDomain, isGleanApp: true })
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `Could not reach Glean to look up your instance: ${msg}`
+    };
+  }
+  if (!resp.ok) {
+    return {
+      ok: false,
+      error: `Glean instance lookup failed (HTTP ${resp.status}).`
+    };
+  }
+  let data;
+  try {
+    data = await resp.json();
+  } catch {
+    return {
+      ok: false,
+      error: "Glean instance lookup returned an unexpected response."
+    };
+  }
+  const cfg = data.search_config;
+  const queryUrl = cfg?.queryURL;
+  if (!queryUrl || cfg?.centralURL && cfg.isMultiTenant !== true && sameOrigin(queryUrl, cfg.centralURL)) {
+    return {
+      ok: false,
+      error: `No Glean instance is registered for "${emailDomain}".`
+    };
+  }
+  return { ok: true, queryUrl };
+}
+function sameOrigin(a, b) {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}
+
 // src/index.ts
 function readEnv(...keys) {
   for (const key of keys) {
@@ -26187,12 +26247,9 @@ function normalizeServerUrl(raw) {
 }
 var SETUP_REQUIRED_TEXT = `[SETUP_REQUIRED]
 
-To connect this plugin to your Glean instance:
-1. Visit https://app.glean.com/admin/about-glean (log in if needed)
-2. Copy the **Server instance (QE)** URL shown on that page (e.g. https://acme-be.glean.com/)
-3. Paste it here
-
-Then call this tool again with the server_url parameter set to the URL you copied.`;
+To connect, enter your work email (e.g. you@acme.com) and we'll find your Glean instance automatically.
+`;
+var EMAIL_RESOLVE_FAILED_TEXT = `Double-check the email for typos and try again with the corrected email.`;
 var SETUP_NEEDED_ERROR = "Glean is not configured yet. Call the `setup` tool first to provide your Glean Server URL before using find_skills or run_tool.";
 var AUTH_REDIRECT_TO_SETUP_TEXT = "[SETUP_REQUIRED]\n\nAuthentication is required. Call the `setup` tool (no arguments) to sign in to Glean, then retry this tool.";
 function resolveLogPath() {
@@ -26289,13 +26346,17 @@ var RUN_TOOL_TOOL = {
 var SETUP_TOOL = {
   name: "setup",
   annotations: { readOnlyHint: true },
-  description: "Check or configure the Glean connection. Setup completes in three stages: (1) save the Server URL, (2) sign in, (3) fetch the remote tool catalog. Call with no arguments to advance through the next missing stage; it opens the Glean sign-in page in the browser when needed. Call with server_url to (re)configure. Call with reset=true to clear all configuration.",
+  description: "Check or configure the Glean connection. Setup completes in three stages: (1) resolve and save the Server URL, (2) authenticate, (3) fetch the remote tool catalog. Call with no arguments to advance through the next missing stage. Call with email to look up and (re)configure user's Glean instance. Call with reset=true to clear all configuration.",
   inputSchema: {
     type: "object",
     properties: {
+      email: {
+        type: "string",
+        description: "User's work email (e.g. you@acme.com). Used to look up and configure your Glean Server instance (QE) URL automatically."
+      },
       server_url: {
         type: "string",
-        description: "Glean Server Instance (QE) URL (e.g. https://acme-be.glean.com)."
+        description: "Advanced. Sets the Glean Server (QE) URL directly instead of resolving it from email. Do not suggest this to users \u2014 email is the preferred path. Documented in the README for technical users who ask for it explicitly."
       },
       reset: {
         type: "boolean",
@@ -26663,12 +26724,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [
             {
               type: "text",
-              text: "Glean configuration has been reset. Call setup again with server_url to reconfigure."
+              text: "Glean configuration has been reset. Call setup again with your email to reconfigure."
             }
           ]
         };
       }
-      const rawUrl = typeof args.server_url === "string" ? args.server_url.trim() : "";
+      let rawUrl = typeof args.server_url === "string" ? args.server_url.trim() : "";
+      const email2 = typeof args.email === "string" ? args.email.trim() : "";
+      if (!rawUrl && email2) {
+        const resolved = await resolveServerUrlFromEmail(email2);
+        if (!resolved.ok) {
+          logLine("setup.email-resolve-failed", { email: email2, error: resolved.error });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `${resolved.error}
+
+${EMAIL_RESOLVE_FAILED_TEXT}`
+              }
+            ],
+            isError: true
+          };
+        }
+        rawUrl = resolved.queryUrl;
+        logLine("setup.email-resolved", { email: email2, queryUrl: rawUrl });
+      }
       if (rawUrl) {
         let normalized;
         try {
@@ -26678,7 +26759,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             content: [
               {
                 type: "text",
-                text: `Invalid URL: "${rawUrl}". Please provide the Server instance (QE) URL from https://app.glean.com/admin/about-glean (e.g. https://acme-be.glean.com).`
+                text: `Invalid URL: "${rawUrl}". Please provide the Server instance (QE) URL (e.g. https://acme-be.glean.com), or pass your email instead.`
               }
             ],
             isError: true

--- a/plugins/glean/skills/glean_run/SKILL.md
+++ b/plugins/glean/skills/glean_run/SKILL.md
@@ -22,8 +22,8 @@ returns a response containing `[SETUP_REQUIRED]`, the user needs to
 When this happens:
 1. Call `setup` (no arguments).
    - If no Server URL is configured, `setup` returns `[SETUP_REQUIRED]` with
-     instructions. Relay them, ask the user for their Glean Server instance
-     (QE) URL, then call `setup` again with `server_url` set to that URL.
+     instructions. Relay them, ask the user for their work email, then call
+     `setup` again with `email` set to what they provided. 
    - Once a Server URL is configured, `setup` opens the Glean sign-in page in
      the browser and waits for sign-in.
 2. Once `setup` returns "Glean setup is complete", retry the original tool

--- a/src/config-search.ts
+++ b/src/config-search.ts
@@ -1,0 +1,92 @@
+const CONFIG_SEARCH_URL = "https://app.glean.com/config/search";
+
+// Shape of the deployment config returned by the config/search endpoint.
+interface DeploymentConfig {
+  queryURL?: string;
+  centralURL?: string;
+  isMultiTenant?: boolean;
+}
+
+interface ConfigSearchResponse {
+  search_config?: DeploymentConfig;
+}
+
+export type ResolveResult =
+  | { ok: true; queryUrl: string }
+  | { ok: false; error: string };
+
+const emailPattern = /^[^@\s]+@([^@\s]+\.[^@\s]+)$/;
+
+export async function resolveServerUrlFromEmail(
+  email: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ResolveResult> {
+  const trimmed = email.trim();
+  const match = emailPattern.exec(trimmed);
+  if (!match) {
+    return { ok: false, error: `"${email}" is not a valid email address.` };
+  }
+  const emailDomain = match[1].toLowerCase();
+
+  let resp: Response;
+  try {
+    resp = await fetchImpl(CONFIG_SEARCH_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ email: trimmed, emailDomain, isGleanApp: true }),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `Could not reach Glean to look up your instance: ${msg}`,
+    };
+  }
+
+  if (!resp.ok) {
+    return {
+      ok: false,
+      error: `Glean instance lookup failed (HTTP ${resp.status}).`,
+    };
+  }
+
+  let data: ConfigSearchResponse;
+  try {
+    data = (await resp.json()) as ConfigSearchResponse;
+  } catch {
+    return {
+      ok: false,
+      error: "Glean instance lookup returned an unexpected response.",
+    };
+  }
+
+  const cfg = data.search_config;
+  const queryUrl = cfg?.queryURL;
+
+  // No usable instance if there's no queryURL, or the endpoint returned the
+  // shared central URL for an unknown domain or typo in email
+  if (
+    !queryUrl ||
+    (cfg?.centralURL &&
+      cfg.isMultiTenant !== true &&
+      sameOrigin(queryUrl, cfg.centralURL))
+  ) {
+    return {
+      ok: false,
+      error: `No Glean instance is registered for "${emailDomain}".`,
+    };
+  }
+
+  return { ok: true, queryUrl };
+}
+
+function sameOrigin(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import {
   type DispatchContext,
 } from "./tools/remote-passthrough.js";
 import { resolveSessionId } from "./session-id.js";
+import { resolveServerUrlFromEmail } from "./config-search.js";
 
 function readEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -64,11 +65,14 @@ function normalizeServerUrl(raw: string): string {
 
 const SETUP_REQUIRED_TEXT =
   `[SETUP_REQUIRED]\n\n` +
-  `To connect this plugin to your Glean instance:\n` +
-  `1. Visit https://app.glean.com/admin/about-glean (log in if needed)\n` +
-  `2. Copy the **Server instance (QE)** URL shown on that page (e.g. https://acme-be.glean.com/)\n` +
-  `3. Paste it here\n\n` +
-  `Then call this tool again with the server_url parameter set to the URL you copied.`;
+  `To connect, enter your work email (e.g. you@acme.com) and we'll find ` +
+  `your Glean instance automatically.\n`;
+
+// A failed lookup asks the user to retry with a corrected email. 
+// Admins who must set the URL manually use
+// the server_url parameter (documented in the README)
+const EMAIL_RESOLVE_FAILED_TEXT =
+  `Double-check the email for typos and try again with the corrected email.`;
 
 const SETUP_NEEDED_ERROR =
   "Glean is not configured yet. Call the `setup` tool first to provide " +
@@ -232,18 +236,27 @@ const SETUP_TOOL: Tool = {
   annotations: { readOnlyHint: true },
   description:
     "Check or configure the Glean connection. Setup completes in three " +
-    "stages: (1) save the Server URL, (2) sign in, (3) fetch the remote " +
-    "tool catalog. Call with no arguments to advance through the next " +
-    "missing stage; it opens the Glean sign-in page in the browser when " +
-    "needed. Call with server_url to (re)configure. Call with reset=true to " +
-    "clear all configuration.",
+    "stages: (1) resolve and save the Server URL, (2) authenticate, " +
+    "(3) fetch the remote tool catalog. Call with no arguments to advance " +
+    "through the next missing stage. Call with email to look up and " +
+    "(re)configure user's Glean instance. Call with reset=true to clear " +
+    "all configuration.",
   inputSchema: {
     type: "object" as const,
     properties: {
+      email: {
+        type: "string",
+        description:
+          "User's work email (e.g. you@acme.com). Used to look up and " +
+          "configure your Glean Server instance (QE) URL automatically.",
+      },
       server_url: {
         type: "string",
         description:
-          "Glean Server Instance (QE) URL (e.g. https://acme-be.glean.com).",
+          "Advanced. Sets the Glean Server (QE) URL directly instead of " +
+          "resolving it from email. Do not suggest this to users — email " +
+          "is the preferred path. Documented in the README for technical " +
+          "users who ask for it explicitly.",
       },
       reset: {
         type: "boolean",
@@ -694,14 +707,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               type: "text",
               text:
                 "Glean configuration has been reset. Call setup again with " +
-                "server_url to reconfigure.",
+                "your email to reconfigure.",
             },
           ],
         };
       }
 
-      const rawUrl =
+      // An explicit server_url wins; otherwise derive the QE URL from the
+      // user's email via the public config/search lookup.
+      let rawUrl =
         typeof args.server_url === "string" ? args.server_url.trim() : "";
+      const email = typeof args.email === "string" ? args.email.trim() : "";
+
+      if (!rawUrl && email) {
+        const resolved = await resolveServerUrlFromEmail(email);
+        if (!resolved.ok) {
+          logLine("setup.email-resolve-failed", { email, error: resolved.error });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `${resolved.error}\n\n${EMAIL_RESOLVE_FAILED_TEXT}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        rawUrl = resolved.queryUrl;
+        logLine("setup.email-resolved", { email, queryUrl: rawUrl });
+      }
 
       if (rawUrl) {
         let normalized: string;
@@ -714,8 +748,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 type: "text",
                 text:
                   `Invalid URL: "${rawUrl}". Please provide the Server instance (QE) URL ` +
-                  `from https://app.glean.com/admin/about-glean ` +
-                  `(e.g. https://acme-be.glean.com).`,
+                  `(e.g. https://acme-be.glean.com), or pass your email instead.`,
               },
             ],
             isError: true,

--- a/tests/config-search.test.ts
+++ b/tests/config-search.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveServerUrlFromEmail } from "../src/config-search.js";
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("resolveServerUrlFromEmail", () => {
+  it("returns the tenant queryURL for a recognized domain", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        search_config: {
+          queryURL: "https://acme-be.glean.com/",
+          centralURL: "https://apps-be.glean.com/",
+          isMultiTenant: false,
+        },
+      }),
+    );
+
+    const result = await resolveServerUrlFromEmail(
+      "you@acme.com",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result).toEqual({ ok: true, queryUrl: "https://acme-be.glean.com/" });
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://app.glean.com/config/search");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      email: "you@acme.com",
+      emailDomain: "acme.com",
+      isGleanApp: true,
+    });
+  });
+
+  it("accepts a multi-tenant deployment served from the central URL", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        search_config: {
+          queryURL: "https://apps-be.glean.com/",
+          centralURL: "https://apps-be.glean.com/",
+          isMultiTenant: true,
+        },
+      }),
+    );
+
+    const result = await resolveServerUrlFromEmail(
+      "you@multitenant.example",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result).toEqual({ ok: true, queryUrl: "https://apps-be.glean.com/" });
+  });
+
+  it("rejects an unrecognized domain that falls back to the central URL", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        search_config: {
+          queryURL: "https://apps-be.glean.com/",
+          centralURL: "https://apps-be.glean.com/",
+          isMultiTenant: false,
+        },
+      }),
+    );
+
+    const result = await resolveServerUrlFromEmail(
+      "you@unknown-domain.example",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a malformed email without calling the endpoint", async () => {
+    const fetchImpl = vi.fn();
+    const result = await resolveServerUrlFromEmail(
+      "not-an-email",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the endpoint returns no queryURL", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ search_config: { centralURL: "https://apps-be.glean.com/" } }),
+    );
+
+    const result = await resolveServerUrlFromEmail(
+      "you@acme.com",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("surfaces a non-OK HTTP status as an error", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, false, 500));
+
+    const result = await resolveServerUrlFromEmail(
+      "you@acme.com",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("surfaces a network failure as an error", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+
+    const result = await resolveServerUrlFromEmail(
+      "you@acme.com",
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
setup now accepts a work email and resolves the Server (QE) URL via the public config/search endpoint, instead of requiring the admin-only about-glean URL. Falls back to manual server_url entry when the domain isn't recognized; multi-tenant deployments resolve correctly.

Bumps esbuild->0.28.1 and pins vite->7.3.5 (overrides) to clear CVE blocks that prevented the build from installing.