### PR TITLE
Mark dist bundles as generated to suppress diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-plugins/glean/dist/** linguist-generated=true
+packages/codex/dist/** linguist-generated=true -diff
+plugins/glean/dist/** linguist-generated=true -diff

--- a/.githooks/pre-commit.d/01-rebuild-dist.sh
+++ b/.githooks/pre-commit.d/01-rebuild-dist.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-# Rebuild dist/index.js and stage it on every commit.
+# Rebuild dist/index.js and stage it on every commit that touches source files.
 set -e
 cd "$(git rev-parse --show-toplevel)"
+
+# Skip rebuild if only non-source files are staged (docs, CI, git metadata).
+IGNORE_PATHS="^(\.git(attributes|ignore|hooks/)|\.github/|README|LICENSE|CHANGELOG|\.node-version)"
+if ! git diff --cached --name-only | grep -qvE "$IGNORE_PATHS"; then
+  exit 0
+fi
 
 if [ ! -d node_modules ] || [ -L node_modules ]; then
   echo "pre-commit: node_modules missing or is a symlink; running npm ci" >&2


### PR DESCRIPTION
## Summary
- Add `packages/codex/dist/**` to `.gitattributes` with `linguist-generated` and `-diff` so GitHub collapses them in PR review and `git diff` suppresses their content
- Update the pre-commit rebuild hook to use an ignorelist — skip rebuild only when ALL staged files are non-source (docs, CI config, git metadata, hooks). New source paths automatically trigger rebuilds without needing to update the hook.

## Test plan
- [x] `git diff --exit-code` still detects out-of-sync dist (exits non-zero with "Binary files differ")
- [x] CI `check-version-bump` unaffected — `.gitattributes` and `.githooks/` don't match `PLUGIN_PATHS`
- [x] Commits touching only ignored paths (e.g. `.gitattributes`) skip rebuild and version bump