### PR TITLE
Parse object/array file_args as JSON via the downstream tool schema

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25773,6 +25773,14 @@ var FileArgsError = class extends Error {
     this.name = "FileArgsError";
   }
 };
+function declaredParamTypes(inputSchema, argName) {
+  const t = inputSchema?.properties?.[argName]?.type;
+  if (typeof t === "string") return /* @__PURE__ */ new Set([t]);
+  if (Array.isArray(t)) {
+    return new Set(t.filter((x) => typeof x === "string"));
+  }
+  return /* @__PURE__ */ new Set();
+}
 function fileArgsMaxBytes() {
   const raw = process.env.GLEAN_FILE_ARG_MAX_BYTES;
   if (!raw) return DEFAULT_FILE_ARG_MAX_BYTES;
@@ -25785,7 +25793,7 @@ function hitlTimeoutMs() {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultHitlTimeoutMs;
 }
-async function resolveFileArgs(fileArgs, baseArgs) {
+async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
   if (fileArgs === void 0 || fileArgs === null) return baseArgs;
   if (typeof fileArgs !== "object" || Array.isArray(fileArgs)) {
     throw new FileArgsError(
@@ -25831,7 +25839,24 @@ async function resolveFileArgs(fileArgs, baseArgs) {
         `file_args.${argName}: "${filePathRaw}" is ${stat.size} bytes, exceeds ${maxBytes} byte limit (set GLEAN_FILE_ARG_MAX_BYTES to override)`
       );
     }
-    merged[argName] = await fs4.readFile(filePathRaw, "utf-8");
+    const content = await fs4.readFile(filePathRaw, "utf-8");
+    const types = declaredParamTypes(inputSchema, argName);
+    if (types.has("object") || types.has("array")) {
+      try {
+        merged[argName] = JSON.parse(content);
+      } catch (err) {
+        if (types.has("string")) {
+          merged[argName] = content;
+        } else {
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new FileArgsError(
+            `file_args.${argName}: "${filePathRaw}" must contain valid JSON for the object/array-typed parameter, but parsing failed: ${msg}`
+          );
+        }
+      }
+    } else {
+      merged[argName] = content;
+    }
   }
   return merged;
 }
@@ -25893,10 +25918,15 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       isError: true
     };
   }
