### PR TITLE
Promote chat, memory, user_activity, employee_search to first-class tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /dist/
 .DS_Store
+.claude/tmp/

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26014,7 +26014,12 @@ function clearRemoteTools(serverUrl) {
 // src/tools/remote-passthrough.ts
 var REMOTE_TOOLS_ALLOWLIST = /* @__PURE__ */ new Set([
   "search",
-  "read_document"
+  "read_document",
+  "chat",
+  "memory",
+  "memory_schema",
+  "user_activity",
+  "employee_search"
 ]);
 function augmentSchemaForLocal(schema) {
   const base = schema && typeof schema === "object" && !Array.isArray(schema) ? structuredClone(schema) : {};

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -1,70 +1,112 @@
 #!/bin/bash
-# CI check: verify the version was incremented when plugin files change.
-# Compares the PR branch version against the base branch version.
-# Rejects downgrades. Version source of truth: plugins/glean/.claude-plugin/plugin.json
+# CI check: verify the plugin version was incremented when plugin files change.
+#
+# The plugin ships one manifest per host (Claude, Codex, Cursor). They must
+# stay in lockstep: every manifest carries the same version, and that version
+# must increase whenever plugin runtime files change. This check enforces:
+#   1. all manifests exist and hold a valid semver triplet,
+#   2. all manifests share one aligned version,
+#   3. that version is strictly greater than the highest version on the base
+#      branch (rejects both "changed but not bumped" and downgrades).
 set -euo pipefail
 
 BASE_REF="${1:-origin/main}"
 
+# Per-host plugin manifests — kept in lockstep on a single version.
+MANIFESTS=(
+  "plugins/glean/.claude-plugin/plugin.json"
+  "plugins/glean/.codex-plugin/plugin.json"
+  "plugins/glean/.cursor-plugin/plugin.json"
+)
+
 # Only trigger on files that affect the plugin runtime — not CI or tooling.
-PLUGIN_PATHS="^(src/|plugins/glean/(dist/|skills/|start\.sh|\.mcp\.json|package\.json|\.claude-plugin/plugin\.json))"
+PLUGIN_PATHS='^(src/|plugins/glean/(dist/|skills/|start\.sh|\.mcp\.json|\.mcp\.codex\.json|package\.json|\.(claude|codex|cursor)-plugin/plugin\.json))'
 
 if ! git diff --name-only "$BASE_REF"...HEAD | grep -qE "$PLUGIN_PATHS"; then
   echo "No plugin files changed — skipping version check."
   exit 0
 fi
 
-PLUGIN_MANIFEST="plugins/glean/.claude-plugin/plugin.json"
 SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
-# Current version from the working tree.
-PLUGIN_VERSION=$(node -p "require('./$PLUGIN_MANIFEST').version")
-if ! [[ "$PLUGIN_VERSION" =~ $SEMVER_RE ]]; then
-  echo "ERROR: Current version '$PLUGIN_VERSION' is not a valid semver triplet (x.y.z)."
-  exit 1
-fi
+# semver_cmp A B -> prints 1 if A>B, -1 if A<B, 0 if equal (exits 0).
+semver_cmp() {
+  node -e "
+    const a='$1'.split('.').map(Number), b='$2'.split('.').map(Number);
+    for (let i = 0; i < 3; i++) {
+      if (a[i] > b[i]) { console.log(1); process.exit(0); }
+      if (a[i] < b[i]) { console.log(-1); process.exit(0); }
+    }
+    console.log(0);
+  "
+}
 
-# Base version from the base ref. The manifest may not exist there yet — e.g. the
-# plugin is being introduced for the first time, or the base branch predates it.
-# There is then no prior version to bump from, so the check passes. Capturing the
-# blob separately (instead of piping git into node) keeps `set -o pipefail` from
-# turning a missing path into an opaque JSON parse error.
-if ! BASE_PLUGIN_JSON=$(git show "$BASE_REF:$PLUGIN_MANIFEST" 2>/dev/null); then
-  echo "Plugin manifest not present on $BASE_REF — new plugin, skipping version-bump check (current version: $PLUGIN_VERSION)."
+# --- Current versions (working tree): every manifest must exist, be valid semver,
+# and agree on one version.
+CURRENT=""
+for m in "${MANIFESTS[@]}"; do
+  if [ ! -f "$m" ]; then
+    echo "ERROR: Expected plugin manifest '$m' is missing."
+    exit 1
+  fi
+  v=$(node -p "require('./$m').version")
+  if ! [[ "$v" =~ $SEMVER_RE ]]; then
+    echo "ERROR: Version '$v' in $m is not a valid semver triplet (x.y.z)."
+    exit 1
+  fi
+  if [ -z "$CURRENT" ]; then
+    CURRENT="$v"
+  elif [ "$v" != "$CURRENT" ]; then
+    echo "ERROR: Plugin manifest versions are not aligned. All manifests must share one version:"
+    for mm in "${MANIFESTS[@]}"; do
+      echo "  $(node -p "require('./$mm').version")  $mm"
+    done
+    exit 1
+  fi
+done
+
+# --- Base versions: read each manifest from the base ref. A manifest may be
+# absent there (plugin or host being introduced) — those are skipped. The floor
+# the current version must beat is the highest version present on the base.
+# Capturing each blob separately (instead of piping git into node) keeps
+# `set -o pipefail` from turning a missing path into an opaque parse error.
+BASE_MAX=""
+for m in "${MANIFESTS[@]}"; do
+  if ! base_json=$(git show "$BASE_REF:$m" 2>/dev/null); then
+    continue
+  fi
+  bv=$(node -p "JSON.parse(require('fs').readFileSync(0,'utf-8')).version" <<<"$base_json")
+  if ! [[ "$bv" =~ $SEMVER_RE ]]; then
+    echo "ERROR: Base version '$bv' in $m is not a valid semver triplet (x.y.z)."
+    exit 1
+  fi
+  if [ -z "$BASE_MAX" ] || [ "$(semver_cmp "$bv" "$BASE_MAX")" = "1" ]; then
+    BASE_MAX="$bv"
+  fi
+done
+
+if [ -z "$BASE_MAX" ]; then
+  echo "No plugin manifests present on $BASE_REF — new plugin, skipping version-bump check (current version: $CURRENT)."
   exit 0
 fi
 
-BASE_VERSION=$(node -p "JSON.parse(require('fs').readFileSync(0,'utf-8')).version" <<<"$BASE_PLUGIN_JSON")
-if ! [[ "$BASE_VERSION" =~ $SEMVER_RE ]]; then
-  echo "ERROR: Base version '$BASE_VERSION' is not a valid semver triplet (x.y.z)."
-  exit 1
-fi
-
-if [ "$PLUGIN_VERSION" = "$BASE_VERSION" ]; then
+CMP=$(semver_cmp "$CURRENT" "$BASE_MAX")
+if [ "$CMP" = "0" ]; then
   echo "ERROR: Plugin files changed but version was not bumped."
-  echo "  Base version:    $BASE_VERSION"
-  echo "  Current version: $PLUGIN_VERSION"
+  echo "  Base version:    $BASE_MAX"
+  echo "  Current version: $CURRENT"
   echo ""
-  echo "Bump the version in plugins/glean/.claude-plugin/plugin.json"
+  echo "Bump the version in every plugin manifest (keep them aligned):"
+  printf '  %s\n' "${MANIFESTS[@]}"
   exit 1
 fi
-
-# Reject downgrades: current version must be strictly greater than base.
-if ! node -e "
-  const a = '$BASE_VERSION'.split('.').map(Number);
-  const b = '$PLUGIN_VERSION'.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    if (b[i] > a[i]) process.exit(0);
-    if (b[i] < a[i]) process.exit(1);
-  }
-  process.exit(1);
-"; then
+if [ "$CMP" = "-1" ]; then
   echo "ERROR: Version was downgraded."
-  echo "  Base version:    $BASE_VERSION"
-  echo "  Current version: $PLUGIN_VERSION"
+  echo "  Base version:    $BASE_MAX"
+  echo "  Current version: $CURRENT"
   echo ""
   echo "The version must be higher than the base branch."
   exit 1
 fi
 
-echo "Version bump verified: $BASE_VERSION → $PLUGIN_VERSION"
+echo "Version bump verified: $BASE_MAX → $CURRENT (all manifests aligned)."

--- a/src/tools/descriptions.ts
+++ b/src/tools/descriptions.ts
@@ -1,7 +1,8 @@
 /**
  * Shared input-schema descriptions for parameters that recur across our
  * static tools and the dynamically-promoted remote tools (chat, search,
- * read_document). Keeping a single source of truth keeps the agent-facing
+ * read_document, memory, memory_schema, user_activity, employee_search).
+ * Keeping a single source of truth keeps the agent-facing
  * wording consistent and prevents drift when the paste-back semantics evolve.
  */
 

--- a/src/tools/remote-passthrough.ts
+++ b/src/tools/remote-passthrough.ts
@@ -7,13 +7,17 @@ import {
   type RemoteClientOptions,
 } from "../remote-client.js";
 
-// `chat` is intentionally excluded for now: the upstream Glean MCP backend
-// keeps returning "Error running chat tool: response contains message of
-// type ERROR" with no structured detail, so surfacing it would expose a
-// broken first-class tool. Re-add once the backend is healthy.
+// Remote tools promoted to first-class local tools once setup completes.
+// Anything the remote MCP server exposes that is not in this set is dropped
+// by fetchAllowedRemoteTools and rejected by dispatchRemoteTool.
 export const REMOTE_TOOLS_ALLOWLIST: ReadonlySet<string> = new Set([
   "search",
   "read_document",
+  "chat",
+  "memory",
+  "memory_schema",
+  "user_activity",
+  "employee_search",
 ]);
 
 type ToolInputSchema = Tool["inputSchema"];

--- a/tests/remote-passthrough.test.ts
+++ b/tests/remote-passthrough.test.ts
@@ -38,10 +38,15 @@ function makeCtx(overrides: Partial<DispatchContext> = {}): DispatchContext {
 }
 
 describe("REMOTE_TOOLS_ALLOWLIST", () => {
-  it("contains exactly search and read_document (chat is excluded while broken)", () => {
+  it("contains the promoted Glean remote tools", () => {
     expect([...REMOTE_TOOLS_ALLOWLIST].sort()).toEqual([
+      "chat",
+      "employee_search",
+      "memory",
+      "memory_schema",
       "read_document",
       "search",
+      "user_activity",
     ]);
   });
 });
@@ -103,7 +108,7 @@ describe("fetchAllowedRemoteTools", () => {
     const client = clientWithPages([
       {
         tools: [
-          { name: "chat", description: "Chat (excluded)", inputSchema: { type: "object", properties: {}, required: [] } },
+          { name: "not_allowed", description: "Excluded", inputSchema: { type: "object", properties: {}, required: [] } },
           { name: "weird_unknown", description: "x", inputSchema: { type: "object" } },
           { name: "search", description: "Search", inputSchema: { type: "object", properties: { q: { type: "string" } }, required: ["q"] } },
         ],


### PR DESCRIPTION
## Summary

Two related changes:

### 1. Promote five Glean remote tools to first-class local tools

Promotes the following alongside the existing `search` and `read_document`:

- `chat`
- `memory`
- `memory_schema`
- `user_activity`
- `employee_search`

`chat` was previously excluded because the upstream Glean MCP backend kept
returning `"response contains message of type ERROR"`. That backend issue is
resolved, so `chat` is now re-enabled.

### 2. Extend the version-bump CI check to all plugin manifests

The plugin ships one manifest per host (Claude, Codex, Cursor), but the
version-bump check only validated the Claude one — so the Codex and Cursor
manifests had silently drifted (both `0.2.24` while Claude moved to `0.2.25`).

`scripts/check-version-bump.sh` now validates all three manifests: each must
be valid semver, all must share one aligned version, and that version must be
strictly greater than the highest version on the base branch. The change
trigger also fires on the codex/cursor manifests and `.mcp.codex.json`. The
Codex and Cursor manifests are aligned to `0.2.25`.

## Changes

- `src/tools/remote-passthrough.ts` — add the five tools to `REMOTE_TOOLS_ALLOWLIST`.
- `src/tools/descriptions.ts` — extend the shared-description doc comment to cover the newly promoted tools.
- `tests/remote-passthrough.test.ts` — update the allowlist assertion to the full promoted set; switch the "excluded tool" fixture off `chat`.
- `scripts/check-version-bump.sh` — validate all three manifests (aligned + bumped + no downgrade); broaden the change trigger.
- `plugins/glean/.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json` — bump to `0.2.25` (aligned).
- `plugins/glean/dist/index.js` — rebuilt bundle (esbuild 0.28.1, matching the lockfile so CI's rebuild matches byte-for-byte).
- `.gitignore` — ignore the local `.claude/tmp/` skills cache.

## Testing

- `npm run test` — 145/145 passing.
- `npm run typecheck` — clean.
- `bash scripts/check-version-bump.sh origin/main` — verified pass (aligned + bumped), and verified it fails on drift and on a non-bumped version.
