### PR TITLE
Cursor HITL: use Cursor's native approval (drop readOnlyHint + skip our elicitation)

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26017,8 +26017,8 @@ function buildRemoteArgs(serverId, toolName, resolvedArgs) {
     arguments: resolvedArgs
   };
 }
-function runToolAnnotations(enableHitl, clientSupportsElicitation) {
-  return enableHitl && clientSupportsElicitation ? { readOnlyHint: true } : void 0;
+function runToolAnnotations(enableHitl, clientSupportsElicitation, isCursor) {
+  return enableHitl && clientSupportsElicitation && !isCursor ? { readOnlyHint: true } : void 0;
 }
 
 // src/url-config-store.ts
@@ -26434,7 +26434,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     ...RUN_TOOL_TOOL,
     annotations: runToolAnnotations(
       process.env.ENABLE_HITL === "true",
-      !!server.getClientCapabilities()?.elicitation
+      !!server.getClientCapabilities()?.elicitation,
+      isCursorClient(server)
     )
   };
   const staticTools = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25962,7 +25962,7 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
     throw err;
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
-  if (hitlEnabled && toolMeta?.requires_approval && mcpServer.getClientCapabilities()?.elicitation) {
+  if (hitlEnabled && toolMeta?.requires_approval && !isCursorClient(mcpServer) && mcpServer.getClientCapabilities()?.elicitation) {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
       const message = await buildApprovalMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,11 @@ import {
   closeCallbackServer,
 } from "./auth-callback-server.js";
 import { handleFindSkills } from "./tools/find-skills.js";
-import { handleRunTool, runToolAnnotations } from "./tools/run-tool.js";
+import {
+  handleRunTool,
+  isCursorClient,
+  runToolAnnotations,
+} from "./tools/run-tool.js";
 import { evictStaleSkills } from "./skill-writer.js";
 import {
   loadServerUrl,
@@ -281,6 +285,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     annotations: runToolAnnotations(
       process.env.ENABLE_HITL === "true",
       !!server.getClientCapabilities()?.elicitation,
+      isCursorClient(server),
     ),
   };
   const staticTools: Tool[] = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -190,7 +190,7 @@ async function findToolJson(
 // A stdio server's only client signal is clientInfo.name. Cursor reports
 // "cursor-vscode" and already renders the tool name + arguments in its own
 // expandable UI, so its approval prompt only needs a one-line review ask.
-function isCursorClient(mcpServer: Server): boolean {
+export function isCursorClient(mcpServer: Server): boolean {
   return (mcpServer.getClientVersion()?.name ?? "")
     .toLowerCase()
     .startsWith("cursor");
@@ -423,12 +423,24 @@ export function buildRemoteArgs(
  * the tool `readOnlyHint` to suppress the client's native run-tool confirmation
  * and avoid a double prompt. Without HITL there is no gate of our own, so we
  * leave annotations unset and let the client decide.
+ *
+ * TEMP (Cursor): Cursor 3.12.x only renders a server-initiated elicitation on
+ * its attended tool-call lane; a `run_tool` marked `readOnlyHint` lands on the
+ * auto-run lane where the HITL elicitation is silently dropped (5-minute hang,
+ * then fail-closed timeout) and no approval banner ever shows. Cursor also
+ * ignores the annotation for its own native prompt (it strips tool
+ * `annotations` on ingest), so the hint buys us nothing there anyway. Until the
+ * Cursor-side rendering is fixed, do NOT advertise `readOnlyHint` to Cursor so
+ * the call stays on the interactive lane and the banner renders. Claude Code is
+ * unaffected: it renders elicitation regardless of lane and the hint still
+ * correctly suppresses its native prompt.
  */
 export function runToolAnnotations(
   enableHitl: boolean,
   clientSupportsElicitation: boolean,
+  isCursor: boolean,
 ): Tool["annotations"] {
-  return enableHitl && clientSupportsElicitation
+  return enableHitl && clientSupportsElicitation && !isCursor
     ? { readOnlyHint: true }
     : undefined;
 }

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -329,9 +329,17 @@ export async function handleRunTool(
   }
 
   const hitlEnabled = process.env.ENABLE_HITL === "true";
+  // Cursor is gated by its OWN native run-tool approval, not our elicitation.
+  // We omit run_tool's readOnlyHint for Cursor (see runToolAnnotations), so
+  // Cursor prompts the user before it executes run_tool. Firing our elicitation
+  // on top would be a redundant second gate — and worse, Cursor 3.12.x silently
+  // drops server-initiated elicitations on the auto-run lane, hanging for the
+  // full HITL timeout. So skip our gate for Cursor and let its native prompt
+  // (already shown before this call) be the single approval.
   if (
     hitlEnabled &&
     toolMeta?.requires_approval &&
+    !isCursorClient(mcpServer) &&
     mcpServer.getClientCapabilities()?.elicitation
   ) {
     // In bypassPermissions mode (`claude --dangerously-skip-permissions`) the
@@ -424,16 +432,14 @@ export function buildRemoteArgs(
  * and avoid a double prompt. Without HITL there is no gate of our own, so we
  * leave annotations unset and let the client decide.
  *
- * TEMP (Cursor): Cursor 3.12.x only renders a server-initiated elicitation on
- * its attended tool-call lane; a `run_tool` marked `readOnlyHint` lands on the
- * auto-run lane where the HITL elicitation is silently dropped (5-minute hang,
- * then fail-closed timeout) and no approval banner ever shows. Cursor also
- * ignores the annotation for its own native prompt (it strips tool
- * `annotations` on ingest), so the hint buys us nothing there anyway. Until the
- * Cursor-side rendering is fixed, do NOT advertise `readOnlyHint` to Cursor so
- * the call stays on the interactive lane and the banner renders. Claude Code is
- * unaffected: it renders elicitation regardless of lane and the hint still
- * correctly suppresses its native prompt.
+ * TEMP (Cursor): Cursor 3.12.x silently drops the server-initiated elicitation
+ * for a `run_tool` marked `readOnlyHint` (it lands on the auto-run lane), so the
+ * approval banner never shows and the call hangs to the HITL timeout. For Cursor
+ * we therefore flip the whole strategy: do NOT advertise `readOnlyHint` (so
+ * Cursor shows its OWN native run-tool approval before executing), and skip our
+ * elicitation entirely (see handleRunTool) so Cursor's native prompt is the
+ * single gate. Claude Code is unaffected: it keeps `readOnlyHint` (its native
+ * prompt stays suppressed) and our elicitation remains its gate.
  */
 export function runToolAnnotations(
   enableHitl: boolean,

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -710,15 +710,21 @@ describe("formatArgumentsForFile", () => {
 });
 
 describe("runToolAnnotations", () => {
-  it("marks run_tool read-only when HITL gates an elicitation-capable client", () => {
-    expect(runToolAnnotations(true, true)).toEqual({ readOnlyHint: true });
+  it("marks run_tool read-only when HITL gates an elicitation-capable non-Cursor client", () => {
+    expect(runToolAnnotations(true, true, false)).toEqual({
+      readOnlyHint: true,
+    });
   });
 
   it("leaves annotations unset when HITL is disabled", () => {
-    expect(runToolAnnotations(false, true)).toBeUndefined();
+    expect(runToolAnnotations(false, true, false)).toBeUndefined();
   });
 
   it("leaves annotations unset when the client cannot elicit", () => {
-    expect(runToolAnnotations(true, false)).toBeUndefined();
+    expect(runToolAnnotations(true, false, false)).toBeUndefined();
+  });
+
+  it("does NOT advertise readOnlyHint to Cursor (its elicitation only renders on the attended lane)", () => {
+    expect(runToolAnnotations(true, true, true)).toBeUndefined();
   });
 });

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -340,6 +340,25 @@ describe("handleRunTool (HITL)", () => {
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
+  it("does NOT elicit for Cursor — its native prompt is the gate; executes directly", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn();
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    // Cursor: readOnlyHint is omitted (native prompt shows), so our elicitation
+    // is skipped and the tool runs directly.
+    expect(elicit).not.toHaveBeenCalled();
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
   it("prompts with action name + arguments and forwards on accept", async () => {
     vi.stubEnv("ENABLE_HITL", "true");
     const remote = makeRemote();
@@ -451,25 +470,6 @@ describe("handleRunTool (HITL)", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("not approved");
     expect(text).toContain("NOT executed");
-  });
-
-  it("gives Cursor a one-line prompt without an arguments block", async () => {
-    vi.stubEnv("ENABLE_HITL", "true");
-    const remote = makeRemote();
-    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
-    const server = makeServer({
-      elicitation: true,
-      clientName: "cursor-vscode",
-      elicit,
-    });
-    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
-
-    await handleRunTool(remote, server, tmpDir, baseArgs);
-
-    const message = elicit.mock.calls[0][0].message as string;
-    expect(message).toContain("Submit to allow and Cancel to deny");
-    expect(message).not.toContain("Arguments:");
-    expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
   it("spills large arguments to a file and keeps the prompt short", async () => {


### PR DESCRIPTION
## Fix the Cursor HITL approval flow

**Symptom:** In Cursor, `requires_approval` actions via `run_tool` hang ~5 minutes with no approval prompt, then fail closed. Works fine in Claude Code.

## The fix — for Cursor, use Cursor's own native HITL instead of ours

Two paired changes, Cursor-only.

1. **Don't advertise `readOnlyHint` to Cursor** (`runToolAnnotations` now takes the client identity). Without the hint, Cursor shows its **native run-tool approval** before executing `run_tool`.
2. **Skip our elicitation gate for Cursor** (`!isCursorClient` added to the HITL gate in `handleRunTool`). With Cursor's native prompt already gating the call, our elicitation would be a redundant second gate — and it's the one that hangs. So Cursor executes directly after its native approval.

Demo video

https://github.com/user-attachments/assets/1d099748-2053-4597-bf8d-f8b853b972d5



Net: **Cursor → single native approval prompt; Claude Code → keeps `readOnlyHint` + our elicitation as before.**

## Validation
- `npm run typecheck` clean; `npx vitest run` **189/189**, incl. new cases: Cursor gets no `readOnlyHint`, and Cursor skips elicitation + executes directly.
- Before/after demo (video): two local servers built from the same codebase differing only by this PR — `main` build hangs on a write action in Cursor; PR build shows Cursor's native approval and completes.

## Notes / follow-ups
- Temporary until the Cursor-side elicitation-rendering regression is fixed upstream (bug report to file; repro available).
- `buildApprovalMessage`'s Cursor-specific branch is now unreachable (elicitation never fires for Cursor) — harmless; can be cleaned up separately.
- Latent hardening (not in this PR): the gate checks `getClientCapabilities()?.elicitation` truthy, but the SDK's `elicitInput` needs `.elicitation.form`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)