### PR TITLE
Use CURSOR_CONVERSATION_ID as session id on Cursor (with temp debug logs)

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,16 +1,27 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.24",
-  "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
+  "version": "0.2.25",
+  "description": "Search and act across your company's apps \u2014 Jira, Slack, Salesforce, Google Workspace, and more \u2014 without leaving Cursor.",
   "author": {
     "name": "Glean"
   },
   "homepage": "https://www.glean.com",
   "logo": "assets/GLN_logo-icon-Primary.png",
-  "keywords": ["glean", "enterprise-search", "jira", "slack", "salesforce"],
+  "keywords": [
+    "glean",
+    "enterprise-search",
+    "jira",
+    "slack",
+    "salesforce"
+  ],
   "category": "productivity",
-  "tags": ["search", "enterprise", "mcp", "tools"],
+  "tags": [
+    "search",
+    "enterprise",
+    "mcp",
+    "tools"
+  ],
   "skills": "./skills/",
   "mcpServers": ".mcp.json"
 }

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26106,11 +26106,13 @@ var fallbackSessionId;
 function resolveSessionId() {
   const fromHost = process.env.GLEAN_SESSION_ID?.trim();
   if (fromHost && !fromHost.startsWith("${")) {
+    console.error(`[glean][debug] resolveSessionId using host GLEAN_SESSION_ID=${fromHost}`);
     return fromHost;
   }
   if (!fallbackSessionId) {
     fallbackSessionId = randomUUID();
   }
+  console.error(`[glean][debug] resolveSessionId fallback UUID=${fallbackSessionId}`);
   return fallbackSessionId;
 }
 

--- a/plugins/glean/start.sh
+++ b/plugins/glean/start.sh
@@ -37,11 +37,17 @@ fi
 
 # Resolve the chat session id host-side. Host-awareness lives here, not in the
 # plugin: the launcher reads whatever variable this host exposes and exports the
-# normalized GLEAN_SESSION_ID that the Node bundle reads. Hosts that expose no
-# session id (Cursor, and Cowork until follow-up) leave it unset, and the plugin
-# falls back to a generated per-process id.
+# normalized GLEAN_SESSION_ID that the Node bundle reads. Claude Code exposes
+# CLAUDE_CODE_SESSION_ID; Cursor exposes CURSOR_CONVERSATION_ID. Hosts that
+# expose no session id leave it unset, and the plugin falls back to a generated
+# per-process id.
 if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
   export GLEAN_SESSION_ID="$CLAUDE_CODE_SESSION_ID"
+elif [ -n "${CURSOR_CONVERSATION_ID:-}" ]; then
+  export GLEAN_SESSION_ID="$CURSOR_CONVERSATION_ID"
 fi
+
+# DEBUG (remove before merge): trace which host var fed the session id.
+echo "[glean][debug] CLAUDE_CODE_SESSION_ID=${CLAUDE_CODE_SESSION_ID:-<unset>} CURSOR_CONVERSATION_ID=${CURSOR_CONVERSATION_ID:-<unset>} -> GLEAN_SESSION_ID=${GLEAN_SESSION_ID:-<unset>}" >&2
 
 exec node "$PLUGIN_DIR/dist/index.js"

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -5,24 +5,28 @@ let fallbackSessionId: string | undefined;
 /**
  * Resolves the chat session id from GLEAN_SESSION_ID, which the host-aware
  * launcher (start.sh) exports after reading whatever variable the current host
- * uses for the session/conversation id. The plugin itself stays host-agnostic
- * and never reads host-specific env vars.
+ * uses for the session/conversation id (e.g. CLAUDE_CODE_SESSION_ID on Claude
+ * Code, CURSOR_CONVERSATION_ID on Cursor). The plugin itself stays
+ * host-agnostic and never reads host-specific env vars.
  *
- * When no session id is provided (hosts that expose none, e.g. Cursor), a
- * plain RFC 4122 UUID is generated once per process so every call from this
- * process still shares one stable, non-hallucinated id. The fallback carries
- * no prefix so it stays a valid GUID if the backend ever validates
- * chat_session_id as one.
+ * When no session id is provided (hosts that expose none), a plain RFC 4122
+ * UUID is generated once per process so every call from this process still
+ * shares one stable, non-hallucinated id. The fallback carries no prefix so it
+ * stays a valid GUID if the backend ever validates chat_session_id as one.
  */
 export function resolveSessionId(): string {
   const fromHost = process.env.GLEAN_SESSION_ID?.trim();
   // Ignore empty/whitespace-only values and any un-interpolated "${VAR}"
   // placeholder a launcher might pass through verbatim.
   if (fromHost && !fromHost.startsWith("${")) {
+    // DEBUG (remove before merge): confirm the host-provided id is used.
+    console.error(`[glean][debug] resolveSessionId using host GLEAN_SESSION_ID=${fromHost}`);
     return fromHost;
   }
   if (!fallbackSessionId) {
     fallbackSessionId = randomUUID();
   }
+  // DEBUG (remove before merge): host exposed no session id; using per-process fallback.
+  console.error(`[glean][debug] resolveSessionId fallback UUID=${fallbackSessionId}`);
   return fallbackSessionId;
 }


### PR DESCRIPTION
## What
Maps Cursor's `CURSOR_CONVERSATION_ID` to the normalized `GLEAN_SESSION_ID` in `plugins/glean/start.sh`, mirroring how `CLAUDE_CODE_SESSION_ID` is handled. Host-awareness stays in the launcher; the bundle keeps reading only `GLEAN_SESSION_ID` (`src/session-id.ts` unchanged in behavior). Cursor previously fell back to a per-process UUID; now it uses the real conversation id.

## ⚠️ Temporary debug logs — REMOVE BEFORE MERGE
Marked `DEBUG (remove before merge)`:
- `plugins/glean/start.sh`: stderr line showing which host var fed the session id.
- `src/session-id.ts`: stderr line showing the resolved id (host vs fallback).

These are only to verify the wiring in Cursor; strip them (and rebuild `dist`) before merge.

## Version
Manifests bumped 0.2.24 → 0.2.25.

## Note
The old `CODEX_THREAD_ID` mapping was dropped when `packages/codex` was removed; this PR scopes to Cursor only.