### PR TITLE
[Plugins] Surface file_args content in the HITL approval prompt

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25886,6 +25886,19 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       isError: true
     };
   }
+  const baseArgs = args.arguments != null && typeof args.arguments === "object" ? args.arguments : {};
+  let resolvedArgs;
+  try {
+    resolvedArgs = await resolveFileArgs(args.file_args, baseArgs);
+  } catch (err) {
+    if (err instanceof FileArgsError) {
+      return {
+        content: [{ type: "text", text: err.message }],
+        isError: true
+      };
+    }
+    throw err;
+  }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
   if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
     const toolMeta = await findToolJson(skillsBaseDir, toolName);
@@ -25893,7 +25906,7 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       const message = await buildApprovalMessage(
         mcpServer,
         toolName,
-        args.arguments
+        resolvedArgs
       );
       const timeout = hitlTimeoutMs();
       try {
@@ -25927,19 +25940,6 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
         };
       }
     }
-  }
-  const baseArgs = args.arguments != null && typeof args.arguments === "object" ? args.arguments : {};
-  let resolvedArgs;
-  try {
-    resolvedArgs = await resolveFileArgs(args.file_args, baseArgs);
-  } catch (err) {
-    if (err instanceof FileArgsError) {
-      return {
-        content: [{ type: "text", text: err.message }],
-        isError: true
-      };
-    }
-    throw err;
   }
   return callRemoteTool(
     remoteClient,

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -195,6 +195,26 @@ export async function handleRunTool(
     };
   }
 
+  // Resolve file_args up front so the approval prompt shows the COMPLETE input
+  // (file-sourced values included, not just the inline `arguments`), and so an
+  // unreadable file_args path fails before we prompt the user.
+  const baseArgs =
+    args.arguments != null && typeof args.arguments === "object"
+      ? (args.arguments as Record<string, unknown>)
+      : {};
+  let resolvedArgs: Record<string, unknown>;
+  try {
+    resolvedArgs = await resolveFileArgs(args.file_args, baseArgs);
+  } catch (err) {
+    if (err instanceof FileArgsError) {
+      return {
+        content: [{ type: "text", text: err.message }],
+        isError: true,
+      };
+    }
+    throw err;
+  }
+
   const hitlEnabled = process.env.ENABLE_HITL === "true";
   if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
     const toolMeta = await findToolJson(skillsBaseDir, toolName);
@@ -203,7 +223,7 @@ export async function handleRunTool(
       const message = await buildApprovalMessage(
         mcpServer,
         toolName,
-        args.arguments,
+        resolvedArgs,
       );
       const timeout = hitlTimeoutMs();
 
@@ -242,23 +262,6 @@ export async function handleRunTool(
         };
       }
     }
-  }
-
-  const baseArgs =
-    args.arguments != null && typeof args.arguments === "object"
-      ? (args.arguments as Record<string, unknown>)
-      : {};
-  let resolvedArgs: Record<string, unknown>;
-  try {
-    resolvedArgs = await resolveFileArgs(args.file_args, baseArgs);
-  } catch (err) {
-    if (err instanceof FileArgsError) {
-      return {
-        content: [{ type: "text", text: err.message }],
-        isError: true,
-      };
-    }
-    throw err;
   }
 
   return callRemoteTool(

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -375,6 +375,47 @@ describe("handleRunTool (HITL)", () => {
     expect(fileContent).toContain("## body");
     await fs.rm(filePath, { force: true });
   });
+
+  it("surfaces file_args content in the approval prompt", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "create_doc", { requires_approval: true });
+    const bodyFile = path.join(tmpDir, "draft.md");
+    await fs.writeFile(bodyFile, "FILE_SOURCED_BODY", "utf-8");
+
+    await handleRunTool(remote, server, tmpDir, {
+      server_id: "s",
+      tool_name: "create_doc",
+      arguments: { title: "Doc" },
+      file_args: { body: bodyFile },
+    });
+
+    const message = elicit.mock.calls[0][0].message as string;
+    expect(message).toContain("TITLE: Doc");
+    expect(message).toContain("BODY: FILE_SOURCED_BODY"); // file-sourced arg shown
+    expect(remote.callTool).toHaveBeenCalledTimes(1); // executed on accept
+  });
+
+  it("fails before prompting when a file_args path is unreadable", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "create_doc", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, {
+      server_id: "s",
+      tool_name: "create_doc",
+      arguments: {},
+      file_args: { body: "/no/such/abs/path.md" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(elicit).not.toHaveBeenCalled(); // no prompt for unreadable input
+    expect(remote.callTool).not.toHaveBeenCalled();
+  });
 });
 
 describe("buildCompactArgs", () => {


### PR DESCRIPTION
## Problem

`run_tool` accepts `file_args` (arg name → absolute file path); the plugin reads each file and merges its content into `arguments` before calling the action. That resolution happened **after** the HITL approval, so file-sourced values never appeared in the approval prompt — a user could approve an action (e.g. "send a message") without seeing input that comes from a file (the message body sourced from `file_args`).

## Fix

Resolve `file_args` **before** building the approval prompt and build the prompt from the merged result. File-sourced values now appear in the displayed arguments alongside inline ones; large file content is truncated inline and written in full to the spill file, same as any large argument. An unreadable `file_args` path now also fails **before** prompting (instead of after the user approves).

## Stacked on the HITL display PR

Based on the HITL display PR rather than `main`: surfacing (potentially large) file content stays viewport-safe only because of that PR's truncate-inline + spill-to-file behavior — on `main` alone a large file body would overflow the prompt. When the base PR merges, this retargets to `main` automatically.

## Tests

- file_args content appears in the approval message; the action executes on accept.
- an unreadable file_args path fails before prompting (no elicitation, not executed).
- Build + typecheck + tests all green.
