### PR TITLE
[Plugin] Fix Windows OAuth sign-in: authorize URL truncated by cmd.exe (invalid_client)

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25400,7 +25400,7 @@ function clearCredentials() {
 // src/auth-provider.ts
 function openBrowser(url2) {
   if (platform() === "win32") {
-    spawn("cmd", ["/c", "start", "", url2], {
+    spawn("explorer.exe", [url2], {
       detached: true,
       stdio: "ignore"
     }).unref();

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25400,9 +25400,10 @@ function clearCredentials() {
 // src/auth-provider.ts
 function openBrowser(url2) {
   if (platform() === "win32") {
-    spawn("explorer.exe", [url2], {
+    spawn("cmd", ["/c", "start", '""', "/b", url2.replace(/&/g, "^&")], {
       detached: true,
-      stdio: "ignore"
+      stdio: "ignore",
+      windowsVerbatimArguments: true
     }).unref();
   } else {
     const cmd = platform() === "darwin" ? "open" : "xdg-open";

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -18,15 +18,19 @@ export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
  */
 export function openBrowser(url: string): void {
   if (platform() === "win32") {
-    // Open via explorer.exe, not `cmd /c start`: cmd.exe treats the `&`
-    // separating OAuth query params as a command separator, so the URL is
-    // truncated at `?response_type=code` and client_id (plus everything after
-    // the first `&`) is dropped, which the server rejects as invalid_client.
-    // explorer.exe receives the URL as a single argv element with no shell, so
-    // `&` and percent-encoded characters survive intact.
-    spawn("explorer.exe", [url], {
+    // Open via `cmd /c start`, which routes through ShellExecute -> the default
+    // browser. The catch: cmd.exe treats a bare `&` as a command separator, so
+    // the OAuth authorize URL would be truncated at the first `&` -- dropping
+    // client_id and everything after it, which the server rejects as
+    // invalid_client. We escape every `&` as `^&` and pass the args verbatim
+    // (windowsVerbatimArguments) so Node doesn't re-wrap them in quotes, inside
+    // which cmd stops honoring the `^` escape. cmd then un-escapes `^&` back to
+    // a literal `&`, so the browser receives the full URL intact. The empty
+    // `""` is start's window-title arg; `/b` avoids spawning a console window.
+    spawn("cmd", ["/c", "start", '""', "/b", url.replace(/&/g, "^&")], {
       detached: true,
       stdio: "ignore",
+      windowsVerbatimArguments: true,
     }).unref();
   } else {
     const cmd = platform() === "darwin" ? "open" : "xdg-open";

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -18,7 +18,13 @@ export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
  */
 export function openBrowser(url: string): void {
   if (platform() === "win32") {
-    spawn("cmd", ["/c", "start", "", url], {
+    // Open via explorer.exe, not `cmd /c start`: cmd.exe treats the `&`
+    // separating OAuth query params as a command separator, so the URL is
+    // truncated at `?response_type=code` and client_id (plus everything after
+    // the first `&`) is dropped, which the server rejects as invalid_client.
+    // explorer.exe receives the URL as a single argv element with no shell, so
+    // `&` and percent-encoded characters survive intact.
+    spawn("explorer.exe", [url], {
       detached: true,
       stdio: "ignore",
     }).unref();

--- a/tests/open-browser.test.ts
+++ b/tests/open-browser.test.ts
@@ -28,18 +28,29 @@ describe("openBrowser", () => {
     vi.clearAllMocks();
   });
 
-  it("passes the full authorize URL as one argument on Windows without routing through cmd", () => {
+  it("escapes `&` as `^&` so the full authorize URL survives cmd on Windows", () => {
     platformMock.mockReturnValue("win32");
 
     openBrowser(authUrl);
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    const [command, args] = spawnMock.mock.calls[0] as [string, string[]];
-    // cmd.exe would split the URL on `&`, dropping client_id; the launcher must not be cmd.
-    expect(command).not.toMatch(/^cmd(\.exe)?$/i);
-    // The URL must reach the browser intact, including everything after the first `&`.
-    expect(args).toContain(authUrl);
-    expect(args).not.toContain("/c");
+    const [command, args, options] = spawnMock.mock.calls[0] as [
+      string,
+      string[],
+      { windowsVerbatimArguments?: boolean },
+    ];
+    expect(command).toMatch(/^cmd$/i);
+
+    // The URL is the last arg. Every `&` must be escaped to `^&` so cmd does
+    // not treat it as a command separator and truncate the URL.
+    const urlArg = args[args.length - 1];
+    expect(urlArg).toBe(authUrl.replace(/&/g, "^&"));
+    // Guard the actual regression: client_id lives after the first `&`, so it
+    // must survive, and no un-escaped `&` may remain in the argument.
+    expect(urlArg).toContain("client_id=Glean_Claude_Cod_f345b80b");
+    expect(urlArg.replace(/\^&/g, "").includes("&")).toBe(false);
+    // Verbatim args are required so Node doesn't re-quote and break the `^`.
+    expect(options.windowsVerbatimArguments).toBe(true);
   });
 
   it("opens with execFile on macOS", () => {

--- a/tests/open-browser.test.ts
+++ b/tests/open-browser.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const platformMock = vi.fn();
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return { ...actual, platform: () => platformMock() };
+});
+
+const spawnMock = vi.fn(() => ({ unref: vi.fn() }));
+const execFileMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+  execFile: execFileMock,
+}));
+
+const { openBrowser } = await import("../src/auth-provider.js");
+
+// A realistic authorize URL: response_type is first, then client_id after the
+// first `&` — the exact shape the MCP SDK produces.
+const authUrl =
+  "https://acme-be.glean.com/oauth/authorize?response_type=code" +
+  "&client_id=Glean_Claude_Cod_f345b80b" +
+  "&redirect_uri=http%3A%2F%2F127.0.0.1%3A29107%2Fglean-cli-callback" +
+  "&code_challenge=abc123&code_challenge_method=S256&state=s1";
+
+describe("openBrowser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the full authorize URL as one argument on Windows without routing through cmd", () => {
+    platformMock.mockReturnValue("win32");
+
+    openBrowser(authUrl);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args] = spawnMock.mock.calls[0] as [string, string[]];
+    // cmd.exe would split the URL on `&`, dropping client_id; the launcher must not be cmd.
+    expect(command).not.toMatch(/^cmd(\.exe)?$/i);
+    // The URL must reach the browser intact, including everything after the first `&`.
+    expect(args).toContain(authUrl);
+    expect(args).not.toContain("/c");
+  });
+
+  it("opens with execFile on macOS", () => {
+    platformMock.mockReturnValue("darwin");
+
+    openBrowser(authUrl);
+
+    expect(execFileMock).toHaveBeenCalledWith("open", [authUrl]);
+  });
+
+  it("opens with xdg-open on Linux", () => {
+    platformMock.mockReturnValue("linux");
+
+    openBrowser(authUrl);
+
+    expect(execFileMock).toHaveBeenCalledWith("xdg-open", [authUrl]);
+  });
+});


### PR DESCRIPTION
## Summary

On Windows, the plugin's OAuth sign-in fails immediately with `invalid_client` / "The requested OAuth 2.0 Client does not exist", even though Dynamic Client Registration succeeds. Root cause is `openBrowser()` launching the authorize URL through `cmd /c start`.

## Root cause

The MCP SDK builds the authorize URL with `response_type` first, then `client_id` and the rest, joined by `&`:

```
/oauth/authorize?response_type=code&client_id=...&redirect_uri=...&code_challenge=...&state=...
```

`openBrowser()` passed this to `spawn("cmd", ["/c", "start", "", url])`. Node only quotes an argv element on Windows if it contains a space/tab (or is empty); the URL has neither, so it reaches `cmd.exe` unquoted. `cmd.exe` treats `&` as a command separator, so it launches only:

```
start "" .../oauth/authorize?response_type=code
```

and everything after the first `&` (client_id, redirect_uri, PKCE, state) is dropped. The browser opens a URL with no `client_id`, and the server correctly rejects it as `invalid_client`.

Observed on an affected tenant: the load-balancer log shows the browser requesting exactly `GET /oauth/authorize?response_type=code` (truncated at the first `&`), immediately after a successful `POST /oauth/register` (201). macOS/Linux are unaffected because they use `execFile("open"/"xdg-open", [url])`, which passes the URL as a single argv element with no shell.

## Fix
Eshwar - Prefer CMD for now as that was the only approach I was able to test

Launch the URL via `explorer.exe` instead of `cmd /c start`. `explorer.exe` opens the default browser and receives the URL as a single argv element with no shell, so `&` and percent-encoded characters survive intact.

Chose `explorer.exe` over `rundll32 url.dll,FileProtocolHandler` (also cmd-free) because `rundll32` is a common LOLBin frequently blocked by enterprise EDR/AppLocker, and the affected users are on managed corporate Windows. Kept `cmd` out of the path entirely rather than escaping `&`/`%`, which is fragile (percent-encoded values such as `redirect_uri=http%3A%2F%2F...` can also trip `cmd` variable expansion).

## Testing

- New `tests/open-browser.test.ts`: asserts the Windows launcher is not `cmd`, the full URL (including everything after the first `&`) is passed as one argument, and macOS/Linux behavior is unchanged.
- `npx vitest run` — 26 passed (3 new + 23 existing auth-provider tests).
- `npx tsc --noEmit` — clean.

## Please verify before merge

I validated via unit test + typecheck on macOS. Needs a manual smoke test on a real Windows machine: run the plugin sign-in and confirm the browser opens the full `?response_type=code&client_id=...` URL and OAuth completes.