+  const toolMeta = await findToolJson(skillsBaseDir, toolName);
   const baseArgs = args.arguments != null && typeof args.arguments === "object" ? args.arguments : {};
   let resolvedArgs;
   try {
-    resolvedArgs = await resolveFileArgs(args.file_args, baseArgs);
+    resolvedArgs = await resolveFileArgs(
+      args.file_args,
+      baseArgs,
+      toolMeta?.inputSchema
+    );
   } catch (err) {
     if (err instanceof FileArgsError) {
       return {
@@ -25908,7 +25938,6 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
   if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
-    const toolMeta = await findToolJson(skillsBaseDir, toolName);
     if (toolMeta?.requires_approval) {
       const message = await buildApprovalMessage(
         mcpServer,
@@ -26344,7 +26373,7 @@ var RUN_TOOL_TOOL = {
       },
       file_args: {
         type: "object",
-        description: "Optional map from argument name to absolute local file path. The plugin reads each file and substitutes its UTF-8 contents into the corresponding key in `arguments` before calling the remote tool. Use this for long-form drafted content (Slack message bodies, Confluence pages, doc contents, etc.) so the draft doesn't have to be passed as a huge inline string. Paths must be absolute. Each file must be \u2264 1 MB (override via GLEAN_FILE_ARG_MAX_BYTES). A key in `file_args` must not also appear in `arguments`.",
+        description: "Optional map from argument name to absolute local file path. The plugin reads each file and substitutes its contents into the corresponding key in `arguments` before calling the remote tool. If the target parameter is typed as an object or array in the tool's inputSchema, the file is parsed as JSON and injected as structured data; otherwise its contents are injected as a UTF-8 string. Use this to keep large values out of the inline call \u2014 long-form text (Slack message bodies, Confluence pages, doc contents) or a large structured argument (e.g. an agent spec). Paths must be absolute. Each file must be \u2264 1 MB (override via GLEAN_FILE_ARG_MAX_BYTES). A key in `file_args` must not also appear in `arguments`.",
         additionalProperties: { type: "string" }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,11 +221,14 @@ const RUN_TOOL_TOOL: Tool = {
         type: "object",
         description:
           "Optional map from argument name to absolute local file path. " +
-          "The plugin reads each file and substitutes its UTF-8 contents " +
-          "into the corresponding key in `arguments` before calling the " +
-          "remote tool. Use this for long-form drafted content (Slack " +
-          "message bodies, Confluence pages, doc contents, etc.) so the " +
-          "draft doesn't have to be passed as a huge inline string. " +
+          "The plugin reads each file and substitutes its contents into the " +
+          "corresponding key in `arguments` before calling the remote tool. " +
+          "If the target parameter is typed as an object or array in the " +
+          "tool's inputSchema, the file is parsed as JSON and injected as " +
+          "structured data; otherwise its contents are injected as a UTF-8 " +
+          "string. Use this to keep large values out of the inline call — " +
+          "long-form text (Slack message bodies, Confluence pages, doc " +
+          "contents) or a large structured argument (e.g. an agent spec). " +
           "Paths must be absolute. Each file must be ≤ 1 MB (override " +
           "via GLEAN_FILE_ARG_MAX_BYTES). A key in `file_args` must not " +
           "also appear in `arguments`.",

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -21,6 +21,30 @@ export class FileArgsError extends Error {
   }
 }
 
+// A downstream tool parameter's JSON Schema, narrowed to the bits we use.
+// `type` may be a single string or an array (e.g. ["object", "null"]).
+interface ParamSchema {
+  type?: string | string[];
+}
+interface ToolInputSchema {
+  properties?: Record<string, ParamSchema>;
+}
+
+// The set of JSON Schema types declared for a top-level parameter. file_args
+// keys always map to top-level argument names, so a direct properties lookup
+// is sufficient — no need to walk nested schemas.
+function declaredParamTypes(
+  inputSchema: ToolInputSchema | undefined,
+  argName: string,
+): Set<string> {
+  const t = inputSchema?.properties?.[argName]?.type;
+  if (typeof t === "string") return new Set([t]);
+  if (Array.isArray(t)) {
+    return new Set(t.filter((x): x is string => typeof x === "string"));
+  }
+  return new Set();
+}
+
 function fileArgsMaxBytes(): number {
   const raw = process.env.GLEAN_FILE_ARG_MAX_BYTES;
   if (!raw) return DEFAULT_FILE_ARG_MAX_BYTES;
@@ -38,13 +62,19 @@ function hitlTimeoutMs(): number {
 }
 
 /**
- * Reads each `file_args` entry from disk and merges its UTF-8 content into
- * `baseArgs` under the given key. Throws FileArgsError on any validation
- * failure so the caller can surface the message verbatim to the model.
+ * Reads each `file_args` entry from disk and merges its content into
+ * `baseArgs` under the given key. The downstream tool's `inputSchema` decides
+ * how the content is injected: a parameter typed `object`/`array` is JSON-
+ * parsed into structured data (a raw string would fail the downstream schema
+ * with "Expected object, given string"), while everything else — the common
+ * case of long-form text bodies — is injected verbatim as a UTF-8 string.
+ * Throws FileArgsError on any validation failure so the caller can surface the
+ * message verbatim to the model.
  */
 export async function resolveFileArgs(
   fileArgs: unknown,
   baseArgs: Record<string, unknown>,
+  inputSchema?: ToolInputSchema,
 ): Promise<Record<string, unknown>> {
   if (fileArgs === undefined || fileArgs === null) return baseArgs;
   if (
@@ -99,7 +129,27 @@ export async function resolveFileArgs(
       );
     }
 
-    merged[argName] = await fs.readFile(filePathRaw, "utf-8");
+    const content = await fs.readFile(filePathRaw, "utf-8");
+    const types = declaredParamTypes(inputSchema, argName);
+    if (types.has("object") || types.has("array")) {
+      try {
+        merged[argName] = JSON.parse(content);
+      } catch (err) {
+        // A union like ["string", "object"] can legitimately take raw text, so
+        // keep the string. A pure object/array param cannot — fail with a clear
+        // message before the opaque downstream "Expected object, given string".
+        if (types.has("string")) {
+          merged[argName] = content;
+        } else {
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new FileArgsError(
+            `file_args.${argName}: "${filePathRaw}" must contain valid JSON for the object/array-typed parameter, but parsing failed: ${msg}`,
+          );
+        }
+      }
+    } else {
+      merged[argName] = content;
+    }
   }
 
   return merged;
@@ -110,6 +160,7 @@ interface ToolMetadata {
   name?: string;
   description?: string;
   server_id?: string;
+  inputSchema?: ToolInputSchema;
 }
 
 async function findToolJson(
@@ -207,6 +258,11 @@ export async function handleRunTool(
     };
   }
 
+  // Load the downstream tool's metadata once, up front: its inputSchema drives
+  // file_args JSON-parsing (object/array params) and its requires_approval
+  // drives the HITL gate. Both paths must see it regardless of ENABLE_HITL.
+  const toolMeta = await findToolJson(skillsBaseDir, toolName);
+
   // Resolve file_args up front so the approval prompt shows the COMPLETE input
   // (file-sourced values included, not just the inline `arguments`), and so an
   // unreadable file_args path fails before we prompt the user.
@@ -216,7 +272,11 @@ export async function handleRunTool(
       : {};
   let resolvedArgs: Record<string, unknown>;
   try {
-    resolvedArgs = await resolveFileArgs(args.file_args, baseArgs);
+    resolvedArgs = await resolveFileArgs(
+      args.file_args,
+      baseArgs,
+      toolMeta?.inputSchema,
+    );
   } catch (err) {
     if (err instanceof FileArgsError) {
       return {
@@ -229,8 +289,6 @@ export async function handleRunTool(
 
   const hitlEnabled = process.env.ENABLE_HITL === "true";
   if (hitlEnabled && mcpServer.getClientCapabilities()?.elicitation) {
-    const toolMeta = await findToolJson(skillsBaseDir, toolName);
-
     if (toolMeta?.requires_approval) {
       const message = await buildApprovalMessage(
         mcpServer,

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -141,6 +141,81 @@ describe("resolveFileArgs", () => {
       resolveFileArgs({ body: file }, { body: "existing" }),
     ).rejects.toThrow(/conflicts/);
   });
+
+  it("parses JSON into an object when the param type is object", async () => {
+    const file = path.join(tmpDir, "spec.json");
+    await fs.writeFile(file, '{"name":"agent","steps":[1,2,3]}');
+
+    const result = await resolveFileArgs({ spec: file }, {}, {
+      properties: { spec: { type: "object" } },
+    });
+
+    expect(result.spec).toEqual({ name: "agent", steps: [1, 2, 3] });
+  });
+
+  it("parses JSON into an array when the param type is array", async () => {
+    const file = path.join(tmpDir, "items.json");
+    await fs.writeFile(file, '["a","b"]');
+
+    const result = await resolveFileArgs({ items: file }, {}, {
+      properties: { items: { type: "array" } },
+    });
+
+    expect(result.items).toEqual(["a", "b"]);
+  });
+
+  it("parses when type is given as an array including object", async () => {
+    const file = path.join(tmpDir, "spec.json");
+    await fs.writeFile(file, '{"k":1}');
+
+    const result = await resolveFileArgs({ spec: file }, {}, {
+      properties: { spec: { type: ["object", "null"] } },
+    });
+
+    expect(result.spec).toEqual({ k: 1 });
+  });
+
+  it("keeps raw string for a string param even when content is JSON", async () => {
+    const file = path.join(tmpDir, "body.json");
+    await fs.writeFile(file, '{"looks":"like json"}');
+
+    const result = await resolveFileArgs({ body: file }, {}, {
+      properties: { body: { type: "string" } },
+    });
+
+    expect(result.body).toBe('{"looks":"like json"}');
+  });
+
+  it("keeps raw string when no schema is provided (backward compat)", async () => {
+    const file = path.join(tmpDir, "body.json");
+    await fs.writeFile(file, '{"a":1}');
+
+    const result = await resolveFileArgs({ body: file }, {});
+
+    expect(result.body).toBe('{"a":1}');
+  });
+
+  it("throws a clear error when an object-typed param gets invalid JSON", async () => {
+    const file = path.join(tmpDir, "spec.json");
+    await fs.writeFile(file, "not json {");
+
+    await expect(
+      resolveFileArgs({ spec: file }, {}, {
+        properties: { spec: { type: "object" } },
+      }),
+    ).rejects.toThrow(/must contain valid JSON/);
+  });
+
+  it("falls back to the raw string for a string|object union with invalid JSON", async () => {
+    const file = path.join(tmpDir, "val.txt");
+    await fs.writeFile(file, "plain text");
+
+    const result = await resolveFileArgs({ val: file }, {}, {
+      properties: { val: { type: ["string", "object"] } },
+    });
+
+    expect(result.val).toBe("plain text");
+  });
 });
 
 describe("buildRemoteArgs", () => {
@@ -432,6 +507,32 @@ describe("handleRunTool (HITL)", () => {
     expect(message).toContain("TITLE: Doc");
     expect(message).toContain("BODY: FILE_SOURCED_BODY"); // file-sourced arg shown
     expect(remote.callTool).toHaveBeenCalledTimes(1); // executed on accept
+  });
+
+  it("parses an object-typed file_arg from the tool schema and forwards it as structured data", async () => {
+    vi.stubEnv("ENABLE_HITL", "false");
+    const remote = makeRemote();
+    const server = makeServer({ elicitation: false });
+    await writeToolJson(tmpDir, "save_agent", {
+      requires_approval: false,
+      inputSchema: { properties: { spec: { type: "object" } } },
+    });
+    const specFile = path.join(tmpDir, "spec.json");
+    await fs.writeFile(specFile, '{"name":"my-agent","steps":[1,2]}', "utf-8");
+
+    await handleRunTool(remote, server, tmpDir, {
+      server_id: "default",
+      tool_name: "save_agent",
+      arguments: {},
+      file_args: { spec: specFile },
+    });
+
+    const call = remote.callTool.mock.calls[0][0];
+    expect(call.name).toBe("run_tool");
+    expect(call.arguments.arguments.spec).toEqual({
+      name: "my-agent",
+      steps: [1, 2],
+    });
   });
 
   it("fails before prompting when a file_args path is unreadable", async () => {


### PR DESCRIPTION
## Problem

`file_args` always injected file contents as a **UTF-8 string**. When the target parameter is typed `object`/`array` in the downstream tool's schema (e.g. `save_agent.spec`), that string fails remote validation with `Expected object, given string`. So large structured arguments that can't be inlined — the ~140 KB agent spec reported in `#feedback-tesseract` — had **no working path**.

## Fix

Make `file_args` **schema-aware**, using the tool JSON the model already reads. For each `file_args` entry, look up the parameter's declared type at `inputSchema.properties[<arg>].type` (single string, or array form like `["object","null"]`):

- `object` / `array` → `JSON.parse` the file and inject structured data.
- anything else (the common case: doc bodies, message text) → inject the verbatim UTF-8 string — **unchanged** behavior.

Invalid JSON for an `object`/`array`-only param now fails fast with a clear `FileArgsError` instead of the opaque downstream `Expected object, given string`; a `string | object` union falls back to the raw string.

## Relationship to HITL: none (this is the part to clarify)

The parsing is **completely independent of `ENABLE_HITL`** — it behaves identically whether HITL is on or off. `findToolJson` (which loads the `inputSchema`) is hoisted to the top of `handleRunTool`, so `file_args` resolution runs on **every** `run_tool` call, *before* the HITL approval gate is even evaluated. There is no code path where parsing depends on HITL state.

For context on the original report, the two symptoms surfaced on the same `save_agent` call but are **separate** bugs:
1. the Cursor elicitation prompt not rendering / `-32001` timeout — a **HITL** issue (addressed separately). `ENABLE_HITL=false` was the reporter's workaround for *that*.
2. `Expected object, given string` — **this** bug, fixed here.

With this change, neither `ENABLE_HITL=false` nor hand-parsing `.json` file_args is needed — and turning HITL back on does not change file_args behavior.

**Known limitation (intentional):** params declared via `anyOf`/`oneOf` with no top-level `type` fall back to raw string. `save_agent.spec` uses `type: "object"`, so the reported case is covered.

## Testing

- `npm run typecheck`, `npm test` (168 passing), `npm run build` — all green. 8 new tests: object/array parsing, array-form `type`, string-param stays raw, no-schema backward compat, invalid-JSON error, `string | object` union fallback, and an end-to-end `handleRunTool` test forwarding a parsed object.
- Reproduced live on the released build (`read_document` array param via `file_args` → downstream rejected the string), then verified the fix on the real compiled bundle against a production tool-JSON fixture. The fixture test exercises the no-HITL path (no elicitation capability), and the hoist guarantees the same parse runs with HITL enabled.

All 3 host manifests aligned at 0.2.38.