### PR TITLE
Add GitHub Copilot as a fourth plugin host (CLI + VS Code)

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "glean-plugins-vnext",
+  "metadata": {
+    "description": "Glean plugins for GitHub Copilot — search and act across enterprise apps without leaving your editor or terminal"
+  },
+  "owner": {
+    "name": "Glean"
+  },
+  "plugins": [
+    {
+      "name": "glean-vnext",
+      "source": "./plugins/glean",
+      "description": "Glean plugin for discovering skills and running tools."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Glean plugin
 
 Glean's plugin for [Claude Code](https://code.claude.com/docs/en/overview),
-Codex, and Cursor. This repo is a single-plugin marketplace, shipping one
-manifest per host.
+Codex, Cursor, and [GitHub Copilot](https://docs.github.com/en/copilot) (CLI and
+VS Code). This repo is a single-plugin marketplace, shipping one manifest per
+host.
 
 Today it ships one plugin:
 
@@ -31,6 +32,32 @@ host at `gleanwork/glean-plugins-vnext` and install **glean-vnext** through that
 host's plugin flow. The launcher, skills, and server bundle are shared across
 all hosts. For Cursor, see
 [Team marketplaces](https://cursor.com/docs/plugins#team-marketplaces).
+
+### GitHub Copilot (CLI and VS Code)
+
+GitHub Copilot uses the same agent-plugin format as Claude Code, so the shipped
+Claude-format manifest (`.claude-plugin/plugin.json` + `.mcp.json` + `skills/`)
+is what Copilot loads — there is no separate Copilot plugin manifest. The repo
+exposes a Copilot-native marketplace at `.github/plugin/marketplace.json`.
+
+**Copilot CLI:**
+
+```
+copilot plugin marketplace add gleanwork/glean-plugins-vnext
+copilot plugin install glean-vnext@glean-plugins-vnext
+```
+
+**VS Code:** register the marketplace via the `chat.plugins.marketplaces`
+setting (or run **Chat: Install Plugin From Source** with this repo's Git URL),
+then install **glean-vnext** from the **Agent Plugins** view (`@agentPlugins` in
+the Extensions search). VS Code also auto-discovers plugins you installed with
+the Copilot CLI from `~/.copilot/installed-plugins/`.
+
+The plugin stays in Claude format on purpose: its `.mcp.json` references
+`${CLAUDE_PLUGIN_ROOT}` to locate `start.sh`, and that token is only substituted
+for Claude-format plugins — the Copilot-native format defines no plugin-root
+token. Adding a `.plugin/plugin.json` would make Copilot treat the plugin as
+native format and break that path resolution, so we don't ship one.
 
 ## First run
 
@@ -127,7 +154,8 @@ every launch and setting them yourself has no effect:
   `<PLUGIN_DATA_DIR>/glean-skills-cache`, or redirected under the launch
   project's `.claude/tmp/` when `USE_CLAUDE_PROJECT_DIR=1`.
 - `GLEAN_SESSION_ID` — the host's conversation id: `CLAUDE_CODE_SESSION_ID` for
-  Claude Code, `CODEX_THREAD_ID` for Codex, otherwise a generated UUID.
+  Claude Code, `CODEX_THREAD_ID` for Codex, `COPILOT_AGENT_SESSION_ID` for
+  GitHub Copilot, otherwise a generated UUID.
 
 ## Troubleshooting
 
@@ -180,15 +208,20 @@ runtime lives under `plugins/glean/`. See the Layout section below.
   marketplace.json        Marketplace manifest for Cursor.
 .agents/plugins/
   marketplace.json        Marketplace manifest for Codex.
+.github/plugin/
+  marketplace.json        Marketplace manifest for GitHub Copilot
+                          (CLI + VS Code).
 plugins/glean/
   .claude-plugin/
-    plugin.json           Claude plugin manifest — name, version, description
+    plugin.json           Claude plugin manifest — name, version, description.
+                          Also the manifest GitHub Copilot loads (shared
+                          Claude/Copilot agent-plugin format).
   .codex-plugin/
     plugin.json           Codex plugin manifest (skills, mcpServers, interface)
   .cursor-plugin/
     plugin.json           Cursor plugin manifest
-  .mcp.json               MCP server invocation for Claude / Cursor. Source
-                          of truth; sets ENABLE_HITL / HITL_TIMEOUT_MS.
+  .mcp.json               MCP server invocation for Claude / Cursor / Copilot.
+                          Source of truth; sets ENABLE_HITL / HITL_TIMEOUT_MS.
   .mcp.codex.json         MCP server invocation for Codex
   assets/                 Shared brand assets (logo) referenced by manifests
   dist/index.js           Built server bundle (every dep inlined; produced

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/start.sh
+++ b/plugins/glean/start.sh
@@ -35,13 +35,16 @@ fi
 # Resolve the chat session id host-side. Host-awareness lives here, not in the
 # plugin: the launcher reads whatever variable this host exposes and exports the
 # normalized GLEAN_SESSION_ID that the Node bundle reads. Claude Code exposes
-# CLAUDE_CODE_SESSION_ID; Codex exposes the conversation id as CODEX_THREAD_ID.
-# Hosts that expose no session id (Cursor) leave it unset, and the plugin falls
-# back to a generated per-process id.
+# CLAUDE_CODE_SESSION_ID; Codex exposes the conversation id as CODEX_THREAD_ID;
+# GitHub Copilot (CLI and VS Code) exposes COPILOT_AGENT_SESSION_ID to MCP
+# servers. Hosts that expose no session id (Cursor) leave it unset, and the
+# plugin falls back to a generated per-process id.
 if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
   export GLEAN_SESSION_ID="$CLAUDE_CODE_SESSION_ID"
 elif [ -n "${CODEX_THREAD_ID:-}" ]; then
   export GLEAN_SESSION_ID="$CODEX_THREAD_ID"
+elif [ -n "${COPILOT_AGENT_SESSION_ID:-}" ]; then
+  export GLEAN_SESSION_ID="$COPILOT_AGENT_SESSION_ID"
 fi
 
 exec node "$PLUGIN_DIR/dist/index.js"


### PR DESCRIPTION
## Summary

Adds GitHub Copilot (CLI and VS Code) as a fourth supported host. Copilot's agent-plugin format is shared with Claude Code, so the existing Claude-format plugin (`.claude-plugin/plugin.json` + `.mcp.json` + `skills/`) is what Copilot loads — there's no separate Copilot plugin manifest, and **deliberately no `.plugin/plugin.json`**: the Copilot-native format defines no plugin-root token, which would break the `${CLAUDE_PLUGIN_ROOT}` reference that locates `start.sh`.

## Changes

- **`.github/plugin/marketplace.json`** (new) — makes the repo a first-class Copilot marketplace at the GitHub-native location, mirroring the per-host marketplace manifests for Claude (`.claude-plugin/`), Cursor (`.cursor-plugin/`), and Codex (`.agents/plugins/`).
- **`start.sh`** — maps Copilot CLI's `COPILOT_AGENT_SESSION_ID` to `GLEAN_SESSION_ID`, so sessions are stable under Copilot instead of falling back to a generated per-process id.
- **README** — new "GitHub Copilot (CLI and VS Code)" install section; updated intro, `GLEAN_SESSION_ID` var reference, and Layout tree.
- **Version bump** — all three plugin manifests `0.2.33 → 0.2.34` (in lockstep; `start.sh` is a tracked plugin runtime file, so `check-version-bump.sh` requires it).

## Install

**Copilot CLI:**
```
copilot plugin marketplace add gleanwork/glean-plugins-vnext
copilot plugin install glean-vnext@glean-plugins-vnext
```

**VS Code:** register the marketplace via `chat.plugins.marketplaces` (or **Chat: Install Plugin From Source**), then install **glean-vnext** from the Agent Plugins view (`@agentPlugins`).

## Testing

- `npm run typecheck` clean; `npm test` → 154/154 pass; `npm run build` → `dist/` byte-identical (dist-sync gate green).
- `bash -n start.sh` clean; all marketplace/plugin manifests validate as JSON; the three plugin versions are aligned at 0.2.34.

## Remaining manual verification

The Copilot CLI isn't installed in my environment, so a live skill-load smoke test wasn't possible. The `glean_run` skill uses an underscore where the docs suggest kebab-case, but the documented silent-failure mode is namespace-prefix + dir/name mismatch (neither applies here, and Claude Code loads it today). After install, confirm `glean_run` appears under `/skills`; rename to `glean-run` only if it doesn't (cross-host change).