### PR TITLE
[Plugin] Fix intermittent re-auth from cross-process refresh-token rotation

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.44",
+  "version": "0.2.48",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.44",
+  "version": "0.2.48",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.44",
+  "version": "0.2.48",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25216,7 +25216,7 @@ function buildTransport(serverUrl, opts, chatSessionId) {
   }
   return new StreamableHTTPClientTransport(parsedUrl, transportOpts);
 }
-async function createRemoteClient(serverUrl, opts, chatSessionId) {
+async function createRemoteClient(serverUrl, opts, chatSessionId, authRetry = false) {
   const authProvider = opts.authProvider;
   if (authProvider?.pendingAuthCode) {
     const transportForAuth = pendingTransport ?? buildTransport(serverUrl, opts, chatSessionId);
@@ -25244,13 +25244,23 @@ async function createRemoteClient(serverUrl, opts, chatSessionId) {
     { name: "glean", version: "1.0.0" },
     { capabilities: {} }
   );
+  const accessTokenAtConnect = authProvider?.tokens()?.access_token;
   const transport = buildTransport(serverUrl, opts, chatSessionId);
   try {
     await client.connect(transport);
   } catch (error2) {
-    if (error2 instanceof UnauthorizedError && authProvider?.authorizationUrl) {
-      pendingTransport = transport;
-      throw new AuthRequiredError(authProvider.authorizationUrl);
+    if (error2 instanceof UnauthorizedError && authProvider) {
+      const refreshedAccessToken = authProvider.tokens()?.access_token;
+      if (!authRetry && refreshedAccessToken && refreshedAccessToken !== accessTokenAtConnect) {
+        console.error(
+          "[auth] Auth failed but a newer token is on disk (sibling refresh) \u2014 retrying once"
+        );
+        return createRemoteClient(serverUrl, opts, chatSessionId, true);
+      }
+      if (authProvider.authorizationUrl) {
+        pendingTransport = transport;
+        throw new AuthRequiredError(authProvider.authorizationUrl);
+      }
     }
     throw error2;
   }
@@ -25371,6 +25381,13 @@ function loadCredentials() {
     return void 0;
   }
 }
+function credentialsMtimeMs() {
+  try {
+    return fs.statSync(credentialsFile()).mtimeMs;
+  } catch {
+    return void 0;
+  }
+}
 function saveCredentials(tokens, clientInfo) {
   try {
     const filePath = credentialsFile();
@@ -25419,6 +25436,10 @@ var GleanOAuthClientProvider = class {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   _authUrlPending = false;
+  // mtime (epoch ms) of the credentials file at the point our in-memory
+  // _tokens/_clientInfo snapshot was last taken from disk. Undefined until the
+  // first successful read. Used to detect sibling rewrites — see syncFromDisk.
+  _credentialsMtimeMs;
   authorizationUrl;
   /**
    * Optional hook invoked whenever the in-memory token state changes —
@@ -25431,6 +25452,39 @@ var GleanOAuthClientProvider = class {
     const stored = loadCredentials();
     if (stored) {
       this._tokens = stored.tokens;
+      this._clientInfo = stored.clientInfo;
+    }
+    this._credentialsMtimeMs = credentialsMtimeMs();
+  }
+  // Re-read the credentials file if it has changed on disk since we last read
+  // it. MCP servers are spawned per session, so several of our processes can be
+  // alive at once sharing one credentials file. When one process refreshes an
+  // (Ory-rotated, single-use) refresh token, it persists the new grant and
+  // silently invalidates the old refresh token that every other process still
+  // holds in memory. Without this, the next process to hit a 401 would refresh
+  // with its now-dead token, get invalid_grant, and force a full re-auth
+  // ([SETUP_REQUIRED]). Syncing here — right before the SDK reads tokens() at
+  // the start of its auth flow — lets us pick up the sibling's fresh grant
+  // instead. Guarded by mtime so the steady state is one stat(), not a re-parse.
+  //
+  // Conservative on removal: if the file is gone (undefined mtime) or has no
+  // tokens, we keep our in-memory snapshot rather than logging ourselves out —
+  // a transient stat failure or another process's explicit logout shouldn't
+  // drop a token that still works for us; a genuinely revoked token self-heals
+  // through the normal 401 path.
+  syncFromDisk() {
+    const mtimeMs = credentialsMtimeMs();
+    if (mtimeMs === void 0) return;
+    if (this._credentialsMtimeMs !== void 0 && mtimeMs <= this._credentialsMtimeMs) {
+      return;
+    }
+    const stored = loadCredentials();
+    this._credentialsMtimeMs = mtimeMs;
+    if (!stored) return;
+    if (stored.tokens) {
+      this._tokens = stored.tokens;
+    }
+    if (stored.clientInfo) {
       this._clientInfo = stored.clientInfo;
     }
   }
@@ -25449,14 +25503,17 @@ var GleanOAuthClientProvider = class {
   saveClientInformation(info) {
     this._clientInfo = info;
     saveCredentials(this._tokens, this._clientInfo);
+    this._credentialsMtimeMs = credentialsMtimeMs();
   }
   tokens() {
+    this.syncFromDisk();
     return this._tokens;
   }
   saveTokens(tokens) {
     this._tokens = tokens;
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
+    this._credentialsMtimeMs = credentialsMtimeMs();
     this.onTokensChanged?.(tokens);
   }
   async invalidateCredentials(scope) {

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25262,9 +25262,19 @@ async function createRemoteClient(serverUrl, opts, chatSessionId, authRetry = fa
         throw new AuthRequiredError(authProvider.authorizationUrl);
       }
     }
+    if (authProvider && !authRetry && isLikelyRefreshFailure(error2) && await authProvider.waitForSiblingRefresh(accessTokenAtConnect)) {
+      console.error(
+        "[auth] Refresh failed but a sibling refreshed \u2014 retrying with its token"
+      );
+      return createRemoteClient(serverUrl, opts, chatSessionId, true);
+    }
     throw error2;
   }
   return client;
+}
+function isLikelyRefreshFailure(error2) {
+  const msg = error2 instanceof Error ? error2.message : String(error2);
+  return /refresh|invalid_grant|invalid_request|oauth/i.test(msg);
 }
 async function callRemoteTool(client, name, args) {
   const result = await client.callTool({ name, arguments: args }, void 0, {
@@ -25395,11 +25405,12 @@ function saveCredentials(tokens, clientInfo) {
     fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
     fs.chmodSync(dir, DIR_MODE);
     const data = { tokens, clientInfo };
-    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+    const tmpPath = `${filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), {
       encoding: "utf-8",
       mode: FILE_MODE
     });
-    fs.chmodSync(filePath, FILE_MODE);
+    fs.renameSync(tmpPath, filePath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[auth] Failed to persist credentials: ${msg}`);
@@ -25415,6 +25426,19 @@ function clearCredentials() {
 }
 
 // src/auth-provider.ts
+var ROTATION_GRACE_MS_DEFAULT = 2e3;
+var ROTATION_POLL_MS = 100;
+function rotationGraceMs() {
+  const raw = process.env.GLEAN_ROTATION_GRACE_MS;
+  if (raw !== void 0) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return ROTATION_GRACE_MS_DEFAULT;
+}
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 function openBrowser(url2) {
   if (platform() === "win32") {
     spawn("cmd", ["/c", "start", '""', "/b", url2.replace(/&/g, "^&")], {
@@ -25502,6 +25526,37 @@ var GleanOAuthClientProvider = class {
     );
     return true;
   }
+  // The losing side of a refresh race often sees invalid_grant milliseconds
+  // BEFORE the winner's write lands on disk. Poll briefly for it instead of
+  // clearing right away — the clear writes {tokens: undefined} to the shared
+  // store, which would poison the winner's fresh grant for every session.
+  // Skipped when we held no refresh token: no refresh was possible, so
+  // there's no race to wait out.
+  async adoptNewerTokenWithGrace() {
+    if (this.adoptNewerTokenFromDisk()) return true;
+    if (!this._tokens?.refresh_token) return false;
+    const deadline = Date.now() + rotationGraceMs();
+    while (Date.now() < deadline) {
+      await sleep(ROTATION_POLL_MS);
+      if (this.adoptNewerTokenFromDisk()) return true;
+    }
+    return false;
+  }
+  // Grace-bounded wait for a sibling's refresh to land on disk. Covers the
+  // collision shapes the SDK does NOT route through invalidateCredentials —
+  // observed live: two concurrent refreshes of the same grant make fosite
+  // return invalid_request (not invalid_grant) to the loser, which surfaces
+  // as a raw connect error. Returns true once a token differing from
+  // `previousAccessToken` is available to retry with.
+  async waitForSiblingRefresh(previousAccessToken) {
+    const deadline = Date.now() + rotationGraceMs();
+    for (; ; ) {
+      const current = this.tokens()?.access_token;
+      if (current && current !== previousAccessToken) return true;
+      if (Date.now() >= deadline) return false;
+      await sleep(ROTATION_POLL_MS);
+    }
+  }
   get redirectUrl() {
     return getCallbackUrl();
   }
@@ -25546,7 +25601,7 @@ var GleanOAuthClientProvider = class {
         saveCredentials(this._tokens, void 0);
         break;
       case "tokens":
-        if (this.adoptNewerTokenFromDisk()) return;
+        if (await this.adoptNewerTokenWithGrace()) return;
         this._tokens = void 0;
         saveCredentials(void 0, this._clientInfo);
         break;

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25488,6 +25488,37 @@ var GleanOAuthClientProvider = class {
       this._clientInfo = stored.clientInfo;
     }
   }
+  // On a refresh failure the SDK calls invalidateCredentials("tokens"), which
+  // would clear our tokens AND overwrite the shared store with an empty set.
+  // But invalid_grant is exactly what a sibling's refresh-token rotation looks
+  // like: the sibling already minted a fresh grant and wrote it to disk, and we
+  // only failed because we refreshed with the now-revoked old token. In that
+  // case, blindly wiping would (a) force a needless re-auth and (b) poison the
+  // fresh token other sessions depend on. So: if disk holds a token newer than
+  // the one we just failed with, adopt it and return true — the caller keeps it
+  // on disk instead of clearing, and the SDK's post-invalidation retry refreshes
+  // with the fresh token and succeeds. Returns false when there's genuinely
+  // nothing newer to adopt (real invalidation → clear as normal).
+  adoptNewerTokenFromDisk() {
+    const diskMtime = credentialsMtimeMs();
+    if (diskMtime === void 0 || this._credentialsMtimeMs === void 0 || diskMtime <= this._credentialsMtimeMs) {
+      return false;
+    }
+    const stored = loadCredentials();
+    const diskTokens = stored?.tokens;
+    if (!diskTokens?.access_token || diskTokens.access_token === this._tokens?.access_token) {
+      return false;
+    }
+    this._tokens = diskTokens;
+    this._credentialsMtimeMs = diskMtime;
+    if (stored?.clientInfo) {
+      this._clientInfo = stored.clientInfo;
+    }
+    console.error(
+      "[auth] invalid_grant, but a newer token is on disk (sibling refresh) \u2014 adopting it instead of clearing"
+    );
+    return true;
+  }
   get redirectUrl() {
     return getCallbackUrl();
   }
@@ -25532,6 +25563,7 @@ var GleanOAuthClientProvider = class {
         saveCredentials(this._tokens, void 0);
         break;
       case "tokens":
+        if (this.adoptNewerTokenFromDisk()) return;
         this._tokens = void 0;
         saveCredentials(void 0, this._clientInfo);
         break;

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25404,6 +25404,7 @@ function saveCredentials(tokens, clientInfo) {
       encoding: "utf-8",
       mode: FILE_MODE
     });
+    fs.chmodSync(tmpPath, FILE_MODE);
     fs.renameSync(tmpPath, filePath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25460,8 +25460,7 @@ var GleanOAuthClientProvider = class {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   _authUrlPending = false;
-  // mtime of the creds file when we last read it — lets us spot a sibling
-  // process rewriting the shared store. See syncTokensFromDisk.
+  // mtime at last read; detects sibling rewrites of the shared store.
   _credentialsMtimeMs;
   authorizationUrl;
   /**
@@ -25479,12 +25478,8 @@ var GleanOAuthClientProvider = class {
     }
     this._credentialsMtimeMs = credentialsMtimeMs();
   }
-  // Per-session sibling processes share one creds file. When one refreshes, the
-  // rotated single-use refresh token it persists kills the copy every other
-  // process holds in memory. Re-read before the SDK reads tokens() so we use the
-  // sibling's fresh grant, not a dead token that would force re-auth. Stay
-  // conservative on a missing/token-less file — don't evict a token that still
-  // works for us.
+  // Re-read the shared store after a sibling process rewrites it, so we use
+  // the rotated grant instead of a stale in-memory copy.
   syncTokensFromDisk() {
     const mtimeMs = credentialsMtimeMs();
     if (mtimeMs === void 0) return;
@@ -25501,11 +25496,8 @@ var GleanOAuthClientProvider = class {
       this._clientInfo = stored.clientInfo;
     }
   }
-  // invalid_grant is what a sibling's rotation looks like: it already wrote a
-  // fresh grant to disk and we only failed because we used the revoked old
-  // token. Wiping would force a needless re-auth and poison the shared token
-  // other sessions depend on, so adopt a newer on-disk token instead. Returns
-  // false when nothing newer exists (a real invalidation → clear as normal).
+  // On invalid_grant, adopt a sibling's newer on-disk token instead of
+  // clearing. Returns false when nothing newer exists.
   adoptNewerTokenFromDisk() {
     const diskMtime = credentialsMtimeMs();
     if (diskMtime === void 0 || this._credentialsMtimeMs === void 0 || diskMtime <= this._credentialsMtimeMs) {
@@ -25526,12 +25518,8 @@ var GleanOAuthClientProvider = class {
     );
     return true;
   }
-  // The losing side of a refresh race often sees invalid_grant milliseconds
-  // BEFORE the winner's write lands on disk. Poll briefly for it instead of
-  // clearing right away — the clear writes {tokens: undefined} to the shared
-  // store, which would poison the winner's fresh grant for every session.
-  // Skipped when we held no refresh token: no refresh was possible, so
-  // there's no race to wait out.
+  // Poll briefly for the race winner's write before clearing. Skipped when
+  // no refresh token was held (no race possible).
   async adoptNewerTokenWithGrace() {
     if (this.adoptNewerTokenFromDisk()) return true;
     if (!this._tokens?.refresh_token) return false;
@@ -25542,12 +25530,8 @@ var GleanOAuthClientProvider = class {
     }
     return false;
   }
-  // Grace-bounded wait for a sibling's refresh to land on disk. Covers the
-  // collision shapes the SDK does NOT route through invalidateCredentials —
-  // observed live: two concurrent refreshes of the same grant make fosite
-  // return invalid_request (not invalid_grant) to the loser, which surfaces
-  // as a raw connect error. Returns true once a token differing from
-  // `previousAccessToken` is available to retry with.
+  // Grace-bounded wait for a sibling's refresh; covers failures the SDK does
+  // not route through invalidateCredentials (e.g. invalid_request collisions).
   async waitForSiblingRefresh(previousAccessToken) {
     const deadline = Date.now() + rotationGraceMs();
     for (; ; ) {

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25262,7 +25262,7 @@ async function createRemoteClient(serverUrl, opts, chatSessionId, authRetry = fa
         throw new AuthRequiredError(authProvider.authorizationUrl);
       }
     }
-    if (authProvider && !authRetry && isLikelyRefreshFailure(error2) && await authProvider.waitForSiblingRefresh(accessTokenAtConnect)) {
+    if (authProvider && !authRetry && isRefreshOAuthError(error2) && await authProvider.waitForSiblingRefresh(accessTokenAtConnect)) {
       console.error(
         "[auth] Refresh failed but a sibling refreshed \u2014 retrying with its token"
       );
@@ -25272,9 +25272,8 @@ async function createRemoteClient(serverUrl, opts, chatSessionId, authRetry = fa
   }
   return client;
 }
-function isLikelyRefreshFailure(error2) {
-  const msg = error2 instanceof Error ? error2.message : String(error2);
-  return /refresh|invalid_grant|invalid_request|oauth/i.test(msg);
+function isRefreshOAuthError(error2) {
+  return error2 instanceof OAuthError && (error2.errorCode === "invalid_request" || error2.errorCode === "invalid_grant");
 }
 async function callRemoteTool(client, name, args) {
   const result = await client.callTool({ name, arguments: args }, void 0, {

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25461,7 +25461,7 @@ var GleanOAuthClientProvider = class {
   // complete — likely because the server rejected the (stale) client_id.
   _authUrlPending = false;
   // mtime of the creds file when we last read it — lets us spot a sibling
-  // process rewriting the shared store. See syncFromDisk.
+  // process rewriting the shared store. See syncTokensFromDisk.
   _credentialsMtimeMs;
   authorizationUrl;
   /**
@@ -25485,7 +25485,7 @@ var GleanOAuthClientProvider = class {
   // sibling's fresh grant, not a dead token that would force re-auth. Stay
   // conservative on a missing/token-less file — don't evict a token that still
   // works for us.
-  syncFromDisk() {
+  syncTokensFromDisk() {
     const mtimeMs = credentialsMtimeMs();
     if (mtimeMs === void 0) return;
     if (this._credentialsMtimeMs !== void 0 && mtimeMs <= this._credentialsMtimeMs) {
@@ -25575,7 +25575,7 @@ var GleanOAuthClientProvider = class {
     this._credentialsMtimeMs = credentialsMtimeMs();
   }
   tokens() {
-    this.syncFromDisk();
+    this.syncTokensFromDisk();
     return this._tokens;
   }
   saveTokens(tokens) {

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25391,13 +25391,6 @@ function loadCredentials() {
     return void 0;
   }
 }
-function credentialsMtimeMs() {
-  try {
-    return fs.statSync(credentialsFile()).mtimeMs;
-  } catch {
-    return void 0;
-  }
-}
 function saveCredentials(tokens, clientInfo) {
   try {
     const filePath = credentialsFile();
@@ -25460,8 +25453,6 @@ var GleanOAuthClientProvider = class {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   _authUrlPending = false;
-  // mtime at last read; detects sibling rewrites of the shared store.
-  _credentialsMtimeMs;
   authorizationUrl;
   /**
    * Optional hook invoked whenever the in-memory token state changes —
@@ -25476,18 +25467,11 @@ var GleanOAuthClientProvider = class {
       this._tokens = stored.tokens;
       this._clientInfo = stored.clientInfo;
     }
-    this._credentialsMtimeMs = credentialsMtimeMs();
   }
-  // Re-read the shared store after a sibling process rewrites it, so we use
-  // the rotated grant instead of a stale in-memory copy.
+  // Re-read the shared store on every token access so a sibling's rotated
+  // grant is used instead of a stale in-memory copy.
   syncTokensFromDisk() {
-    const mtimeMs = credentialsMtimeMs();
-    if (mtimeMs === void 0) return;
-    if (this._credentialsMtimeMs !== void 0 && mtimeMs <= this._credentialsMtimeMs) {
-      return;
-    }
     const stored = loadCredentials();
-    this._credentialsMtimeMs = mtimeMs;
     if (!stored) return;
     if (stored.tokens) {
       this._tokens = stored.tokens;
@@ -25496,42 +25480,8 @@ var GleanOAuthClientProvider = class {
       this._clientInfo = stored.clientInfo;
     }
   }
-  // On invalid_grant, adopt a sibling's newer on-disk token instead of
-  // clearing. Returns false when nothing newer exists.
-  adoptNewerTokenFromDisk() {
-    const diskMtime = credentialsMtimeMs();
-    if (diskMtime === void 0 || this._credentialsMtimeMs === void 0 || diskMtime <= this._credentialsMtimeMs) {
-      return false;
-    }
-    const stored = loadCredentials();
-    const diskTokens = stored?.tokens;
-    if (!diskTokens?.access_token || diskTokens.access_token === this._tokens?.access_token) {
-      return false;
-    }
-    this._tokens = diskTokens;
-    this._credentialsMtimeMs = diskMtime;
-    if (stored?.clientInfo) {
-      this._clientInfo = stored.clientInfo;
-    }
-    console.error(
-      "[auth] invalid_grant, but a newer token is on disk (sibling refresh) \u2014 adopting it instead of clearing"
-    );
-    return true;
-  }
-  // Poll briefly for the race winner's write before clearing. Skipped when
-  // no refresh token was held (no race possible).
-  async adoptNewerTokenWithGrace() {
-    if (this.adoptNewerTokenFromDisk()) return true;
-    if (!this._tokens?.refresh_token) return false;
-    const deadline = Date.now() + rotationGraceMs();
-    while (Date.now() < deadline) {
-      await sleep(ROTATION_POLL_MS);
-      if (this.adoptNewerTokenFromDisk()) return true;
-    }
-    return false;
-  }
-  // Grace-bounded wait for a sibling's refresh; covers failures the SDK does
-  // not route through invalidateCredentials (e.g. invalid_request collisions).
+  // Wait for a sibling's refresh to land on disk. Returns true once a
+  // different access token is available for adoption/retry.
   async waitForSiblingRefresh(previousAccessToken) {
     const deadline = Date.now() + rotationGraceMs();
     for (; ; ) {
@@ -25556,7 +25506,6 @@ var GleanOAuthClientProvider = class {
   saveClientInformation(info) {
     this._clientInfo = info;
     saveCredentials(this._tokens, this._clientInfo);
-    this._credentialsMtimeMs = credentialsMtimeMs();
   }
   tokens() {
     this.syncTokensFromDisk();
@@ -25566,7 +25515,6 @@ var GleanOAuthClientProvider = class {
     this._tokens = tokens;
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
-    this._credentialsMtimeMs = credentialsMtimeMs();
     this.onTokensChanged?.(tokens);
   }
   async invalidateCredentials(scope) {
@@ -25584,11 +25532,15 @@ var GleanOAuthClientProvider = class {
         this._clientInfo = void 0;
         saveCredentials(this._tokens, void 0);
         break;
-      case "tokens":
-        if (await this.adoptNewerTokenWithGrace()) return;
+      case "tokens": {
+        const previousAccessToken = this._tokens?.access_token;
+        if (this._tokens?.refresh_token && await this.waitForSiblingRefresh(previousAccessToken)) {
+          return;
+        }
         this._tokens = void 0;
         saveCredentials(void 0, this._clientInfo);
         break;
+      }
       case "verifier":
         this._codeVerifier = "";
         break;

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25288,6 +25288,7 @@ async function callRemoteTool(client, name, args) {
 
 // src/auth-provider.ts
 import { execFile, spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
 import { platform } from "node:os";
 
 // src/auth-callback-server.ts
@@ -25419,19 +25420,8 @@ function clearCredentials() {
 }
 
 // src/auth-provider.ts
-var ROTATION_GRACE_MS_DEFAULT = 2e3;
+var ROTATION_GRACE_MS = 2e3;
 var ROTATION_POLL_MS = 100;
-function rotationGraceMs() {
-  const raw = process.env.GLEAN_ROTATION_GRACE_MS;
-  if (raw !== void 0) {
-    const parsed = Number.parseInt(raw, 10);
-    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
-  }
-  return ROTATION_GRACE_MS_DEFAULT;
-}
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 function openBrowser(url2) {
   if (platform() === "win32") {
     spawn("cmd", ["/c", "start", '""', "/b", url2.replace(/&/g, "^&")], {
@@ -25483,7 +25473,7 @@ var GleanOAuthClientProvider = class {
   // Wait for a sibling's refresh to land on disk. Returns true once a
   // different access token is available for adoption/retry.
   async waitForSiblingRefresh(previousAccessToken) {
-    const deadline = Date.now() + rotationGraceMs();
+    const deadline = Date.now() + ROTATION_GRACE_MS;
     for (; ; ) {
       const current = this.tokens()?.access_token;
       if (current && current !== previousAccessToken) return true;

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25436,9 +25436,8 @@ var GleanOAuthClientProvider = class {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   _authUrlPending = false;
-  // mtime (epoch ms) of the credentials file at the point our in-memory
-  // _tokens/_clientInfo snapshot was last taken from disk. Undefined until the
-  // first successful read. Used to detect sibling rewrites — see syncFromDisk.
+  // mtime of the creds file when we last read it — lets us spot a sibling
+  // process rewriting the shared store. See syncFromDisk.
   _credentialsMtimeMs;
   authorizationUrl;
   /**
@@ -25456,22 +25455,12 @@ var GleanOAuthClientProvider = class {
     }
     this._credentialsMtimeMs = credentialsMtimeMs();
   }
-  // Re-read the credentials file if it has changed on disk since we last read
-  // it. MCP servers are spawned per session, so several of our processes can be
-  // alive at once sharing one credentials file. When one process refreshes an
-  // (Ory-rotated, single-use) refresh token, it persists the new grant and
-  // silently invalidates the old refresh token that every other process still
-  // holds in memory. Without this, the next process to hit a 401 would refresh
-  // with its now-dead token, get invalid_grant, and force a full re-auth
-  // ([SETUP_REQUIRED]). Syncing here — right before the SDK reads tokens() at
-  // the start of its auth flow — lets us pick up the sibling's fresh grant
-  // instead. Guarded by mtime so the steady state is one stat(), not a re-parse.
-  //
-  // Conservative on removal: if the file is gone (undefined mtime) or has no
-  // tokens, we keep our in-memory snapshot rather than logging ourselves out —
-  // a transient stat failure or another process's explicit logout shouldn't
-  // drop a token that still works for us; a genuinely revoked token self-heals
-  // through the normal 401 path.
+  // Per-session sibling processes share one creds file. When one refreshes, the
+  // rotated single-use refresh token it persists kills the copy every other
+  // process holds in memory. Re-read before the SDK reads tokens() so we use the
+  // sibling's fresh grant, not a dead token that would force re-auth. Stay
+  // conservative on a missing/token-less file — don't evict a token that still
+  // works for us.
   syncFromDisk() {
     const mtimeMs = credentialsMtimeMs();
     if (mtimeMs === void 0) return;
@@ -25488,17 +25477,11 @@ var GleanOAuthClientProvider = class {
       this._clientInfo = stored.clientInfo;
     }
   }
-  // On a refresh failure the SDK calls invalidateCredentials("tokens"), which
-  // would clear our tokens AND overwrite the shared store with an empty set.
-  // But invalid_grant is exactly what a sibling's refresh-token rotation looks
-  // like: the sibling already minted a fresh grant and wrote it to disk, and we
-  // only failed because we refreshed with the now-revoked old token. In that
-  // case, blindly wiping would (a) force a needless re-auth and (b) poison the
-  // fresh token other sessions depend on. So: if disk holds a token newer than
-  // the one we just failed with, adopt it and return true — the caller keeps it
-  // on disk instead of clearing, and the SDK's post-invalidation retry refreshes
-  // with the fresh token and succeeds. Returns false when there's genuinely
-  // nothing newer to adopt (real invalidation → clear as normal).
+  // invalid_grant is what a sibling's rotation looks like: it already wrote a
+  // fresh grant to disk and we only failed because we used the revoked old
+  // token. Wiping would force a needless re-auth and poison the shared token
+  // other sessions depend on, so adopt a newer on-disk token instead. Returns
+  // false when nothing newer exists (a real invalidation → clear as normal).
   adoptNewerTokenFromDisk() {
     const diskMtime = credentialsMtimeMs();
     if (diskMtime === void 0 || this._credentialsMtimeMs === void 0 || diskMtime <= this._credentialsMtimeMs) {

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -7,7 +7,12 @@ import type {
 import { execFile, spawn } from "node:child_process";
 import { platform } from "node:os";
 import { getCallbackUrl, setExpectedState } from "./auth-callback-server.js";
-import { clearCredentials, loadCredentials, saveCredentials } from "./token-store.js";
+import {
+  clearCredentials,
+  credentialsMtimeMs,
+  loadCredentials,
+  saveCredentials,
+} from "./token-store.js";
 
 export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
 
@@ -47,6 +52,10 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   private _authUrlPending = false;
+  // mtime (epoch ms) of the credentials file at the point our in-memory
+  // _tokens/_clientInfo snapshot was last taken from disk. Undefined until the
+  // first successful read. Used to detect sibling rewrites — see syncFromDisk.
+  private _credentialsMtimeMs: number | undefined;
 
   authorizationUrl: string | undefined;
 
@@ -63,6 +72,43 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     if (stored) {
       this._tokens = stored.tokens as OAuthTokens | undefined;
       this._clientInfo = stored.clientInfo as OAuthClientInformationMixed | undefined;
+    }
+    this._credentialsMtimeMs = credentialsMtimeMs();
+  }
+
+  // Re-read the credentials file if it has changed on disk since we last read
+  // it. MCP servers are spawned per session, so several of our processes can be
+  // alive at once sharing one credentials file. When one process refreshes an
+  // (Ory-rotated, single-use) refresh token, it persists the new grant and
+  // silently invalidates the old refresh token that every other process still
+  // holds in memory. Without this, the next process to hit a 401 would refresh
+  // with its now-dead token, get invalid_grant, and force a full re-auth
+  // ([SETUP_REQUIRED]). Syncing here — right before the SDK reads tokens() at
+  // the start of its auth flow — lets us pick up the sibling's fresh grant
+  // instead. Guarded by mtime so the steady state is one stat(), not a re-parse.
+  //
+  // Conservative on removal: if the file is gone (undefined mtime) or has no
+  // tokens, we keep our in-memory snapshot rather than logging ourselves out —
+  // a transient stat failure or another process's explicit logout shouldn't
+  // drop a token that still works for us; a genuinely revoked token self-heals
+  // through the normal 401 path.
+  private syncFromDisk(): void {
+    const mtimeMs = credentialsMtimeMs();
+    if (mtimeMs === undefined) return;
+    if (
+      this._credentialsMtimeMs !== undefined &&
+      mtimeMs <= this._credentialsMtimeMs
+    ) {
+      return;
+    }
+    const stored = loadCredentials();
+    this._credentialsMtimeMs = mtimeMs;
+    if (!stored) return;
+    if (stored.tokens) {
+      this._tokens = stored.tokens as OAuthTokens;
+    }
+    if (stored.clientInfo) {
+      this._clientInfo = stored.clientInfo as OAuthClientInformationMixed;
     }
   }
 
@@ -84,9 +130,11 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   saveClientInformation(info: OAuthClientInformationMixed): void {
     this._clientInfo = info;
     saveCredentials(this._tokens, this._clientInfo);
+    this._credentialsMtimeMs = credentialsMtimeMs();
   }
 
   tokens(): OAuthTokens | undefined {
+    this.syncFromDisk();
     return this._tokens;
   }
 
@@ -94,6 +142,9 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     this._tokens = tokens;
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
+    // Record the mtime of the file we just wrote so our own write doesn't look
+    // like a sibling change on the next syncFromDisk.
+    this._credentialsMtimeMs = credentialsMtimeMs();
     this.onTokensChanged?.(tokens);
   }
 

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -5,6 +5,7 @@ import type {
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { execFile, spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
 import { platform } from "node:os";
 import { getCallbackUrl, setExpectedState } from "./auth-callback-server.js";
 import {
@@ -16,21 +17,8 @@ import {
 export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
 
 // Grace window for a sibling's in-flight refresh to land on disk.
-const ROTATION_GRACE_MS_DEFAULT = 2000;
+const ROTATION_GRACE_MS = 2000;
 const ROTATION_POLL_MS = 100;
-
-function rotationGraceMs(): number {
-  const raw = process.env.GLEAN_ROTATION_GRACE_MS;
-  if (raw !== undefined) {
-    const parsed = Number.parseInt(raw, 10);
-    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
-  }
-  return ROTATION_GRACE_MS_DEFAULT;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * Open `url` in the user's default browser. Used for the self-open sign-in
@@ -104,7 +92,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   async waitForSiblingRefresh(
     previousAccessToken: string | undefined,
   ): Promise<boolean> {
-    const deadline = Date.now() + rotationGraceMs();
+    const deadline = Date.now() + ROTATION_GRACE_MS;
     for (;;) {
       const current = this.tokens()?.access_token;
       if (current && current !== previousAccessToken) return true;

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -52,9 +52,8 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   private _authUrlPending = false;
-  // mtime (epoch ms) of the credentials file at the point our in-memory
-  // _tokens/_clientInfo snapshot was last taken from disk. Undefined until the
-  // first successful read. Used to detect sibling rewrites — see syncFromDisk.
+  // mtime of the creds file when we last read it — lets us spot a sibling
+  // process rewriting the shared store. See syncFromDisk.
   private _credentialsMtimeMs: number | undefined;
 
   authorizationUrl: string | undefined;
@@ -76,22 +75,12 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     this._credentialsMtimeMs = credentialsMtimeMs();
   }
 
-  // Re-read the credentials file if it has changed on disk since we last read
-  // it. MCP servers are spawned per session, so several of our processes can be
-  // alive at once sharing one credentials file. When one process refreshes an
-  // (Ory-rotated, single-use) refresh token, it persists the new grant and
-  // silently invalidates the old refresh token that every other process still
-  // holds in memory. Without this, the next process to hit a 401 would refresh
-  // with its now-dead token, get invalid_grant, and force a full re-auth
-  // ([SETUP_REQUIRED]). Syncing here — right before the SDK reads tokens() at
-  // the start of its auth flow — lets us pick up the sibling's fresh grant
-  // instead. Guarded by mtime so the steady state is one stat(), not a re-parse.
-  //
-  // Conservative on removal: if the file is gone (undefined mtime) or has no
-  // tokens, we keep our in-memory snapshot rather than logging ourselves out —
-  // a transient stat failure or another process's explicit logout shouldn't
-  // drop a token that still works for us; a genuinely revoked token self-heals
-  // through the normal 401 path.
+  // Per-session sibling processes share one creds file. When one refreshes, the
+  // rotated single-use refresh token it persists kills the copy every other
+  // process holds in memory. Re-read before the SDK reads tokens() so we use the
+  // sibling's fresh grant, not a dead token that would force re-auth. Stay
+  // conservative on a missing/token-less file — don't evict a token that still
+  // works for us.
   private syncFromDisk(): void {
     const mtimeMs = credentialsMtimeMs();
     if (mtimeMs === undefined) return;
@@ -112,17 +101,11 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  // On a refresh failure the SDK calls invalidateCredentials("tokens"), which
-  // would clear our tokens AND overwrite the shared store with an empty set.
-  // But invalid_grant is exactly what a sibling's refresh-token rotation looks
-  // like: the sibling already minted a fresh grant and wrote it to disk, and we
-  // only failed because we refreshed with the now-revoked old token. In that
-  // case, blindly wiping would (a) force a needless re-auth and (b) poison the
-  // fresh token other sessions depend on. So: if disk holds a token newer than
-  // the one we just failed with, adopt it and return true — the caller keeps it
-  // on disk instead of clearing, and the SDK's post-invalidation retry refreshes
-  // with the fresh token and succeeds. Returns false when there's genuinely
-  // nothing newer to adopt (real invalidation → clear as normal).
+  // invalid_grant is what a sibling's rotation looks like: it already wrote a
+  // fresh grant to disk and we only failed because we used the revoked old
+  // token. Wiping would force a needless re-auth and poison the shared token
+  // other sessions depend on, so adopt a newer on-disk token instead. Returns
+  // false when nothing newer exists (a real invalidation → clear as normal).
   private adoptNewerTokenFromDisk(): boolean {
     const diskMtime = credentialsMtimeMs();
     if (
@@ -204,8 +187,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
         saveCredentials(this._tokens, undefined);
         break;
       case "tokens":
-        // A refresh failure is usually a sibling's rotation, not a dead session
-        // — adopt any newer on-disk token instead of wiping the shared store.
+        // Usually a sibling's rotation, not a dead session — see helper.
         if (this.adoptNewerTokenFromDisk()) return;
         this._tokens = undefined;
         saveCredentials(undefined, this._clientInfo);

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -73,7 +73,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   // complete — likely because the server rejected the (stale) client_id.
   private _authUrlPending = false;
   // mtime of the creds file when we last read it — lets us spot a sibling
-  // process rewriting the shared store. See syncFromDisk.
+  // process rewriting the shared store. See syncTokensFromDisk.
   private _credentialsMtimeMs: number | undefined;
 
   authorizationUrl: string | undefined;
@@ -101,7 +101,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   // sibling's fresh grant, not a dead token that would force re-auth. Stay
   // conservative on a missing/token-less file — don't evict a token that still
   // works for us.
-  private syncFromDisk(): void {
+  private syncTokensFromDisk(): void {
     const mtimeMs = credentialsMtimeMs();
     if (mtimeMs === undefined) return;
     if (
@@ -212,7 +212,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   }
 
   tokens(): OAuthTokens | undefined {
-    this.syncFromDisk();
+    this.syncTokensFromDisk();
     return this._tokens;
   }
 
@@ -221,7 +221,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
     // Record the mtime of the file we just wrote so our own write doesn't look
-    // like a sibling change on the next syncFromDisk.
+    // like a sibling change on the next syncTokensFromDisk.
     this._credentialsMtimeMs = credentialsMtimeMs();
     this.onTokensChanged?.(tokens);
   }

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -16,6 +16,26 @@ import {
 
 export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
 
+// How long to wait for a sibling's in-flight refresh to land on disk before
+// treating invalid_grant as a real invalidation. The losing side of a
+// rotation race usually sees invalid_grant milliseconds before the winner's
+// write arrives; clearing immediately would poison the shared store.
+const ROTATION_GRACE_MS_DEFAULT = 2000;
+const ROTATION_POLL_MS = 100;
+
+function rotationGraceMs(): number {
+  const raw = process.env.GLEAN_ROTATION_GRACE_MS;
+  if (raw !== undefined) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return ROTATION_GRACE_MS_DEFAULT;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Open `url` in the user's default browser. Used for the self-open sign-in
  * path when the client does not support URL-mode elicitation (where the client
@@ -135,6 +155,41 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     return true;
   }
 
+  // The losing side of a refresh race often sees invalid_grant milliseconds
+  // BEFORE the winner's write lands on disk. Poll briefly for it instead of
+  // clearing right away — the clear writes {tokens: undefined} to the shared
+  // store, which would poison the winner's fresh grant for every session.
+  // Skipped when we held no refresh token: no refresh was possible, so
+  // there's no race to wait out.
+  private async adoptNewerTokenWithGrace(): Promise<boolean> {
+    if (this.adoptNewerTokenFromDisk()) return true;
+    if (!this._tokens?.refresh_token) return false;
+    const deadline = Date.now() + rotationGraceMs();
+    while (Date.now() < deadline) {
+      await sleep(ROTATION_POLL_MS);
+      if (this.adoptNewerTokenFromDisk()) return true;
+    }
+    return false;
+  }
+
+  // Grace-bounded wait for a sibling's refresh to land on disk. Covers the
+  // collision shapes the SDK does NOT route through invalidateCredentials —
+  // observed live: two concurrent refreshes of the same grant make fosite
+  // return invalid_request (not invalid_grant) to the loser, which surfaces
+  // as a raw connect error. Returns true once a token differing from
+  // `previousAccessToken` is available to retry with.
+  async waitForSiblingRefresh(
+    previousAccessToken: string | undefined,
+  ): Promise<boolean> {
+    const deadline = Date.now() + rotationGraceMs();
+    for (;;) {
+      const current = this.tokens()?.access_token;
+      if (current && current !== previousAccessToken) return true;
+      if (Date.now() >= deadline) return false;
+      await sleep(ROTATION_POLL_MS);
+    }
+  }
+
   get redirectUrl(): string {
     return getCallbackUrl();
   }
@@ -187,8 +242,10 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
         saveCredentials(this._tokens, undefined);
         break;
       case "tokens":
-        // Usually a sibling's rotation, not a dead session — see helper.
-        if (this.adoptNewerTokenFromDisk()) return;
+        // Usually a sibling's rotation, not a dead session — see helpers.
+        // Waits out an in-flight sibling refresh before the destructive
+        // clear.
+        if (await this.adoptNewerTokenWithGrace()) return;
         this._tokens = undefined;
         saveCredentials(undefined, this._clientInfo);
         break;

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -16,10 +16,7 @@ import {
 
 export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
 
-// How long to wait for a sibling's in-flight refresh to land on disk before
-// treating invalid_grant as a real invalidation. The losing side of a
-// rotation race usually sees invalid_grant milliseconds before the winner's
-// write arrives; clearing immediately would poison the shared store.
+// Grace window for a sibling's in-flight refresh to land on disk.
 const ROTATION_GRACE_MS_DEFAULT = 2000;
 const ROTATION_POLL_MS = 100;
 
@@ -72,8 +69,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   private _authUrlPending = false;
-  // mtime of the creds file when we last read it — lets us spot a sibling
-  // process rewriting the shared store. See syncTokensFromDisk.
+  // mtime at last read; detects sibling rewrites of the shared store.
   private _credentialsMtimeMs: number | undefined;
 
   authorizationUrl: string | undefined;
@@ -95,12 +91,8 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     this._credentialsMtimeMs = credentialsMtimeMs();
   }
 
-  // Per-session sibling processes share one creds file. When one refreshes, the
-  // rotated single-use refresh token it persists kills the copy every other
-  // process holds in memory. Re-read before the SDK reads tokens() so we use the
-  // sibling's fresh grant, not a dead token that would force re-auth. Stay
-  // conservative on a missing/token-less file — don't evict a token that still
-  // works for us.
+  // Re-read the shared store after a sibling process rewrites it, so we use
+  // the rotated grant instead of a stale in-memory copy.
   private syncTokensFromDisk(): void {
     const mtimeMs = credentialsMtimeMs();
     if (mtimeMs === undefined) return;
@@ -121,11 +113,8 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  // invalid_grant is what a sibling's rotation looks like: it already wrote a
-  // fresh grant to disk and we only failed because we used the revoked old
-  // token. Wiping would force a needless re-auth and poison the shared token
-  // other sessions depend on, so adopt a newer on-disk token instead. Returns
-  // false when nothing newer exists (a real invalidation → clear as normal).
+  // On invalid_grant, adopt a sibling's newer on-disk token instead of
+  // clearing. Returns false when nothing newer exists.
   private adoptNewerTokenFromDisk(): boolean {
     const diskMtime = credentialsMtimeMs();
     if (
@@ -155,12 +144,8 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     return true;
   }
 
-  // The losing side of a refresh race often sees invalid_grant milliseconds
-  // BEFORE the winner's write lands on disk. Poll briefly for it instead of
-  // clearing right away — the clear writes {tokens: undefined} to the shared
-  // store, which would poison the winner's fresh grant for every session.
-  // Skipped when we held no refresh token: no refresh was possible, so
-  // there's no race to wait out.
+  // Poll briefly for the race winner's write before clearing. Skipped when
+  // no refresh token was held (no race possible).
   private async adoptNewerTokenWithGrace(): Promise<boolean> {
     if (this.adoptNewerTokenFromDisk()) return true;
     if (!this._tokens?.refresh_token) return false;
@@ -172,12 +157,8 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     return false;
   }
 
-  // Grace-bounded wait for a sibling's refresh to land on disk. Covers the
-  // collision shapes the SDK does NOT route through invalidateCredentials —
-  // observed live: two concurrent refreshes of the same grant make fosite
-  // return invalid_request (not invalid_grant) to the loser, which surfaces
-  // as a raw connect error. Returns true once a token differing from
-  // `previousAccessToken` is available to retry with.
+  // Grace-bounded wait for a sibling's refresh; covers failures the SDK does
+  // not route through invalidateCredentials (e.g. invalid_request collisions).
   async waitForSiblingRefresh(
     previousAccessToken: string | undefined,
   ): Promise<boolean> {
@@ -220,8 +201,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     this._tokens = tokens;
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
-    // Record the mtime of the file we just wrote so our own write doesn't look
-    // like a sibling change on the next syncTokensFromDisk.
+    // Own write must not look like a sibling change.
     this._credentialsMtimeMs = credentialsMtimeMs();
     this.onTokensChanged?.(tokens);
   }
@@ -242,9 +222,7 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
         saveCredentials(this._tokens, undefined);
         break;
       case "tokens":
-        // Usually a sibling's rotation, not a dead session — see helpers.
-        // Waits out an in-flight sibling refresh before the destructive
-        // clear.
+        // Usually a sibling's rotation — try adopting before clearing.
         if (await this.adoptNewerTokenWithGrace()) return;
         this._tokens = undefined;
         saveCredentials(undefined, this._clientInfo);

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -9,7 +9,6 @@ import { platform } from "node:os";
 import { getCallbackUrl, setExpectedState } from "./auth-callback-server.js";
 import {
   clearCredentials,
-  credentialsMtimeMs,
   loadCredentials,
   saveCredentials,
 } from "./token-store.js";
@@ -69,9 +68,6 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   // explicitly invalidating. Used to detect when a previous auth URL didn't
   // complete — likely because the server rejected the (stale) client_id.
   private _authUrlPending = false;
-  // mtime at last read; detects sibling rewrites of the shared store.
-  private _credentialsMtimeMs: number | undefined;
-
   authorizationUrl: string | undefined;
 
   /**
@@ -88,22 +84,12 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
       this._tokens = stored.tokens as OAuthTokens | undefined;
       this._clientInfo = stored.clientInfo as OAuthClientInformationMixed | undefined;
     }
-    this._credentialsMtimeMs = credentialsMtimeMs();
   }
 
-  // Re-read the shared store after a sibling process rewrites it, so we use
-  // the rotated grant instead of a stale in-memory copy.
+  // Re-read the shared store on every token access so a sibling's rotated
+  // grant is used instead of a stale in-memory copy.
   private syncTokensFromDisk(): void {
-    const mtimeMs = credentialsMtimeMs();
-    if (mtimeMs === undefined) return;
-    if (
-      this._credentialsMtimeMs !== undefined &&
-      mtimeMs <= this._credentialsMtimeMs
-    ) {
-      return;
-    }
     const stored = loadCredentials();
-    this._credentialsMtimeMs = mtimeMs;
     if (!stored) return;
     if (stored.tokens) {
       this._tokens = stored.tokens as OAuthTokens;
@@ -113,52 +99,8 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  // On invalid_grant, adopt a sibling's newer on-disk token instead of
-  // clearing. Returns false when nothing newer exists.
-  private adoptNewerTokenFromDisk(): boolean {
-    const diskMtime = credentialsMtimeMs();
-    if (
-      diskMtime === undefined ||
-      this._credentialsMtimeMs === undefined ||
-      diskMtime <= this._credentialsMtimeMs
-    ) {
-      return false;
-    }
-    const stored = loadCredentials();
-    const diskTokens = stored?.tokens as OAuthTokens | undefined;
-    if (
-      !diskTokens?.access_token ||
-      diskTokens.access_token === this._tokens?.access_token
-    ) {
-      return false;
-    }
-    this._tokens = diskTokens;
-    this._credentialsMtimeMs = diskMtime;
-    if (stored?.clientInfo) {
-      this._clientInfo = stored.clientInfo as OAuthClientInformationMixed;
-    }
-    console.error(
-      "[auth] invalid_grant, but a newer token is on disk " +
-        "(sibling refresh) — adopting it instead of clearing",
-    );
-    return true;
-  }
-
-  // Poll briefly for the race winner's write before clearing. Skipped when
-  // no refresh token was held (no race possible).
-  private async adoptNewerTokenWithGrace(): Promise<boolean> {
-    if (this.adoptNewerTokenFromDisk()) return true;
-    if (!this._tokens?.refresh_token) return false;
-    const deadline = Date.now() + rotationGraceMs();
-    while (Date.now() < deadline) {
-      await sleep(ROTATION_POLL_MS);
-      if (this.adoptNewerTokenFromDisk()) return true;
-    }
-    return false;
-  }
-
-  // Grace-bounded wait for a sibling's refresh; covers failures the SDK does
-  // not route through invalidateCredentials (e.g. invalid_request collisions).
+  // Wait for a sibling's refresh to land on disk. Returns true once a
+  // different access token is available for adoption/retry.
   async waitForSiblingRefresh(
     previousAccessToken: string | undefined,
   ): Promise<boolean> {
@@ -189,7 +131,6 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
   saveClientInformation(info: OAuthClientInformationMixed): void {
     this._clientInfo = info;
     saveCredentials(this._tokens, this._clientInfo);
-    this._credentialsMtimeMs = credentialsMtimeMs();
   }
 
   tokens(): OAuthTokens | undefined {
@@ -201,8 +142,6 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     this._tokens = tokens;
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
-    // Own write must not look like a sibling change.
-    this._credentialsMtimeMs = credentialsMtimeMs();
     this.onTokensChanged?.(tokens);
   }
 
@@ -221,12 +160,19 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
         this._clientInfo = undefined;
         saveCredentials(this._tokens, undefined);
         break;
-      case "tokens":
+      case "tokens": {
         // Usually a sibling's rotation — try adopting before clearing.
-        if (await this.adoptNewerTokenWithGrace()) return;
+        const previousAccessToken = this._tokens?.access_token;
+        if (
+          this._tokens?.refresh_token &&
+          (await this.waitForSiblingRefresh(previousAccessToken))
+        ) {
+          return;
+        }
         this._tokens = undefined;
         saveCredentials(undefined, this._clientInfo);
         break;
+      }
       case "verifier":
         this._codeVerifier = "";
         break;

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -112,6 +112,46 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
+  // On a refresh failure the SDK calls invalidateCredentials("tokens"), which
+  // would clear our tokens AND overwrite the shared store with an empty set.
+  // But invalid_grant is exactly what a sibling's refresh-token rotation looks
+  // like: the sibling already minted a fresh grant and wrote it to disk, and we
+  // only failed because we refreshed with the now-revoked old token. In that
+  // case, blindly wiping would (a) force a needless re-auth and (b) poison the
+  // fresh token other sessions depend on. So: if disk holds a token newer than
+  // the one we just failed with, adopt it and return true — the caller keeps it
+  // on disk instead of clearing, and the SDK's post-invalidation retry refreshes
+  // with the fresh token and succeeds. Returns false when there's genuinely
+  // nothing newer to adopt (real invalidation → clear as normal).
+  private adoptNewerTokenFromDisk(): boolean {
+    const diskMtime = credentialsMtimeMs();
+    if (
+      diskMtime === undefined ||
+      this._credentialsMtimeMs === undefined ||
+      diskMtime <= this._credentialsMtimeMs
+    ) {
+      return false;
+    }
+    const stored = loadCredentials();
+    const diskTokens = stored?.tokens as OAuthTokens | undefined;
+    if (
+      !diskTokens?.access_token ||
+      diskTokens.access_token === this._tokens?.access_token
+    ) {
+      return false;
+    }
+    this._tokens = diskTokens;
+    this._credentialsMtimeMs = diskMtime;
+    if (stored?.clientInfo) {
+      this._clientInfo = stored.clientInfo as OAuthClientInformationMixed;
+    }
+    console.error(
+      "[auth] invalid_grant, but a newer token is on disk " +
+        "(sibling refresh) — adopting it instead of clearing",
+    );
+    return true;
+  }
+
   get redirectUrl(): string {
     return getCallbackUrl();
   }
@@ -164,6 +204,9 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
         saveCredentials(this._tokens, undefined);
         break;
       case "tokens":
+        // A refresh failure is usually a sibling's rotation, not a dead session
+        // — adopt any newer on-disk token instead of wiping the shared store.
+        if (this.adoptNewerTokenFromDisk()) return;
         this._tokens = undefined;
         saveCredentials(undefined, this._clientInfo);
         break;

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -144,6 +144,7 @@ export async function createRemoteClient(
   serverUrl: string,
   opts: RemoteClientOptions,
   chatSessionId?: string,
+  authRetry = false,
 ): Promise<Client> {
   const authProvider = opts.authProvider;
 
@@ -189,14 +190,37 @@ export async function createRemoteClient(
     { capabilities: {} },
   );
 
+  // Snapshot the access token we're about to connect with. Between now and a
+  // possible 401, a sibling per-session server can rotate the (single-use)
+  // refresh token and persist a newer grant. authProvider.tokens() re-reads the
+  // store when it changed on disk, so on auth failure we can tell whether a
+  // fresher token has since appeared and retry once with it — turning a
+  // cross-process rotation race into a silent reconnect instead of a full
+  // re-auth. Bounded to a single retry via authRetry so it can't spin.
+  const accessTokenAtConnect = authProvider?.tokens()?.access_token;
+
   const transport = buildTransport(serverUrl, opts, chatSessionId);
 
   try {
     await client.connect(transport);
   } catch (error) {
-    if (error instanceof UnauthorizedError && authProvider?.authorizationUrl) {
-      pendingTransport = transport;
-      throw new AuthRequiredError(authProvider.authorizationUrl);
+    if (error instanceof UnauthorizedError && authProvider) {
+      const refreshedAccessToken = authProvider.tokens()?.access_token;
+      if (
+        !authRetry &&
+        refreshedAccessToken &&
+        refreshedAccessToken !== accessTokenAtConnect
+      ) {
+        console.error(
+          "[auth] Auth failed but a newer token is on disk " +
+            "(sibling refresh) — retrying once",
+        );
+        return createRemoteClient(serverUrl, opts, chatSessionId, true);
+      }
+      if (authProvider.authorizationUrl) {
+        pendingTransport = transport;
+        throw new AuthRequiredError(authProvider.authorizationUrl);
+      }
     }
     throw error;
   }

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -190,13 +190,10 @@ export async function createRemoteClient(
     { capabilities: {} },
   );
 
-  // Snapshot the access token we're about to connect with. Between now and a
-  // possible 401, a sibling per-session server can rotate the (single-use)
-  // refresh token and persist a newer grant. authProvider.tokens() re-reads the
-  // store when it changed on disk, so on auth failure we can tell whether a
-  // fresher token has since appeared and retry once with it — turning a
-  // cross-process rotation race into a silent reconnect instead of a full
-  // re-auth. Bounded to a single retry via authRetry so it can't spin.
+  // Snapshot the token we connect with. A sibling may rotate and persist a newer
+  // grant before we hit a 401; comparing against this on failure lets us retry
+  // once with the fresh token (silent reconnect) instead of forcing re-auth.
+  // authRetry bounds it to one retry.
   const accessTokenAtConnect = authProvider?.tokens()?.access_token;
 
   const transport = buildTransport(serverUrl, opts, chatSessionId);

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -190,10 +190,7 @@ export async function createRemoteClient(
     { capabilities: {} },
   );
 
-  // Snapshot the token we connect with. A sibling may rotate and persist a newer
-  // grant before we hit a 401; comparing against this on failure lets us retry
-  // once with the fresh token (silent reconnect) instead of forcing re-auth.
-  // authRetry bounds it to one retry.
+  // Snapshot to detect a sibling's refresh between connect and failure.
   const accessTokenAtConnect = authProvider?.tokens()?.access_token;
 
   const transport = buildTransport(serverUrl, opts, chatSessionId);
@@ -219,11 +216,8 @@ export async function createRemoteClient(
         throw new AuthRequiredError(authProvider.authorizationUrl);
       }
     }
-    // Concurrent refreshes of the same grant: fosite fails the loser with
-    // invalid_request (observed live), which the SDK rethrows as a raw error
-    // without touching invalidateCredentials. If a sibling's fresh grant
-    // lands on disk within the grace window, retry with it instead of
-    // surfacing the error.
+    // Concurrent-refresh losers get errors the SDK rethrows raw (e.g. fosite
+    // invalid_request); retry once if a sibling's grant lands in the grace window.
     if (
       authProvider &&
       !authRetry &&
@@ -241,9 +235,7 @@ export async function createRemoteClient(
   return client;
 }
 
-// Token-refresh failures reach us as OAuth protocol errors whose shapes vary
-// by server and race timing — match broadly; the disk re-check in the caller
-// is what actually gates the retry.
+// Match broadly; the caller's disk re-check gates the actual retry.
 function isLikelyRefreshFailure(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
   return /refresh|invalid_grant|invalid_request|oauth/i.test(msg);

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -219,10 +219,34 @@ export async function createRemoteClient(
         throw new AuthRequiredError(authProvider.authorizationUrl);
       }
     }
+    // Concurrent refreshes of the same grant: fosite fails the loser with
+    // invalid_request (observed live), which the SDK rethrows as a raw error
+    // without touching invalidateCredentials. If a sibling's fresh grant
+    // lands on disk within the grace window, retry with it instead of
+    // surfacing the error.
+    if (
+      authProvider &&
+      !authRetry &&
+      isLikelyRefreshFailure(error) &&
+      (await authProvider.waitForSiblingRefresh(accessTokenAtConnect))
+    ) {
+      console.error(
+        "[auth] Refresh failed but a sibling refreshed — retrying with its token",
+      );
+      return createRemoteClient(serverUrl, opts, chatSessionId, true);
+    }
     throw error;
   }
 
   return client;
+}
+
+// Token-refresh failures reach us as OAuth protocol errors whose shapes vary
+// by server and race timing — match broadly; the disk re-check in the caller
+// is what actually gates the retry.
+function isLikelyRefreshFailure(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return /refresh|invalid_grant|invalid_request|oauth/i.test(msg);
 }
 
 export async function callRemoteTool(

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -1,6 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { OAuthError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { GleanOAuthClientProvider } from "./auth-provider.js";
 
@@ -216,12 +217,13 @@ export async function createRemoteClient(
         throw new AuthRequiredError(authProvider.authorizationUrl);
       }
     }
-    // Concurrent-refresh losers get errors the SDK rethrows raw (e.g. fosite
-    // invalid_request); retry once if a sibling's grant lands in the grace window.
+    // Concurrent-refresh losers are reported with structured OAuth errors
+    // (typically invalid_request); retry once if a sibling's grant lands in the
+    // grace window.
     if (
       authProvider &&
       !authRetry &&
-      isLikelyRefreshFailure(error) &&
+      isRefreshOAuthError(error) &&
       (await authProvider.waitForSiblingRefresh(accessTokenAtConnect))
     ) {
       console.error(
@@ -235,10 +237,14 @@ export async function createRemoteClient(
   return client;
 }
 
-// Match broadly; the caller's disk re-check gates the actual retry.
-function isLikelyRefreshFailure(error: unknown): boolean {
-  const msg = error instanceof Error ? error.message : String(error);
-  return /refresh|invalid_grant|invalid_request|oauth/i.test(msg);
+// Restrict recovery to OAuth errors that can indicate a refresh race. The SDK
+// preserves the response's machine-readable error code.
+function isRefreshOAuthError(error: unknown): boolean {
+  return (
+    error instanceof OAuthError &&
+    (error.errorCode === "invalid_request" ||
+      error.errorCode === "invalid_grant")
+  );
 }
 
 export async function callRemoteTool(

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -28,6 +28,22 @@ export function loadCredentials(): StoredCredentials | undefined {
   }
 }
 
+/**
+ * Last-modified time (epoch ms) of the credentials file, or undefined if it
+ * doesn't exist / can't be stat'd. Used as a cheap change-detection probe so a
+ * long-lived provider can notice when a sibling process has rewritten the
+ * shared store (e.g. after a refresh-token rotation) and re-read it, instead of
+ * serving a stale in-memory snapshot. Kept separate from loadCredentials so the
+ * common "nothing changed" path is a single stat, not a full read + parse.
+ */
+export function credentialsMtimeMs(): number | undefined {
+  try {
+    return fs.statSync(credentialsFile()).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
 export function saveCredentials(tokens: unknown, clientInfo: unknown): void {
   try {
     const filePath = credentialsFile();

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -41,6 +41,7 @@ export function saveCredentials(tokens: unknown, clientInfo: unknown): void {
       encoding: "utf-8",
       mode: FILE_MODE,
     });
+    fs.chmodSync(tmpPath, FILE_MODE);
     fs.renameSync(tmpPath, filePath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -28,18 +28,6 @@ export function loadCredentials(): StoredCredentials | undefined {
   }
 }
 
-/**
- * mtime of the credentials file (epoch ms), or undefined if unreadable.
- * Cheap change probe: a single stat, no read + parse.
- */
-export function credentialsMtimeMs(): number | undefined {
-  try {
-    return fs.statSync(credentialsFile()).mtimeMs;
-  } catch {
-    return undefined;
-  }
-}
-
 export function saveCredentials(tokens: unknown, clientInfo: unknown): void {
   try {
     const filePath = credentialsFile();

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -51,11 +51,16 @@ export function saveCredentials(tokens: unknown, clientInfo: unknown): void {
     fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
     fs.chmodSync(dir, DIR_MODE);
     const data: StoredCredentials = { tokens, clientInfo };
-    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+    // Write-temp-then-rename: the store is shared by concurrent sibling
+    // processes, and an in-place write could be read half-written — a parse
+    // failure that masquerades as a wiped store. Rename is atomic, so readers
+    // only ever see a complete old or complete new file.
+    const tmpPath = `${filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), {
       encoding: "utf-8",
       mode: FILE_MODE,
     });
-    fs.chmodSync(filePath, FILE_MODE);
+    fs.renameSync(tmpPath, filePath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[auth] Failed to persist credentials: ${msg}`);

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -29,12 +29,8 @@ export function loadCredentials(): StoredCredentials | undefined {
 }
 
 /**
- * Last-modified time (epoch ms) of the credentials file, or undefined if it
- * doesn't exist / can't be stat'd. Used as a cheap change-detection probe so a
- * long-lived provider can notice when a sibling process has rewritten the
- * shared store (e.g. after a refresh-token rotation) and re-read it, instead of
- * serving a stale in-memory snapshot. Kept separate from loadCredentials so the
- * common "nothing changed" path is a single stat, not a full read + parse.
+ * mtime of the credentials file (epoch ms), or undefined if unreadable.
+ * Cheap change probe: a single stat, no read + parse.
  */
 export function credentialsMtimeMs(): number | undefined {
   try {
@@ -51,10 +47,7 @@ export function saveCredentials(tokens: unknown, clientInfo: unknown): void {
     fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
     fs.chmodSync(dir, DIR_MODE);
     const data: StoredCredentials = { tokens, clientInfo };
-    // Write-temp-then-rename: the store is shared by concurrent sibling
-    // processes, and an in-place write could be read half-written — a parse
-    // failure that masquerades as a wiped store. Rename is atomic, so readers
-    // only ever see a complete old or complete new file.
+    // Temp-file + rename: concurrent readers never see a half-written store.
     const tmpPath = `${filePath}.${process.pid}.tmp`;
     fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), {
       encoding: "utf-8",

--- a/tests/auth-provider.test.ts
+++ b/tests/auth-provider.test.ts
@@ -74,6 +74,71 @@ describe("GleanOAuthClientProvider", () => {
     expect(raw.tokens.access_token).toBe("new_tok");
   });
 
+  // --- Cross-process sync: a per-session sibling server may rotate the
+  // refresh token and rewrite the shared store; tokens() must pick that up
+  // instead of serving the stale startup snapshot. ---
+
+  const credFile = path.join(gleanDir, "mcp-credentials.json");
+
+  function writeCredFileNewer(tokens: unknown, clientInfo?: unknown): void {
+    fs.mkdirSync(gleanDir, { recursive: true });
+    fs.writeFileSync(credFile, JSON.stringify({ tokens, clientInfo }));
+    // Guarantee a strictly-newer mtime than any prior read, independent of
+    // filesystem timestamp resolution.
+    const future = new Date(Date.now() + 10_000);
+    fs.utimesSync(credFile, future, future);
+  }
+
+  it("tokens() adopts a newer token written by another process", () => {
+    fs.mkdirSync(gleanDir, { recursive: true });
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({
+        tokens: { access_token: "T0", refresh_token: "R0" },
+        clientInfo: { client_id: "cid" },
+      }),
+    );
+    const provider = new GleanOAuthClientProvider();
+    expect(provider.tokens()?.access_token).toBe("T0");
+
+    // Sibling refreshes: new access + rotated refresh token on disk.
+    writeCredFileNewer(
+      { access_token: "T1", refresh_token: "R1" },
+      { client_id: "cid" },
+    );
+
+    expect(provider.tokens()?.access_token).toBe("T1");
+    expect(provider.tokens()?.refresh_token).toBe("R1");
+  });
+
+  it("tokens() keeps the in-memory token when the file is deleted", () => {
+    fs.mkdirSync(gleanDir, { recursive: true });
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({ tokens: { access_token: "T0" }, clientInfo: {} }),
+    );
+    const provider = new GleanOAuthClientProvider();
+    expect(provider.tokens()?.access_token).toBe("T0");
+
+    // Transient disappearance / another process mid-write — don't self-evict.
+    fs.rmSync(credFile, { force: true });
+    expect(provider.tokens()?.access_token).toBe("T0");
+  });
+
+  it("tokens() does not adopt a rewrite that carries no tokens", () => {
+    fs.mkdirSync(gleanDir, { recursive: true });
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({ tokens: { access_token: "T0" }, clientInfo: {} }),
+    );
+    const provider = new GleanOAuthClientProvider();
+    expect(provider.tokens()?.access_token).toBe("T0");
+
+    // A client-only rewrite (tokens dropped) must not log us out in-memory.
+    writeCredFileNewer(undefined, { client_id: "cid" });
+    expect(provider.tokens()?.access_token).toBe("T0");
+  });
+
   it("saveClientInformation persists to disk", () => {
     const provider = new GleanOAuthClientProvider();
     const info = { client_id: "cid", client_secret: "sec" } as any;

--- a/tests/auth-provider.test.ts
+++ b/tests/auth-provider.test.ts
@@ -139,6 +139,47 @@ describe("GleanOAuthClientProvider", () => {
     expect(provider.tokens()?.access_token).toBe("T0");
   });
 
+  it("invalidateCredentials('tokens') adopts a sibling's newer token instead of wiping the store", async () => {
+    fs.mkdirSync(gleanDir, { recursive: true });
+    fs.writeFileSync(
+      credFile,
+      JSON.stringify({
+        tokens: { access_token: "T0", refresh_token: "R0" },
+        clientInfo: { client_id: "cid" },
+      }),
+    );
+    const provider = new GleanOAuthClientProvider();
+    expect(provider.tokens()?.access_token).toBe("T0");
+
+    // A sibling refreshed + rotated: fresh grant now on disk with a newer mtime.
+    writeCredFileNewer(
+      { access_token: "T1", refresh_token: "R1" },
+      { client_id: "cid" },
+    );
+
+    // The SDK calls this on invalid_grant. It must NOT clear — the failure was
+    // just our stale token; adopt the sibling's fresh one and leave it on disk.
+    await provider.invalidateCredentials("tokens");
+
+    expect(provider.tokens()?.access_token).toBe("T1");
+    expect(provider.tokens()?.refresh_token).toBe("R1");
+    const raw = JSON.parse(fs.readFileSync(credFile, "utf-8"));
+    expect(raw.tokens.access_token).toBe("T1"); // not clobbered with undefined
+  });
+
+  it("invalidateCredentials('tokens') clears when there is no newer token on disk", async () => {
+    const provider = new GleanOAuthClientProvider();
+    provider.saveTokens({ access_token: "T0", refresh_token: "R0" } as any);
+    expect(provider.tokens()?.access_token).toBe("T0");
+
+    // No sibling write since our snapshot → a genuine invalidation → clear.
+    await provider.invalidateCredentials("tokens");
+
+    expect(provider.tokens()).toBeUndefined();
+    const raw = JSON.parse(fs.readFileSync(credFile, "utf-8"));
+    expect(raw.tokens).toBeUndefined();
+  });
+
   it("saveClientInformation persists to disk", () => {
     const provider = new GleanOAuthClientProvider();
     const info = { client_id: "cid", client_secret: "sec" } as any;

--- a/tests/auth-provider.test.ts
+++ b/tests/auth-provider.test.ts
@@ -28,15 +28,12 @@ describe("GleanOAuthClientProvider", () => {
 
   beforeEach(() => {
     delete process.env.PLUGIN_DATA_DIR;
-    // Skip the rotation grace window by default so invalidation tests don't
-    // wait out the real 2s poll; the grace test overrides this explicitly.
-    process.env.GLEAN_ROTATION_GRACE_MS = "0";
     fs.rmSync(gleanDir, { recursive: true, force: true });
     vi.clearAllMocks();
   });
 
   afterEach(() => {
-    delete process.env.GLEAN_ROTATION_GRACE_MS;
+    vi.useRealTimers();
     fs.rmSync(gleanDir, { recursive: true, force: true });
   });
 
@@ -174,7 +171,10 @@ describe("GleanOAuthClientProvider", () => {
     expect(provider.tokens()?.access_token).toBe("T0");
 
     // No sibling write since our snapshot → a genuine invalidation → clear.
-    await provider.invalidateCredentials("tokens");
+    vi.useFakeTimers();
+    const invalidation = provider.invalidateCredentials("tokens");
+    await vi.advanceTimersByTimeAsync(2000);
+    await invalidation;
 
     expect(provider.tokens()).toBeUndefined();
     const raw = JSON.parse(fs.readFileSync(credFile, "utf-8"));
@@ -183,7 +183,6 @@ describe("GleanOAuthClientProvider", () => {
 
   it("invalidateCredentials('tokens') adopts a token that lands during the grace window", async () => {
     // The winner's write lands just after the loser's invalid_grant.
-    process.env.GLEAN_ROTATION_GRACE_MS = "2000";
     const provider = new GleanOAuthClientProvider();
     provider.saveTokens({ access_token: "T0", refresh_token: "R0" } as any);
 

--- a/tests/auth-provider.test.ts
+++ b/tests/auth-provider.test.ts
@@ -78,9 +78,7 @@ describe("GleanOAuthClientProvider", () => {
     expect(raw.tokens.access_token).toBe("new_tok");
   });
 
-  // --- Cross-process sync: a per-session sibling server may rotate the
-  // refresh token and rewrite the shared store; tokens() must pick that up
-  // instead of serving the stale startup snapshot. ---
+  // --- Cross-process sync: tokens() must pick up a sibling's rewrite. ---
 
   const credFile = path.join(gleanDir, "mcp-credentials.json");
 
@@ -185,9 +183,7 @@ describe("GleanOAuthClientProvider", () => {
   });
 
   it("invalidateCredentials('tokens') adopts a token that lands during the grace window", async () => {
-    // The losing side of a rotation race sees invalid_grant milliseconds
-    // BEFORE the winner writes its fresh grant — the grace poll must catch
-    // the late write instead of clearing the shared store.
+    // The winner's write lands just after the loser's invalid_grant.
     process.env.GLEAN_ROTATION_GRACE_MS = "2000";
     const provider = new GleanOAuthClientProvider();
     provider.saveTokens({ access_token: "T0", refresh_token: "R0" } as any);

--- a/tests/auth-provider.test.ts
+++ b/tests/auth-provider.test.ts
@@ -82,16 +82,12 @@ describe("GleanOAuthClientProvider", () => {
 
   const credFile = path.join(gleanDir, "mcp-credentials.json");
 
-  function writeCredFileNewer(tokens: unknown, clientInfo?: unknown): void {
+  function writeCredFile(tokens: unknown, clientInfo?: unknown): void {
     fs.mkdirSync(gleanDir, { recursive: true });
     fs.writeFileSync(credFile, JSON.stringify({ tokens, clientInfo }));
-    // Guarantee a strictly-newer mtime than any prior read, independent of
-    // filesystem timestamp resolution.
-    const future = new Date(Date.now() + 10_000);
-    fs.utimesSync(credFile, future, future);
   }
 
-  it("tokens() adopts a newer token written by another process", () => {
+  it("tokens() adopts a token written by another process", () => {
     fs.mkdirSync(gleanDir, { recursive: true });
     fs.writeFileSync(
       credFile,
@@ -102,12 +98,15 @@ describe("GleanOAuthClientProvider", () => {
     );
     const provider = new GleanOAuthClientProvider();
     expect(provider.tokens()?.access_token).toBe("T0");
+    const originalMtime = fs.statSync(credFile).mtime;
 
     // Sibling refreshes: new access + rotated refresh token on disk.
-    writeCredFileNewer(
+    writeCredFile(
       { access_token: "T1", refresh_token: "R1" },
       { client_id: "cid" },
     );
+    // The provider must not rely on mtime to observe this rewrite.
+    fs.utimesSync(credFile, originalMtime, originalMtime);
 
     expect(provider.tokens()?.access_token).toBe("T1");
     expect(provider.tokens()?.refresh_token).toBe("R1");
@@ -137,11 +136,11 @@ describe("GleanOAuthClientProvider", () => {
     expect(provider.tokens()?.access_token).toBe("T0");
 
     // A client-only rewrite (tokens dropped) must not log us out in-memory.
-    writeCredFileNewer(undefined, { client_id: "cid" });
+    writeCredFile(undefined, { client_id: "cid" });
     expect(provider.tokens()?.access_token).toBe("T0");
   });
 
-  it("invalidateCredentials('tokens') adopts a sibling's newer token instead of wiping the store", async () => {
+  it("invalidateCredentials('tokens') adopts a sibling's token instead of wiping the store", async () => {
     fs.mkdirSync(gleanDir, { recursive: true });
     fs.writeFileSync(
       credFile,
@@ -153,8 +152,8 @@ describe("GleanOAuthClientProvider", () => {
     const provider = new GleanOAuthClientProvider();
     expect(provider.tokens()?.access_token).toBe("T0");
 
-    // A sibling refreshed + rotated: fresh grant now on disk with a newer mtime.
-    writeCredFileNewer(
+    // A sibling refreshed + rotated: fresh grant is now on disk.
+    writeCredFile(
       { access_token: "T1", refresh_token: "R1" },
       { client_id: "cid" },
     );
@@ -191,7 +190,7 @@ describe("GleanOAuthClientProvider", () => {
     const invalidation = provider.invalidateCredentials("tokens");
     // Sibling's write lands mid-window.
     setTimeout(() => {
-      writeCredFileNewer(
+      writeCredFile(
         { access_token: "T1", refresh_token: "R1" },
         { client_id: "cid" },
       );

--- a/tests/auth-provider.test.ts
+++ b/tests/auth-provider.test.ts
@@ -28,11 +28,15 @@ describe("GleanOAuthClientProvider", () => {
 
   beforeEach(() => {
     delete process.env.PLUGIN_DATA_DIR;
+    // Skip the rotation grace window by default so invalidation tests don't
+    // wait out the real 2s poll; the grace test overrides this explicitly.
+    process.env.GLEAN_ROTATION_GRACE_MS = "0";
     fs.rmSync(gleanDir, { recursive: true, force: true });
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    delete process.env.GLEAN_ROTATION_GRACE_MS;
     fs.rmSync(gleanDir, { recursive: true, force: true });
   });
 
@@ -178,6 +182,41 @@ describe("GleanOAuthClientProvider", () => {
     expect(provider.tokens()).toBeUndefined();
     const raw = JSON.parse(fs.readFileSync(credFile, "utf-8"));
     expect(raw.tokens).toBeUndefined();
+  });
+
+  it("invalidateCredentials('tokens') adopts a token that lands during the grace window", async () => {
+    // The losing side of a rotation race sees invalid_grant milliseconds
+    // BEFORE the winner writes its fresh grant — the grace poll must catch
+    // the late write instead of clearing the shared store.
+    process.env.GLEAN_ROTATION_GRACE_MS = "2000";
+    const provider = new GleanOAuthClientProvider();
+    provider.saveTokens({ access_token: "T0", refresh_token: "R0" } as any);
+
+    const invalidation = provider.invalidateCredentials("tokens");
+    // Sibling's write lands mid-window.
+    setTimeout(() => {
+      writeCredFileNewer(
+        { access_token: "T1", refresh_token: "R1" },
+        { client_id: "cid" },
+      );
+    }, 150);
+    await invalidation;
+
+    expect(provider.tokens()?.access_token).toBe("T1");
+    const raw = JSON.parse(fs.readFileSync(credFile, "utf-8"));
+    expect(raw.tokens.access_token).toBe("T1"); // not clobbered with undefined
+  });
+
+  it("skips the grace window when no refresh token was held (no race possible)", async () => {
+    process.env.GLEAN_ROTATION_GRACE_MS = "5000";
+    const provider = new GleanOAuthClientProvider();
+    provider.saveTokens({ access_token: "T0" } as any); // no refresh_token
+
+    const start = Date.now();
+    await provider.invalidateCredentials("tokens");
+
+    expect(Date.now() - start).toBeLessThan(1000); // no 5s poll
+    expect(provider.tokens()).toBeUndefined();
   });
 
   it("saveClientInformation persists to disk", () => {

--- a/tests/remote-client-auth-retry.test.ts
+++ b/tests/remote-client-auth-retry.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+
+// Control client.connect() across (re)tries.
+const { connectMock } = vi.hoisted(() => ({ connectMock: vi.fn() }));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class {
+    async connect(...args: unknown[]) {
+      return connectMock(...args);
+    }
+  },
+}));
+
+// Keep buildTransport cheap and side-effect free.
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: class {
+    constructor() {}
+    async close() {}
+  },
+}));
+
+const { createRemoteClient, AuthRequiredError } = await import(
+  "../src/remote-client.js"
+);
+
+/**
+ * Minimal OAuthClientProvider stand-in. tokens() returns the next value in
+ * `seq` on each call, mirroring how the real provider re-reads disk: the
+ * pre-connect snapshot, then the value after a sibling may have rewritten it.
+ */
+function makeProvider(seq: Array<{ access_token?: string } | undefined>) {
+  let i = 0;
+  return {
+    tokens() {
+      const t = seq[Math.min(i, seq.length - 1)];
+      i += 1;
+      return t;
+    },
+    authorizationUrl: "https://example.com/oauth/authorize?state=s1",
+    pendingAuthCode: undefined,
+    needsFreshClient: () => false,
+  } as any;
+}
+
+describe("createRemoteClient sibling-refresh retry", () => {
+  beforeEach(() => {
+    connectMock.mockReset();
+  });
+
+  it("retries once and succeeds when a newer token appears on disk", async () => {
+    connectMock
+      .mockRejectedValueOnce(new UnauthorizedError("401"))
+      .mockResolvedValueOnce(undefined);
+
+    // pre-connect snapshot T0, post-failure re-read T1 (rotated), retry snapshot T1.
+    const provider = makeProvider([
+      { access_token: "T0" },
+      { access_token: "T1" },
+      { access_token: "T1" },
+    ]);
+
+    const client = await createRemoteClient(
+      "https://acme-be.glean.com/mcp/gateway/proxy",
+      { authProvider: provider },
+      "sess-1",
+    );
+
+    expect(client).toBeTruthy();
+    expect(connectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when the on-disk token is unchanged", async () => {
+    connectMock.mockRejectedValue(new UnauthorizedError("401"));
+
+    const provider = makeProvider([
+      { access_token: "T0" },
+      { access_token: "T0" },
+    ]);
+
+    await expect(
+      createRemoteClient(
+        "https://acme-be.glean.com/mcp/gateway/proxy",
+        { authProvider: provider },
+        "sess-2",
+      ),
+    ).rejects.toBeInstanceOf(AuthRequiredError);
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/remote-client-auth-retry.test.ts
+++ b/tests/remote-client-auth-retry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { InvalidRequestError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 
 // Control client.connect() across (re)tries.
 const { connectMock } = vi.hoisted(() => ({ connectMock: vi.fn() }));
@@ -95,16 +96,14 @@ describe("createRemoteClient refresh-collision retry", () => {
     connectMock.mockReset();
   });
 
-  // Fosite fails concurrent-refresh losers with invalid_request (SDK rethrows raw).
-  const collisionError = new Error(
-    "The request is missing a required parameter, includes an invalid " +
-      "parameter value, includes a parameter more than once, or is " +
-      "otherwise malformed. Failed to refresh token",
+  // The SDK preserves fosite's machine-readable OAuth error code.
+  const collisionError = new InvalidRequestError(
+    "The refresh request was rejected because another process rotated the grant.",
   );
 
   function makeCollisionProvider(siblingRefreshed: boolean) {
     return {
-      tokens: () => ({ access_token: "T0" }),
+      tokens: () => ({ access_token: "T0", refresh_token: "R0" }),
       authorizationUrl: undefined,
       pendingAuthCode: undefined,
       needsFreshClient: () => false,
@@ -145,8 +144,8 @@ describe("createRemoteClient refresh-collision retry", () => {
     expect(connectMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not treat unrelated connect errors as refresh failures", async () => {
-    connectMock.mockRejectedValue(new Error("socket hang up"));
+  it("does not treat untyped refresh-like errors as refresh failures", async () => {
+    connectMock.mockRejectedValue(new Error("Failed to refresh token"));
     const provider = makeCollisionProvider(true /*siblingRefreshed*/);
 
     await expect(
@@ -155,7 +154,7 @@ describe("createRemoteClient refresh-collision retry", () => {
         { authProvider: provider },
         "sess-7",
       ),
-    ).rejects.toThrow("socket hang up");
+    ).rejects.toThrow("Failed to refresh token");
 
     expect(provider.waitForSiblingRefresh).not.toHaveBeenCalled();
   });

--- a/tests/remote-client-auth-retry.test.ts
+++ b/tests/remote-client-auth-retry.test.ts
@@ -89,3 +89,76 @@ describe("createRemoteClient sibling-refresh retry", () => {
     expect(connectMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("createRemoteClient refresh-collision retry", () => {
+  beforeEach(() => {
+    connectMock.mockReset();
+  });
+
+  // The tight race: fosite fails the losing refresh with invalid_request,
+  // which the SDK rethrows as a raw error (never touching
+  // invalidateCredentials). Verified live on prod /oauth (2026-07-29).
+  const collisionError = new Error(
+    "The request is missing a required parameter, includes an invalid " +
+      "parameter value, includes a parameter more than once, or is " +
+      "otherwise malformed. Failed to refresh token",
+  );
+
+  function makeCollisionProvider(siblingRefreshed: boolean) {
+    return {
+      tokens: () => ({ access_token: "T0" }),
+      authorizationUrl: undefined,
+      pendingAuthCode: undefined,
+      needsFreshClient: () => false,
+      waitForSiblingRefresh: vi.fn(async () => siblingRefreshed),
+      invalidateCredentials: vi.fn(),
+    } as any;
+  }
+
+  it("retries once when a sibling's refresh lands during the grace wait", async () => {
+    connectMock
+      .mockRejectedValueOnce(collisionError)
+      .mockResolvedValueOnce(undefined);
+    const provider = makeCollisionProvider(true /*siblingRefreshed*/);
+
+    const client = await createRemoteClient(
+      "https://acme-be.glean.com/mcp/gateway/proxy",
+      { authProvider: provider },
+      "sess-5",
+    );
+
+    expect(client).toBeTruthy();
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(provider.waitForSiblingRefresh).toHaveBeenCalledWith("T0");
+  });
+
+  it("rethrows when no sibling token appears within the grace window", async () => {
+    connectMock.mockRejectedValue(collisionError);
+    const provider = makeCollisionProvider(false /*siblingRefreshed*/);
+
+    await expect(
+      createRemoteClient(
+        "https://acme-be.glean.com/mcp/gateway/proxy",
+        { authProvider: provider },
+        "sess-6",
+      ),
+    ).rejects.toBe(collisionError);
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat unrelated connect errors as refresh failures", async () => {
+    connectMock.mockRejectedValue(new Error("socket hang up"));
+    const provider = makeCollisionProvider(true /*siblingRefreshed*/);
+
+    await expect(
+      createRemoteClient(
+        "https://acme-be.glean.com/mcp/gateway/proxy",
+        { authProvider: provider },
+        "sess-7",
+      ),
+    ).rejects.toThrow("socket hang up");
+
+    expect(provider.waitForSiblingRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/tests/remote-client-auth-retry.test.ts
+++ b/tests/remote-client-auth-retry.test.ts
@@ -95,9 +95,7 @@ describe("createRemoteClient refresh-collision retry", () => {
     connectMock.mockReset();
   });
 
-  // The tight race: fosite fails the losing refresh with invalid_request,
-  // which the SDK rethrows as a raw error (never touching
-  // invalidateCredentials). Verified live on prod /oauth (2026-07-29).
+  // Fosite fails concurrent-refresh losers with invalid_request (SDK rethrows raw).
   const collisionError = new Error(
     "The request is missing a required parameter, includes an invalid " +
       "parameter value, includes a parameter more than once, or is " +

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -10,9 +10,8 @@ vi.mock("node:os", async () => {
   return { ...actual, homedir: () => tmpDir };
 });
 
-const { clearCredentials, loadCredentials, saveCredentials } = await import(
-  "../src/token-store.js"
-);
+const { clearCredentials, credentialsMtimeMs, loadCredentials, saveCredentials } =
+  await import("../src/token-store.js");
 
 describe("token-store", () => {
   const gleanDir = path.join(tmpDir, ".glean");
@@ -87,5 +86,24 @@ describe("token-store", () => {
   it("clearCredentials is a no-op when file does not exist", () => {
     expect(fs.existsSync(credFile)).toBe(false);
     expect(() => clearCredentials()).not.toThrow();
+  });
+
+  it("credentialsMtimeMs returns undefined when file does not exist", () => {
+    expect(credentialsMtimeMs()).toBeUndefined();
+  });
+
+  it("credentialsMtimeMs returns a number once credentials are saved", () => {
+    saveCredentials({ access_token: "x" }, undefined);
+    expect(typeof credentialsMtimeMs()).toBe("number");
+  });
+
+  it("credentialsMtimeMs advances when the file is rewritten", () => {
+    saveCredentials({ access_token: "x" }, undefined);
+    const first = credentialsMtimeMs()!;
+    // Force a strictly-newer mtime rather than relying on filesystem timer
+    // resolution between two quick writes.
+    const future = new Date(Date.now() + 10_000);
+    fs.utimesSync(credFile, future, future);
+    expect(credentialsMtimeMs()!).toBeGreaterThan(first);
   });
 });

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -10,7 +10,7 @@ vi.mock("node:os", async () => {
   return { ...actual, homedir: () => tmpDir };
 });
 
-const { clearCredentials, credentialsMtimeMs, loadCredentials, saveCredentials } =
+const { clearCredentials, loadCredentials, saveCredentials } =
   await import("../src/token-store.js");
 
 describe("token-store", () => {
@@ -88,22 +88,4 @@ describe("token-store", () => {
     expect(() => clearCredentials()).not.toThrow();
   });
 
-  it("credentialsMtimeMs returns undefined when file does not exist", () => {
-    expect(credentialsMtimeMs()).toBeUndefined();
-  });
-
-  it("credentialsMtimeMs returns a number once credentials are saved", () => {
-    saveCredentials({ access_token: "x" }, undefined);
-    expect(typeof credentialsMtimeMs()).toBe("number");
-  });
-
-  it("credentialsMtimeMs advances when the file is rewritten", () => {
-    saveCredentials({ access_token: "x" }, undefined);
-    const first = credentialsMtimeMs()!;
-    // Force a strictly-newer mtime rather than relying on filesystem timer
-    // resolution between two quick writes.
-    const future = new Date(Date.now() + 10_000);
-    fs.utimesSync(credFile, future, future);
-    expect(credentialsMtimeMs()!).toBeGreaterThan(first);
-  });
 });


### PR DESCRIPTION
## Problem

The plugin can intermittently ask the user to authenticate again — `find_skills` or `run_tool` returns `[SETUP_REQUIRED]` — even though another live plugin process has already refreshed the shared OAuth grant.

## Root cause: cross-process refresh-token rotation

Each MCP session runs its own plugin process, but those processes share one credential file. The OAuth server rotates refresh tokens on every refresh and invalidates the presented refresh token. A sibling process can therefore retain a revoked refresh token in memory:

```text
process A: refreshes R0 → receives A1/R1 → persists A1/R1
process B: still holds R0 → refreshes → invalid_grant or invalid_request
```

Without coordination, the losing process can clear the shared store and surface `[SETUP_REQUIRED]`, potentially taking down the process that already has the valid rotated grant.

## Fix

1. **Treat the credential file as the source of truth.** `tokens()` reloads credentials from disk on every access through `syncTokensFromDisk()`. Correctness no longer depends on file mtime, and there is no mtime-based synchronization or environment override.
2. **Wait before clearing tokens.** `invalidateCredentials("tokens")` waits for a sibling's changed access token for a fixed two-second grace period, polling every 100 ms. If the sibling grant appears, it is adopted; only an unchanged store is cleared.
3. **Retry connect-level refresh failures.** `createRemoteClient()` observes whether a newer access token appeared on disk and retries the connection once. It also handles raw structured OAuth errors with `errorCode` `invalid_request` or `invalid_grant`, rather than matching human-readable error messages.
4. **Keep retries bounded and conservative.** A retry requires a changed token and is limited to one attempt, so unrelated OAuth errors and repeated failures are not hidden or retried indefinitely.
5. **Preserve atomic, private credential writes.** Credential updates continue to use temp-file-plus-rename writes, with `chmodSync(tmpPath, FILE_MODE)` applied before the rename so temporary files are `0600` as well.

The registered OAuth client is not replaced during a sibling retry; the new MCP connection reuses the same provider and the newly persisted grant. DCR client reuse remains covered separately by #45.

## Verification

Against the non-production SST endpoint:

```text
https://salessavvy-test-be.glean.com/mcp/gateway/proxy
```

with `client_api.oauth.accessToken.defaultExpiryMinutes=2`:

- Two separate Claude Code processes were launched with `--strict-mcp-config`.
- Both processes used the candidate plugin MCP server and one shared test credential file.
- A newly issued access token reported `expires_in=120` and the credential file remained mode `0600`.
- After access-token expiry, both real MCP calls succeeded without `[SETUP_REQUIRED]`.
- Local fingerprints confirmed that both the access token and rotated refresh token changed, while the registered client ID stayed stable.
- No raw credentials are included here.

## Files

- `src/auth-provider.ts`: direct disk synchronization, fixed grace-window sibling adoption.
- `src/remote-client.ts`: structured OAuth-error handling and bounded sibling retry.
- `src/token-store.ts`: atomic credential persistence and temp-file permission hardening.
- Corresponding auth-provider, remote-client, and token-store tests.

— sent via Glean Desktop
