### PR TITLE
Log plugin version at startup (server.start)

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26235,6 +26235,7 @@ function sameOrigin(a, b) {
 }
 
 // src/index.ts
+var PLUGIN_VERSION = true ? "0.2.36" : "dev";
 function readEnv(...keys) {
   for (const key of keys) {
     const v = process.env[key];
@@ -26807,6 +26808,11 @@ ${EMAIL_RESOLVE_FAILED_TEXT}`
   }
 });
 async function main() {
+  logLine("server.start", {
+    version: PLUGIN_VERSION,
+    node: process.version,
+    pid: process.pid
+  });
   const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1e3;
   try {
     await evictStaleSkills(resolveSkillsBaseDir(), ONE_WEEK_MS, logLine);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,16 +18,32 @@
 
 import { build } from "esbuild";
 import { builtinModules } from "node:module";
+import { readFileSync } from "node:fs";
 
 const nodeBuiltins = [
   ...builtinModules,
   ...builtinModules.map((m) => `node:${m}`),
 ];
 
+// Stamp the plugin version into the bundle as a compile-time constant so the
+// running server can log which version it is. The per-host manifests are the
+// single source of truth (kept aligned by check-version-bump.sh), so reading
+// the Claude manifest is representative. Under `tsx` dev (no bundle), the
+// constant is absent and src/index.ts falls back to "dev".
+const pluginVersion = JSON.parse(
+  readFileSync(
+    new URL("../plugins/glean/.claude-plugin/plugin.json", import.meta.url),
+    "utf8",
+  ),
+).version;
+
 await build({
   entryPoints: ["src/index.ts"],
   outfile: "plugins/glean/dist/index.js",
   bundle: true,
+  define: {
+    __GLEAN_PLUGIN_VERSION__: JSON.stringify(pluginVersion),
+  },
   platform: "node",
   format: "esm",
   target: "node20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,14 @@ import {
 import { resolveSessionId } from "./session-id.js";
 import { resolveServerUrlFromEmail } from "./config-search.js";
 
+// Injected at build time by scripts/build.mjs from the plugin manifest version.
+// Absent under `tsx` dev runs — the typeof guard falls back to "dev" there.
+declare const __GLEAN_PLUGIN_VERSION__: string | undefined;
+const PLUGIN_VERSION =
+  typeof __GLEAN_PLUGIN_VERSION__ !== "undefined"
+    ? __GLEAN_PLUGIN_VERSION__
+    : "dev";
+
 function readEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
     const v = process.env[key];
@@ -812,6 +820,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 async function main() {
   // Run once per session at MCP server startup.
+  // First line per process: stamps the plugin version (+ node/pid) so any
+  // session's log is traceable to the exact build that served it.
+  logLine("server.start", {
+    version: PLUGIN_VERSION,
+    node: process.version,
+    pid: process.pid,
+  });
   const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
   try {
     await evictStaleSkills(resolveSkillsBaseDir(), ONE_WEEK_MS, logLine);


### PR DESCRIPTION
## Why

`glean-server.log` had no way to tell **which plugin build served a session**. The active log is just repeated `tools-list.served` lines with no version, so when debugging a reported session you can't tell whether it ran current code or an older bundle — e.g. the paste-back vs. loopback OAuth flows behave very differently, and there was no way to confirm which one a user actually hit.

## What

- **Build-time version injection** (`scripts/build.mjs`): read the version from the Claude manifest (all three host manifests are kept aligned by `check-version-bump.sh`) and pass it to esbuild as a `define` constant `__GLEAN_PLUGIN_VERSION__`.
- **`server.start` log line** (`src/index.ts`): emit one structured line as the first thing in `main()` — `server.start {version, node, pid}` — so every session's log is traceable to the exact build, Node version, and process that served it.
- Under `tsx` dev runs the constant is absent; a `typeof` guard falls back to `"dev"` (no `ReferenceError`).

## Verification

- `npm run build` → `__GLEAN_PLUGIN_VERSION__` resolves to `"0.2.36"` in `dist/index.js`; no leftover token.
- Dev fallback proven: `typeof` guard yields `"dev"`, no throw.
- `npm run typecheck` clean; `npm test` 160/160 pass.

## Notes

Per-line session-id tagging and auth-flow logging are intentionally **not** in this PR — they come in a separate auth-logging PR. This change is deliberately minimal: one startup line, one build constant.