### PR TITLE
Cursor HITL: approval-form elicitation schema + pid-stamped gate telemetry

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25893,7 +25893,7 @@ function isCursorClient(mcpServer) {
 }
 async function buildApprovalMessage(mcpServer, toolName, args) {
   if (isCursorClient(mcpServer)) {
-    return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
+    return `Review the tool and arguments shown above, then choose Approve to run it or Deny to block it, and submit.`;
   }
   const { lines, needsFile } = buildCompactArgs(args);
   const message = [
@@ -25910,6 +25910,28 @@ async function buildApprovalMessage(mcpServer, toolName, args) {
     }
   }
   return message.join("\n");
+}
+function approvalRequestedSchema(isCursor) {
+  if (!isCursor) {
+    return { type: "object", properties: {} };
+  }
+  return {
+    type: "object",
+    properties: {
+      decision: {
+        type: "string",
+        title: "Approve this action?",
+        description: "Approve to run the tool, or Deny to block it.",
+        enum: ["Approve", "Deny"]
+      }
+    },
+    required: ["decision"]
+  };
+}
+function isApproved(isCursor, result) {
+  if (result.action !== "accept") return false;
+  if (!isCursor) return true;
+  return result.content?.decision === "Approve";
 }
 var elicitationIdPrimed = /* @__PURE__ */ new WeakSet();
 function primeElicitationCancellation(mcpServer) {
@@ -25971,21 +25993,22 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
         resolvedArgs
       );
       const timeout = hitlTimeoutMs();
