### PR TITLE
Constrain Node version to <26

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ every launch and setting them yourself has no effect:
 
 ## Development
 
-Prerequisites: Node 22+, npm.
+Prerequisites: Node >=22 <26, npm.
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22 <26"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glean",
   "type": "module",
-  "engines":{
+  "engines": {
     "node": ">=22 <26"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "glean",
   "type": "module",
+  "engines":{
+    "node": ">=22 <26"
+  },
   "scripts": {
     "build": "node scripts/build.mjs",
     "typecheck": "tsc --noEmit",

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/package.json
+++ b/plugins/glean/package.json
@@ -2,5 +2,8 @@
   "name": "glean",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": ">=22 <26"
+  },
   "description": "Runtime manifest for the packaged Glean plugin. Lives alongside dist/index.js so Node loads it as an ES module. Dev tooling (build, test, typecheck) lives at the repo root in the top-level package.json."
 }


### PR DESCRIPTION
## What
Constrain supported Node.js versions to <26.

## Why
On Node 26 the plugin's `tools/list` request hangs and times out, so Claude Code drops the plugin's entire toolset. It turns out Node 26 bundles undici 8, which makes `fetch` use HTTP/2 by default, and the plugin appears to receive the Glean gateway's response to `tools/list` only over HTTP/1.1 – over HTTP/2 it receives nothing.

Prior versions of Node bundle `undici <=7` and so do not offer HTTP/2 in `fetch`.

## Code changes
* Updates prerequisites in README to specify <26.
* Specifies Node version constraints (`>=22 <26`) in `package.json`.
