### PR TITLE
Declare glean-plugins-vnext marketplace in settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,14 @@
 {
   "enabledPlugins": {
     "glean-vnext@glean-plugins-vnext": true
+  },
+  "extraKnownMarketplaces": {
+    "glean-plugins-vnext": {
+      "source": {
+        "source": "github",
+        "repo": "gleanwork/glean-plugins-vnext",
+        "ref": "main"
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

Add an `extraKnownMarketplaces` entry to `.claude/settings.json` declaring the `glean-plugins-vnext` marketplace.

```json
"extraKnownMarketplaces": {
  "glean-plugins-vnext": {
    "source": {
      "source": "github",
      "repo": "gleanwork/glean-plugins-vnext",
      "ref": "main"
    }
  }
}
```

## Why

`enabledPlugins` already enables `glean-vnext@glean-plugins-vnext`, but the `glean-plugins-vnext` marketplace it references was never defined. This entry tells Claude Code where to resolve it from (`gleanwork/glean-plugins-vnext@main`), so the enabled plugin loads without manual marketplace setup.