### PR TITLE
run_tool - Clarify Glean is already authenticated on connector AUTH_REQUIRED

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25769,7 +25769,7 @@ function buildApprovalMessage(mcpServer, toolName, args) {
   }
   return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
 }
-var CONNECTOR_AUTH_SUFFIX = "Note: Glean itself is already authenticated. This is a downstream connector/tool authorization request \u2014 NOT [SETUP_REQUIRED]. Do not call the `setup` tool. Have the user authorize using the link above, then retry this tool.";
+var CONNECTOR_AUTH_SUFFIX = "Assistant: ask the user only to authorize using the link above. Do not mention Glean, connectors, setup, or any auth internals, and do not call the `setup` tool.";
 function isConnectorAuth(result) {
   if (!result.isError) return false;
   const text = result.content?.find((c) => c.type === "text");

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25769,6 +25769,24 @@ function buildApprovalMessage(mcpServer, toolName, args) {
   }
   return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
 }
+var CONNECTOR_AUTH_SUFFIX = "Note: Glean itself is already authenticated. This is a downstream connector/tool authorization request \u2014 NOT [SETUP_REQUIRED]. Do not call the `setup` tool. Have the user authorize using the link above, then retry this tool.";
+function isConnectorAuth(result) {
+  if (!result.isError) return false;
+  const text = result.content?.find((c) => c.type === "text");
+  if (!text || text.type !== "text") return false;
+  try {
+    const parsed = JSON.parse(text.text);
+    return !!parsed && typeof parsed === "object" && Array.isArray(parsed.authUrls) && parsed.authUrls.length > 0;
+  } catch {
+    return false;
+  }
+}
+function withConnectorAuthSuffix(result) {
+  return {
+    ...result,
+    content: [...result.content, { type: "text", text: CONNECTOR_AUTH_SUFFIX }]
+  };
+}
 async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
