### PR TITLE
Auto-dismiss HITL approval popup on elicitation timeout

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25875,6 +25875,13 @@ async function buildApprovalMessage(mcpServer, toolName, args) {
   }
   return message.join("\n");
 }
+var elicitationIdPrimed = /* @__PURE__ */ new WeakSet();
+function primeElicitationCancellation(mcpServer) {
+  if (elicitationIdPrimed.has(mcpServer)) return;
+  elicitationIdPrimed.add(mcpServer);
+  void mcpServer.request({ method: "ping" }, EmptyResultSchema).catch(() => {
+  });
+}
 async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
@@ -25909,6 +25916,7 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
         resolvedArgs
       );
       const timeout = hitlTimeoutMs();
+      primeElicitationCancellation(mcpServer);
       try {
         const result = await mcpServer.elicitInput(
           {

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { EmptyResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { callRemoteTool } from "../remote-client.js";
@@ -177,6 +178,17 @@ async function buildApprovalMessage(
   return message.join("\n");
 }
 
+// A WeakSet so a short-lived server in tests doesn't leak,
+// and so the burn happens exactly once per server instance.
+const elicitationIdPrimed = new WeakSet<object>();
+function primeElicitationCancellation(mcpServer: Server): void {
+  if (elicitationIdPrimed.has(mcpServer)) return;
+  elicitationIdPrimed.add(mcpServer);
+  void mcpServer.request({ method: "ping" }, EmptyResultSchema).catch(() => {
+    // Ping rejection is fine: request id 0 is already consumed by this call
+  });
+}
+
 export async function handleRunTool(
   remoteClient: Client,
   mcpServer: Server,
@@ -226,6 +238,9 @@ export async function handleRunTool(
         resolvedArgs,
       );
       const timeout = hitlTimeoutMs();
+
+      // Make a dummy empty request to burn JSON-RPC request id 0
+      primeElicitationCancellation(mcpServer);
 
       try {
         const result = await mcpServer.elicitInput(

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -179,6 +179,7 @@ function makeServer(opts: {
   elicitation?: boolean;
   clientName?: string;
   elicit?: ReturnType<typeof vi.fn>;
+  request?: ReturnType<typeof vi.fn>;
 }) {
   return {
     getClientCapabilities: vi
@@ -188,6 +189,8 @@ function makeServer(opts: {
       .fn()
       .mockReturnValue({ name: opts.clientName ?? "claude-code", version: "1" }),
     elicitInput: opts.elicit ?? vi.fn().mockResolvedValue({ action: "accept" }),
+    // Used by primeElicitationCancellation to burn request id 0.
+    request: opts.request ?? vi.fn().mockResolvedValue({}),
   } as any;
 }
 
@@ -266,6 +269,39 @@ describe("handleRunTool (HITL)", () => {
     expect(params.message).not.toContain("**");
     expect(options.timeout).toBe(300_000);
     expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("pings to burn request id 0 before the first elicitation (so timeout cancellation is honored), once per server", async () => {
+    // The MCP SDK's _oncancel drops notifications/cancelled with a falsy
+    // requestId, so an elicitation that lands on request id 0 never gets
+    // dismissed on timeout. We burn id 0 with a ping before the first prompt.
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const request = vi.fn().mockResolvedValue({});
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({ elicitation: true, elicit, request });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    // Ping fired exactly once for this server, and it is a ping.
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls[0][0]).toEqual({ method: "ping" });
+    // Both prompts still ran.
+    expect(elicit).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not ping when the tool requires no approval (no elicitation)", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const request = vi.fn().mockResolvedValue({});
+    const server = makeServer({ elicitation: true, request });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("honors the HITL_TIMEOUT_MS override", async () => {


### PR DESCRIPTION
When a user doesn't respond to a HITL approval prompt within HITL_TIMEOUT_MS, the popup got stuck: the user had to press Escape and retry. Root cause is a client-side MCP SDK bug. The first server->client request in a session gets JSON-RPC id 0. The SDK's `_oncancel` bails on a falsy requestId (`if (!notification.params.requestId) return`), and `!0` is true — so the `notifications/cancelled` we send on timeout for request id 0 is silently dropped by the client, and the accept/decline popup never auto-dismisses (it lingers with dead buttons). Prompts 2+ get id>=1 and dismiss fine, which is why it looked flaky ("sometimes it disappears").

Fix: burn id 0 with a throwaway ping before the first elicitation, so every approval prompt uses id>=1 and its timeout cancellation is honored. The id is consumed synchronously inside request(), so it's fire-and-forget and tolerant of ping failure. The real fix belongs in the SDK's `_oncancel`; this guards us until clients ship it.
(Reference : https://github.com/modelcontextprotocol/typescript-sdk/issues/2283) 

- src/tools/run-tool.ts: primeElicitationCancellation(), once per server
- tests/run-tool.test.ts: cover the burn (pings once; not when no approval)
- plugins/glean/dist/index.js: rebuilt
- bump all 3 plugin manifests 0.2.33 -> 0.2.34