+      const cursor = isCursorClient(mcpServer);
       primeElicitationCancellation(mcpServer);
       try {
         const result = await mcpServer.elicitInput(
           {
             message,
-            requestedSchema: { type: "object", properties: {} }
+            requestedSchema: approvalRequestedSchema(cursor)
           },
           { timeout }
         );
-        if (result.action !== "accept") {
+        if (!isApproved(cursor, result)) {
           return {
             content: [
               {
                 type: "text",
-                text: `Action ${toolName} was ${result.action === "decline" ? "declined" : "cancelled"} by the user.`
+                text: `Action ${toolName} was ${result.action === "cancel" ? "cancelled" : "declined"} by the user.`
               }
             ]
           };

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25671,6 +25671,7 @@ async function handleFindSkills(remoteClient, skillsBaseDir, args) {
 }
 
 // src/tools/run-tool.ts
+import { appendFileSync } from "node:fs";
 import fs4 from "node:fs/promises";
 import os2 from "node:os";
 import path4 from "node:path";
@@ -25933,6 +25934,16 @@ function isApproved(isCursor, result) {
   if (!isCursor) return true;
   return result.content?.decision === "Approve";
 }
+function hitlLog(label, detail) {
+  const base = process.env.PLUGIN_DATA_DIR || path4.join(os2.homedir(), ".glean");
+  const line = `${(/* @__PURE__ */ new Date()).toISOString()} ${label} ${JSON.stringify({ pid: process.pid, ...detail })}
+`;
+  try {
+    appendFileSync(path4.join(base, "glean-server.log"), line, { mode: 384 });
+  } catch {
+  }
+  console.error(line.trimEnd());
+}
 var elicitationIdPrimed = /* @__PURE__ */ new WeakSet();
 function primeElicitationCancellation(mcpServer) {
   if (elicitationIdPrimed.has(mcpServer)) return;
@@ -25984,6 +25995,13 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
     throw err;
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
+  hitlLog("hitl.gate", {
+    tool: toolName,
+    hitlEnabled,
+    requiresApproval: !!toolMeta?.requires_approval,
+    elicitationCap: mcpServer.getClientCapabilities()?.elicitation ?? null,
+    client: mcpServer.getClientVersion()?.name ?? null
+  });
   if (hitlEnabled && toolMeta?.requires_approval && mcpServer.getClientCapabilities()?.elicitation) {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
@@ -25995,6 +26013,11 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       const timeout = hitlTimeoutMs();
       const cursor = isCursorClient(mcpServer);
       primeElicitationCancellation(mcpServer);
+      hitlLog("hitl.elicit-sent", {
+        tool: toolName,
+        schema: cursor ? "cursor-form" : "empty",
+        timeout
+      });
       try {
         const result = await mcpServer.elicitInput(
           {
@@ -26003,6 +26026,11 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
           },
           { timeout }
         );
+        hitlLog("hitl.elicit-result", {
+          tool: toolName,
+          action: result.action,
+          decision: result.content?.decision ?? null
+        });
         if (!isApproved(cursor, result)) {
           return {
             content: [
@@ -26015,6 +26043,7 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
         }
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
+        hitlLog("hitl.elicit-error", { tool: toolName, msg: detail });
         return {
           content: [
             {

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -205,7 +205,7 @@ async function buildApprovalMessage(
   args: unknown,
 ): Promise<string> {
   if (isCursorClient(mcpServer)) {
-    return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
+    return `Review the tool and arguments shown above, then choose Approve to run it or Deny to block it, and submit.`;
   }
 
   const { lines, needsFile } = buildCompactArgs(args);
@@ -229,6 +229,51 @@ async function buildApprovalMessage(
     }
   }
   return message.join("\n");
+}
+
+// The elicitation schema for the approval prompt.
+//
+// Claude Code advertises bare `elicitation: {}` and renders the `message` text
+// with Accept/Decline buttons regardless of the schema, so an empty object is
+// enough there. Cursor advertises a FORM-based variant (`elicitation:
+// {form:{}}`) and builds the banner FROM the schema's `properties` — an empty
+// `properties` renders no fields, so Cursor shows no visible approval banner
+// and the gate is silently skipped. Cursor therefore gets one required
+// Approve/Deny field: it guarantees the form renders and forces an explicit
+// choice. Keep the non-Cursor path empty so Claude Code's working behavior is
+// untouched.
+export function approvalRequestedSchema(
+  isCursor: boolean,
+): Record<string, unknown> {
+  if (!isCursor) {
+    return { type: "object", properties: {} };
+  }
+  return {
+    type: "object",
+    properties: {
+      decision: {
+        type: "string",
+        title: "Approve this action?",
+        description: "Approve to run the tool, or Deny to block it.",
+        enum: ["Approve", "Deny"],
+      },
+    },
+    required: ["decision"],
+  };
+}
+
+// Whether an elicitation result approves the action. Non-Cursor clients gate
+// purely on the action (the Accept button). Cursor submits a form, so a
+// submitted "Deny" comes back as action "accept" with decision "Deny" — that is
+// a rejection, not an approval, so Cursor approval also requires decision
+// "Approve".
+export function isApproved(
+  isCursor: boolean,
+  result: { action: string; content?: Record<string, unknown> },
+): boolean {
+  if (result.action !== "accept") return false;
+  if (!isCursor) return true;
+  return result.content?.decision === "Approve";
 }
 
 // A WeakSet so a short-lived server in tests doesn't leak,
@@ -349,6 +394,7 @@ export async function handleRunTool(
         resolvedArgs,
       );
       const timeout = hitlTimeoutMs();
+      const cursor = isCursorClient(mcpServer);
 
       // Make a dummy empty request to burn JSON-RPC request id 0
       primeElicitationCancellation(mcpServer);
@@ -357,17 +403,17 @@ export async function handleRunTool(
         const result = await mcpServer.elicitInput(
           {
             message,
-            requestedSchema: { type: "object", properties: {} } as any,
+            requestedSchema: approvalRequestedSchema(cursor) as any,
           },
           { timeout },
         );
 
-        if (result.action !== "accept") {
+        if (!isApproved(cursor, result)) {
           return {
             content: [
               {
                 type: "text",
-                text: `Action ${toolName} was ${result.action === "decline" ? "declined" : "cancelled"} by the user.`,
+                text: `Action ${toolName} was ${result.action === "cancel" ? "cancelled" : "declined"} by the user.`,
               },
             ],
           };

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -2,6 +2,7 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { EmptyResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { appendFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -276,6 +277,24 @@ export function isApproved(
   return result.content?.decision === "Approve";
 }
 
+// Structural HITL telemetry appended to the shared server log. Mirrors
+// index.ts's logLine (private to that module) and additionally stamps the
+// pid: multiple plugin instances can share one log file (a marketplace
+// install next to a local checkout), and the pid ties each line to a
+// specific process. Logs tool names and gate decisions only — never
+// argument values, which can carry PII/secrets.
+function hitlLog(label: string, detail: Record<string, unknown>): void {
+  const base =
+    process.env.PLUGIN_DATA_DIR || path.join(os.homedir(), ".glean");
+  const line = `${new Date().toISOString()} ${label} ${JSON.stringify({ pid: process.pid, ...detail })}\n`;
+  try {
+    appendFileSync(path.join(base, "glean-server.log"), line, { mode: 0o600 });
+  } catch {
+    /* best-effort */
+  }
+  console.error(line.trimEnd());
+}
+
 // A WeakSet so a short-lived server in tests doesn't leak,
 // and so the burn happens exactly once per server instance.
 const elicitationIdPrimed = new WeakSet<object>();
@@ -374,6 +393,13 @@ export async function handleRunTool(
   }
 
   const hitlEnabled = process.env.ENABLE_HITL === "true";
+  hitlLog("hitl.gate", {
+    tool: toolName,
+    hitlEnabled,
+    requiresApproval: !!toolMeta?.requires_approval,
+    elicitationCap: mcpServer.getClientCapabilities()?.elicitation ?? null,
+    client: mcpServer.getClientVersion()?.name ?? null,
+  });
   if (
     hitlEnabled &&
     toolMeta?.requires_approval &&
@@ -399,6 +425,12 @@ export async function handleRunTool(
       // Make a dummy empty request to burn JSON-RPC request id 0
       primeElicitationCancellation(mcpServer);
 
+      hitlLog("hitl.elicit-sent", {
+        tool: toolName,
+        schema: cursor ? "cursor-form" : "empty",
+        timeout,
+      });
+
       try {
         const result = await mcpServer.elicitInput(
           {
@@ -407,6 +439,14 @@ export async function handleRunTool(
           },
           { timeout },
         );
+
+        hitlLog("hitl.elicit-result", {
+          tool: toolName,
+          action: result.action,
+          decision:
+            (result.content as Record<string, unknown> | undefined)
+              ?.decision ?? null,
+        });
 
         if (!isApproved(cursor, result)) {
           return {
@@ -423,6 +463,7 @@ export async function handleRunTool(
         // prompt times out or errors defeats its own purpose — and the SDK
         // rejects elicitInput precisely on request timeout.
         const detail = err instanceof Error ? err.message : String(err);
+        hitlLog("hitl.elicit-error", { tool: toolName, msg: detail });
         return {
           content: [
             {

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -8,6 +8,8 @@ import {
   FileArgsError,
   handleRunTool,
   runToolAnnotations,
+  approvalRequestedSchema,
+  isApproved,
 } from "../src/tools/run-tool.js";
 import {
   buildCompactArgs,
@@ -456,7 +458,9 @@ describe("handleRunTool (HITL)", () => {
   it("gives Cursor a one-line prompt without an arguments block", async () => {
     vi.stubEnv("ENABLE_HITL", "true");
     const remote = makeRemote();
-    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const elicit = vi
+      .fn()
+      .mockResolvedValue({ action: "accept", content: { decision: "Approve" } });
     const server = makeServer({
       elicitation: true,
       clientName: "cursor-vscode",
@@ -467,9 +471,68 @@ describe("handleRunTool (HITL)", () => {
     await handleRunTool(remote, server, tmpDir, baseArgs);
 
     const message = elicit.mock.calls[0][0].message as string;
-    expect(message).toContain("Submit to allow and Cancel to deny");
+    expect(message).toContain("Approve to run it or Deny to block it");
     expect(message).not.toContain("Arguments:");
     expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends Cursor a non-empty form schema so its banner renders", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi
+      .fn()
+      .mockResolvedValue({ action: "accept", content: { decision: "Approve" } });
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    const schema = elicit.mock.calls[0][0].requestedSchema;
+    expect(schema.properties.decision).toBeDefined();
+    expect(schema.properties.decision.enum).toEqual(["Approve", "Deny"]);
+    expect(schema.required).toContain("decision");
+  });
+
+  it("keeps an empty form schema for non-Cursor clients", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({
+      elicitation: true,
+      clientName: "claude-code",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    const schema = elicit.mock.calls[0][0].requestedSchema;
+    expect(schema.properties).toEqual({});
+    expect(schema.required).toBeUndefined();
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not execute when Cursor submits the form with Deny", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi
+      .fn()
+      .mockResolvedValue({ action: "accept", content: { decision: "Deny" } });
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect(remote.callTool).not.toHaveBeenCalled();
+    expect((result.content[0] as { text: string }).text).toContain("declined");
   });
 
   it("spills large arguments to a file and keeps the prompt short", async () => {
@@ -720,5 +783,41 @@ describe("runToolAnnotations", () => {
 
   it("leaves annotations unset when the client cannot elicit", () => {
     expect(runToolAnnotations(true, false)).toBeUndefined();
+  });
+});
+
+describe("approvalRequestedSchema", () => {
+  it("is empty for non-Cursor clients (message-only banner)", () => {
+    expect(approvalRequestedSchema(false)).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("carries a required Approve/Deny field for Cursor's form renderer", () => {
+    const schema = approvalRequestedSchema(true) as any;
+    expect(schema.properties.decision.enum).toEqual(["Approve", "Deny"]);
+    expect(schema.required).toEqual(["decision"]);
+  });
+});
+
+describe("isApproved", () => {
+  it("approves a non-Cursor accept regardless of content", () => {
+    expect(isApproved(false, { action: "accept" })).toBe(true);
+  });
+
+  it("rejects a non-Cursor decline or cancel", () => {
+    expect(isApproved(false, { action: "decline" })).toBe(false);
+    expect(isApproved(false, { action: "cancel" })).toBe(false);
+  });
+
+  it("approves a Cursor accept only when the form decision is Approve", () => {
+    expect(
+      isApproved(true, { action: "accept", content: { decision: "Approve" } }),
+    ).toBe(true);
+    expect(
+      isApproved(true, { action: "accept", content: { decision: "Deny" } }),
+    ).toBe(false);
+    expect(isApproved(true, { action: "accept" })).toBe(false);
   });
 });


### PR DESCRIPTION
## Status: hypothesis disproven by live test — kept for telemetry + forward-compat; root cause is a Cursor client bug

### Original hypothesis (disproven)
Cursor advertises form-based elicitation (`elicitation:{form:{}}`) and the HITL gate sent an empty `requestedSchema`, so we believed Cursor's form renderer had nothing to draw. This PR branches the schema: Cursor gets a required `decision` field (`enum: ["Approve","Deny"]`); other clients keep the empty schema (Claude Code behavior unchanged).

**Live testing on Cursor 3.10.20 disproved the hypothesis**: the banner still does not render with the non-empty form schema.

### Actual root cause (verified 2026-07-20)
Cursor 3.10.20 silently drops `elicitation/create` from stdio MCP servers:

- A minimal Glean-free probe server (one tool, flat single-enum-field `requestedSchema`, 120s timeout) negotiated `clientCaps.elicitation={"form":{}}` with `cursor-vscode/1.0.0` — and timed out with no UI, no JSON-RPC error response, and no client log line.
- Cursor's own bundle (`mcpProcessMain.js`) routes elicitations to the workbench via an internal `mcp.elicitationRequest` command; there are two silent-drop branches (missing `executeCommandBridge`, or `resolveCommandTarget` failure) that swallow the request without responding — matching the observed server-side hang until timeout.
- The workbench UI handler exists (`[MCPService] Received elicitation request`) but its log line never appears in any session log — the request dies before reaching it.
- Cancelling the chat run does return `action:"decline"` to the server, so the response plumbing works; only the UI surfacing is broken.

A Cursor bug report with the probe repro is the follow-up.

### What this PR still delivers
- **`hitl.gate` / `hitl.elicit-sent` / `hitl.elicit-result` / `hitl.elicit-error` telemetry** (pid-stamped, no argument values): before this, "gate never reached" was indistinguishable from "elicitation sent but not rendered" — this ambiguity cost the whole investigation. Worth keeping regardless.
- **Spec-correct Approve/Deny form schema for form-capable clients** plus `isApproved` handling (a submitted `Deny` = rejection): correct behavior the moment Cursor fixes rendering, harmless meanwhile (fail-closed timeout is unchanged).

### Open question for review (not implemented here)
Interim UX for Cursor: `runToolAnnotations` currently sets `readOnlyHint: true` under HITL to avoid a double prompt — but on Cursor this suppresses the **native** tool-approval prompt while the elicitation gate can never render, producing a guaranteed 5-minute silent hang and then a fail-closed error. Until Cursor fixes elicitation, consider not claiming read-only for Cursor clients (let Cursor's native approval gate the call) and skipping the plugin's elicitation gate for Cursor.

### Testing
- `npm run typecheck` clean; `npx vitest run` 196/196.
- Live Cursor 3.10.20 verification of the telemetry path (gate → elicit-sent → decline-on-cancel all observed in `~/.glean/glean-server.log`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)