@@ -25787,19 +25805,19 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       const message = buildApprovalMessage(mcpServer, toolName, args.arguments);
       const timeout = hitlTimeoutMs();
       try {
-        const result = await mcpServer.elicitInput(
+        const result2 = await mcpServer.elicitInput(
           {
             message,
             requestedSchema: { type: "object", properties: {} }
           },
           { timeout }
         );
-        if (result.action !== "accept") {
+        if (result2.action !== "accept") {
           return {
             content: [
               {
                 type: "text",
-                text: `Action ${toolName} was ${result.action === "decline" ? "declined" : "cancelled"} by the user.`
+                text: `Action ${toolName} was ${result2.action === "decline" ? "declined" : "cancelled"} by the user.`
               }
             ]
           };
@@ -25831,11 +25849,15 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
     }
     throw err;
   }
-  return callRemoteTool(
+  const result = await callRemoteTool(
     remoteClient,
     "run_tool",
     buildRemoteArgs(serverId, toolName, resolvedArgs)
   );
+  if (isConnectorAuth(result)) {
+    return withConnectorAuthSuffix(result);
+  }
+  return result;
 }
 function buildRemoteArgs(serverId, toolName, resolvedArgs) {
   return {

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -170,14 +170,13 @@ function buildApprovalMessage(
   return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
 }
 
-// Appended to a connector AUTH_REQUIRED result so the model understands the
-// downstream connector (not Glean) needs authorization, and does not confuse it
-// with the plugin's own [SETUP_REQUIRED] Glean sign-in.
+// Instruction to the ASSISTANT (not user-facing) appended to a connector
+// AUTH_REQUIRED result: keep the user-facing ask minimal and don't leak auth
+// internals, while still preventing a wrong `setup` call.
 const CONNECTOR_AUTH_SUFFIX =
-  "Note: Glean itself is already authenticated. This is a downstream " +
-  "connector/tool authorization request — NOT [SETUP_REQUIRED]. Do not call " +
-  "the `setup` tool. Have the user authorize using the link above, then retry " +
-  "this tool.";
+  "Assistant: ask the user only to authorize using the link above. Do not " +
+  "mention Glean, connectors, setup, or any auth internals, and do not call " +
+  "the `setup` tool.";
 
 // Detect the gateway's connector AUTH_REQUIRED envelope: an error result whose
 // first text content is JSON carrying a non-empty `authUrls` array. This is

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -170,6 +170,45 @@ function buildApprovalMessage(
   return [`Action: ${toolName}`, "Arguments:", formatArguments(args)].join("\n");
 }
 
+// Appended to a connector AUTH_REQUIRED result so the model understands the
+// downstream connector (not Glean) needs authorization, and does not confuse it
+// with the plugin's own [SETUP_REQUIRED] Glean sign-in.
+const CONNECTOR_AUTH_SUFFIX =
+  "Note: Glean itself is already authenticated. This is a downstream " +
+  "connector/tool authorization request — NOT [SETUP_REQUIRED]. Do not call " +
+  "the `setup` tool. Have the user authorize using the link above, then retry " +
+  "this tool.";
+
+// Detect the gateway's connector AUTH_REQUIRED envelope: an error result whose
+// first text content is JSON carrying a non-empty `authUrls` array. This is
+// third-party connector auth (the user authorizing e.g. Jira/Slack) — distinct
+// from the plugin's own [SETUP_REQUIRED] Glean sign-in.
+function isConnectorAuth(result: CallToolResult): boolean {
+  if (!result.isError) return false;
+  const text = result.content?.find((c) => c.type === "text");
+  if (!text || text.type !== "text") return false;
+  try {
+    const parsed = JSON.parse(text.text);
+    return (
+      !!parsed &&
+      typeof parsed === "object" &&
+      Array.isArray((parsed as { authUrls?: unknown }).authUrls) &&
+      (parsed as { authUrls: unknown[] }).authUrls.length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Append the connector-auth clarification as an extra text block, leaving the
+// gateway's original content (links and all) untouched.
+function withConnectorAuthSuffix(result: CallToolResult): CallToolResult {
+  return {
+    ...result,
+    content: [...result.content, { type: "text", text: CONNECTOR_AUTH_SUFFIX }],
+  };
+}
+
 export async function handleRunTool(
   remoteClient: Client,
   mcpServer: Server,
@@ -250,11 +289,23 @@ export async function handleRunTool(
     throw err;
   }
 
-  return callRemoteTool(
+  const result = await callRemoteTool(
     remoteClient,
     "run_tool",
     buildRemoteArgs(serverId, toolName, resolvedArgs),
   );
+
+  // A downstream connector (Jira/Slack/...) can require the user to authorize
+  // their account even though Glean itself is authenticated. The gateway
+  // surfaces that as an error result whose text is a JSON envelope with
+  // `authUrls`. Append a clarification so the model doesn't confuse it with the
+  // plugin's own [SETUP_REQUIRED] and wrongly call `setup`. The gateway's
+  // original content (including the link) is left untouched.
+  if (isConnectorAuth(result)) {
+    return withConnectorAuthSuffix(result);
+  }
+
+  return result;
 }
 
 /**

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -387,7 +387,7 @@ describe("handleRunTool (connector auth suffix)", () => {
     vi.unstubAllEnvs();
   });
 
-  it("appends the Glean-authenticated clarification on connector AUTH_REQUIRED, leaving original content intact", async () => {
+  it("appends a minimal authorize instruction on connector AUTH_REQUIRED, leaving original content intact", async () => {
     const remote = remoteReturning(authResult);
     const server = makeServer({ elicitation: true });
 
@@ -396,8 +396,8 @@ describe("handleRunTool (connector auth suffix)", () => {
     // Original envelope preserved (links untouched) + suffix appended.
     expect(result.content).toHaveLength(2);
     expect((result.content[0] as { text: string }).text).toContain("authUrls");
-    expect(lastText(result)).toContain("Glean itself is already authenticated");
-    expect(lastText(result)).toContain("NOT [SETUP_REQUIRED]");
+    expect(lastText(result)).toContain("authorize");
+    expect(lastText(result)).toContain("setup");
     expect(result.isError).toBe(true);
     // Suffix only — no dialog.
     expect(server.elicitInput).not.toHaveBeenCalled();

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -342,6 +342,91 @@ describe("handleRunTool (HITL)", () => {
   });
 });
 
+describe("handleRunTool (connector auth suffix)", () => {
+  let tmpDir: string;
+  const baseArgs = {
+    server_id: "composio/jira-pack",
+    tool_name: "jirasearch",
+    arguments: { project: "ABC" },
+  };
+  // What the gateway returns when a downstream connector needs the user to
+  // authorize their account (Glean itself is already authenticated).
+  const authResult = {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          error: "This tool requires authentication...",
+          authUrls: ["https://connect.example.com/jira"],
+        }),
+      },
+    ],
+  };
+
+  function remoteReturning(result: unknown) {
+    return {
+      callTool: vi.fn().mockResolvedValue(result),
+      close: vi.fn(),
+    } as any;
+  }
+
+  function lastText(result: {
+    content: Array<{ type: string; text?: string }>;
+  }): string {
+    const block = result.content[result.content.length - 1];
+    return block.type === "text" ? block.text ?? "" : "";
+  }
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "run-tool-connauth-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("appends the Glean-authenticated clarification on connector AUTH_REQUIRED, leaving original content intact", async () => {
+    const remote = remoteReturning(authResult);
+    const server = makeServer({ elicitation: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    // Original envelope preserved (links untouched) + suffix appended.
+    expect(result.content).toHaveLength(2);
+    expect((result.content[0] as { text: string }).text).toContain("authUrls");
+    expect(lastText(result)).toContain("Glean itself is already authenticated");
+    expect(lastText(result)).toContain("NOT [SETUP_REQUIRED]");
+    expect(result.isError).toBe(true);
+    // Suffix only — no dialog.
+    expect(server.elicitInput).not.toHaveBeenCalled();
+  });
+
+  it("passes a normal (non-error) result through unchanged", async () => {
+    const remote = remoteReturning({ content: [{ type: "text", text: "ok" }] });
+    const server = makeServer({ elicitation: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(result.content).toHaveLength(1);
+    expect((result.content[0] as { text: string }).text).toBe("ok");
+  });
+
+  it("passes an ordinary (non-JSON) error through unchanged", async () => {
+    const remote = remoteReturning({
+      isError: true,
+      content: [{ type: "text", text: "Backend exploded" }],
+    });
+    const server = makeServer({ elicitation: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(result.content).toHaveLength(1);
+    expect(lastText(result)).not.toContain("SETUP_REQUIRED");
+  });
+});
+
 describe("runToolAnnotations", () => {
   it("marks run_tool read-only when HITL gates an elicitation-capable client", () => {
     expect(runToolAnnotations(true, true)).toEqual({ readOnlyHint: true });


### PR DESCRIPTION
## Summary

Minimal, **prompt-only** handling of downstream connector authorization in
`run_tool`. When the Glean gateway returns a connector AUTH_REQUIRED result
(`isError` + a JSON envelope with `authUrls`), append a short clarification
text block:

> Note: Glean itself is already authenticated. This is a downstream
> connector/tool authorization request — NOT [SETUP_REQUIRED]. Do not call the
> `setup` tool. Have the user authorize using the link above, then retry this
> tool.

This stops the model from confusing connector auth with the plugin's own
`[SETUP_REQUIRED]` (Glean sign-in) and wrongly calling `setup`.

