### PR TITLE
Serve Glean skills over the MCP skills extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,36 @@ every launch and setting them yourself has no effect:
 - `GLEAN_SESSION_ID` — the host's conversation id: `CLAUDE_CODE_SESSION_ID` for
   Claude Code, `CODEX_THREAD_ID` for Codex, otherwise a generated UUID.
 
+## MCP skills extension
+
+For hosts that import skills from the MCP server itself rather than from the
+packaged plugin directory (ChatGPT plugins, per OpenAI's
+[Import skills from the MCP server](https://developers.openai.com/plugins/build/mcp-server#import-skills-from-the-mcp-server)
+guide), the server advertises the draft
+[SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol)
+skills extension:
+
+```json
+{ "capabilities": { "extensions": { "io.modelcontextprotocol/skills": {} } } }
+```
+
+It serves the skills the signed-in user has in Glean, sourced from the
+experimental Platform Skills API (`GET /api/skills` for metadata,
+`GET /api/skills/{id}/content` for the bundle) on the same origin and bearer
+token that `setup` already captured:
+
+| Method | Behavior |
+| --- | --- |
+| `skills/list` | One page of skills (10 per page); `cursor` maps to the Platform API cursor. Each entry has a `skill://glean/<name>/SKILL.md` uri, the full parsed SKILL.md frontmatter, and every bundle file with a `sha256:` digest. |
+| `skills/get` | The catalog entry for one SKILL.md uri. |
+| `resources/read` | The bytes for any listed uri — `text` for UTF-8 files, `blob` for binary. |
+| `resources/list` | Resources this process has already listed. Empty until `skills/list` runs, so host startup never triggers bundle downloads. |
+
+Unconfigured or signed-out sessions serve an empty catalog — `setup` remains
+the only path that drives OAuth. Only `ENABLED` skills are served; draft,
+disabled, oversized (spec import limits), and duplicate-named skills are
+skipped and logged to `glean-server.log`.
+
 ## Troubleshooting
 
 - **Sign-in loop or stale auth** — prompt the agent to reset and sign in again

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "glean",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "yaml": "^2.7.0"
+        "yaml": "^2.7.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "yaml": "^2.7.0"
+    "yaml": "^2.7.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -1371,12 +1371,12 @@ var require_errors = __commonJS({
       }
       return [E.schemaPath, schPath];
     }
-    function extraErrorProps(cxt, { params, message }, keyValues) {
+    function extraErrorProps(cxt, { params, message: message2 }, keyValues) {
       const { keyword, data, schemaValue, it } = cxt;
       const { opts, propertyName, topSchemaRef, schemaPath } = it;
       keyValues.push([E.keyword, keyword], [E.params, typeof params == "function" ? params(cxt) : params || (0, codegen_1._)`{}`]);
       if (opts.messages) {
-        keyValues.push([E.message, typeof message == "function" ? message(cxt) : message]);
+        keyValues.push([E.message, typeof message2 == "function" ? message2(cxt) : message2]);
       }
       if (opts.verbose) {
         keyValues.push([E.schema, schemaValue], [E.parentSchema, (0, codegen_1._)`${topSchemaRef}${schemaPath}`], [names_1.default.data, data]);
@@ -4196,11 +4196,11 @@ var require_core = __commonJS({
         }
         const valid = this.validate($schema, schema);
         if (!valid && throwOrLogError) {
-          const message = "schema is invalid: " + this.errorsText();
+          const message2 = "schema is invalid: " + this.errorsText();
           if (this.opts.validateSchema === "log")
-            this.logger.error(message);
+            this.logger.error(message2);
           else
-            throw new Error(message);
+            throw new Error(message2);
         }
         return valid;
       }
@@ -7127,10 +7127,10 @@ var require_directives = __commonJS({
     };
     var escapeTagName = (tn) => tn.replace(/[!,[\]{}]/g, (ch) => escapeChars[ch]);
     var Directives = class _Directives {
-      constructor(yaml2, tags) {
+      constructor(yaml3, tags) {
         this.docStart = null;
         this.docEnd = false;
-        this.yaml = Object.assign({}, _Directives.defaultYaml, yaml2);
+        this.yaml = Object.assign({}, _Directives.defaultYaml, yaml3);
         this.tags = Object.assign({}, _Directives.defaultTags, tags);
       }
       clone() {
@@ -10568,22 +10568,22 @@ var require_errors2 = __commonJS({
   "node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
-      constructor(name, pos, code, message) {
+      constructor(name, pos, code, message2) {
         super();
         this.name = name;
         this.code = code;
-        this.message = message;
+        this.message = message2;
         this.pos = pos;
       }
     };
     var YAMLParseError = class extends YAMLError {
-      constructor(pos, code, message) {
-        super("YAMLParseError", pos, code, message);
+      constructor(pos, code, message2) {
+        super("YAMLParseError", pos, code, message2);
       }
     };
     var YAMLWarning = class extends YAMLError {
-      constructor(pos, code, message) {
-        super("YAMLWarning", pos, code, message);
+      constructor(pos, code, message2) {
+        super("YAMLWarning", pos, code, message2);
       }
     };
     var prettifyError2 = (src, lc) => (error2) => {
@@ -11263,8 +11263,8 @@ var require_compose_collection = __commonJS({
         const { anchor, newlineAfterProp: nl } = props;
         const lastProp = anchor && tagToken ? anchor.offset > tagToken.offset ? anchor : tagToken : anchor ?? tagToken;
         if (lastProp && (!nl || nl.offset < lastProp.offset)) {
-          const message = "Missing newline after block sequence props";
-          onError(lastProp, "MISSING_CHAR", message);
+          const message2 = "Missing newline after block sequence props";
+          onError(lastProp, "MISSING_CHAR", message2);
         }
       }
       const expType = token.type === "block-map" ? "map" : token.type === "block-seq" ? "seq" : token.start.source === "{" ? "map" : "seq";
@@ -11336,15 +11336,15 @@ var require_resolve_block_scalar = __commonJS({
             trimIndent = indent.length;
         } else {
           if (indent.length < trimIndent) {
-            const message = "Block scalars with more-indented leading empty lines must use an explicit indentation indicator";
-            onError(offset + indent.length, "MISSING_CHAR", message);
+            const message2 = "Block scalars with more-indented leading empty lines must use an explicit indentation indicator";
+            onError(offset + indent.length, "MISSING_CHAR", message2);
           }
           if (header.indent === 0)
             trimIndent = indent.length;
           contentStart = i;
           if (trimIndent === 0 && !ctx.atRoot) {
-            const message = "Block scalar values in collections must be indented";
-            onError(offset, "BAD_INDENT", message);
+            const message2 = "Block scalar values in collections must be indented";
+            onError(offset, "BAD_INDENT", message2);
           }
           break;
         }
@@ -11367,8 +11367,8 @@ var require_resolve_block_scalar = __commonJS({
           content = content.slice(0, -1);
         if (content && indent.length < trimIndent) {
           const src = header.indent ? "explicit indentation indicator" : "first line";
-          const message = `Block scalar lines must not be less indented than their ${src}`;
-          onError(offset - content.length - (crlf ? 2 : 1), "BAD_INDENT", message);
+          const message2 = `Block scalar lines must not be less indented than their ${src}`;
+          onError(offset - content.length - (crlf ? 2 : 1), "BAD_INDENT", message2);
           indent = "";
         }
         if (type === Scalar.Scalar.BLOCK_LITERAL) {
@@ -11446,8 +11446,8 @@ var require_resolve_block_scalar = __commonJS({
             break;
           case "comment":
             if (strict && !hasSpace) {
-              const message = "Comments must be separated from other tokens by white space characters";
-              onError(token, "MISSING_CHAR", message);
+              const message2 = "Comments must be separated from other tokens by white space characters";
+              onError(token, "MISSING_CHAR", message2);
             }
             length += token.source.length;
             comment = token.source.substring(1);
@@ -11458,8 +11458,8 @@ var require_resolve_block_scalar = __commonJS({
             break;
           /* istanbul ignore next should not happen */
           default: {
-            const message = `Unexpected token in block scalar header: ${token.type}`;
-            onError(token, "UNEXPECTED_TOKEN", message);
+            const message2 = `Unexpected token in block scalar header: ${token.type}`;
+            onError(token, "UNEXPECTED_TOKEN", message2);
             const ts = token.source;
             if (ts && typeof ts === "string")
               length += ts.length;
@@ -11851,13 +11851,13 @@ var require_compose_node = __commonJS({
             if (anchor)
               node.anchor = anchor.source.substring(1);
           } catch (error2) {
-            const message = error2 instanceof Error ? error2.message : String(error2);
-            onError(token, "RESOURCE_EXHAUSTION", message);
+            const message2 = error2 instanceof Error ? error2.message : String(error2);
+            onError(token, "RESOURCE_EXHAUSTION", message2);
           }
           break;
         default: {
-          const message = token.type === "error" ? token.message : `Unsupported token (type: ${token.type})`;
-          onError(token, "UNEXPECTED_TOKEN", message);
+          const message2 = token.type === "error" ? token.message : `Unsupported token (type: ${token.type})`;
+          onError(token, "UNEXPECTED_TOKEN", message2);
           isSrcToken = false;
         }
       }
@@ -12013,12 +12013,12 @@ var require_composer = __commonJS({
         this.prelude = [];
         this.errors = [];
         this.warnings = [];
-        this.onError = (source, code, message, warning) => {
+        this.onError = (source, code, message2, warning) => {
           const pos = getErrorPos(source);
           if (warning)
-            this.warnings.push(new errors.YAMLWarning(pos, code, message));
+            this.warnings.push(new errors.YAMLWarning(pos, code, message2));
           else
-            this.errors.push(new errors.YAMLParseError(pos, code, message));
+            this.errors.push(new errors.YAMLParseError(pos, code, message2));
         };
         this.directives = new directives.Directives({ version: options.version || "1.2" });
         this.options = options;
@@ -12088,10 +12088,10 @@ ${cb}` : comment;
           console.dir(token, { depth: null });
         switch (token.type) {
           case "directive":
-            this.directives.add(token.source, (offset, message, warning) => {
+            this.directives.add(token.source, (offset, message2, warning) => {
               const pos = getErrorPos(token);
               pos[0] += offset;
-              this.onError(pos, "BAD_DIRECTIVE", message, warning);
+              this.onError(pos, "BAD_DIRECTIVE", message2, warning);
             });
             this.prelude.push(token.source);
             this.atDirectives = true;
@@ -12180,12 +12180,12 @@ var require_cst_scalar = __commonJS({
     var stringifyString = require_stringifyString();
     function resolveAsScalar(token, strict = true, onError) {
       if (token) {
-        const _onError = (pos, code, message) => {
+        const _onError = (pos, code, message2) => {
           const offset = typeof pos === "number" ? pos : Array.isArray(pos) ? pos[0] : pos.offset;
           if (onError)
-            onError(offset, code, message);
+            onError(offset, code, message2);
           else
-            throw new errors.YAMLParseError([offset, offset + 1], code, message);
+            throw new errors.YAMLParseError([offset, offset + 1], code, message2);
         };
         switch (token.type) {
           case "scalar":
@@ -13345,8 +13345,8 @@ var require_parser = __commonJS({
         }
         const type = cst.tokenType(source);
         if (!type) {
-          const message = `Not a YAML token: ${source}`;
-          yield* this.pop({ type: "error", offset: this.offset, message, source });
+          const message2 = `Not a YAML token: ${source}`;
+          yield* this.pop({ type: "error", offset: this.offset, message: message2, source });
           this.offset += source.length;
         } else if (type === "scalar") {
           this.atNewLine = false;
@@ -13436,8 +13436,8 @@ var require_parser = __commonJS({
       *pop(error2) {
         const token = error2 ?? this.stack.pop();
         if (!token) {
-          const message = "Tried to pop an empty stack";
-          yield { type: "error", offset: this.offset, source: "", message };
+          const message2 = "Tried to pop an empty stack";
+          yield { type: "error", offset: this.offset, source: "", message: message2 };
         } else if (this.stack.length === 0) {
           yield token;
         } else {
@@ -14886,14 +14886,14 @@ function prefixIssues(path8, issues) {
     return iss;
   });
 }
-function unwrapMessage(message) {
-  return typeof message === "string" ? message : message?.message;
+function unwrapMessage(message2) {
+  return typeof message2 === "string" ? message2 : message2?.message;
 }
 function finalizeIssue(iss, ctx, config2) {
-  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
+  const message2 = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
   const { inst: _inst, continue: _continue, input: _input, ...rest } = iss;
   rest.path ?? (rest.path = []);
-  rest.message = message;
+  rest.message = message2;
   if (ctx?.reportInput) {
     rest.input = _input;
   }
@@ -21180,8 +21180,8 @@ var ServerResultSchema = union([
   CreateTaskResultSchema
 ]);
 var McpError = class _McpError extends Error {
-  constructor(code, message, data) {
-    super(`MCP error ${code}: ${message}`);
+  constructor(code, message2, data) {
+    super(`MCP error ${code}: ${message2}`);
     this.code = code;
     this.data = data;
     this.name = "McpError";
@@ -21189,19 +21189,19 @@ var McpError = class _McpError extends Error {
   /**
    * Factory method to create the appropriate error type based on the error code and data
    */
-  static fromError(code, message, data) {
+  static fromError(code, message2, data) {
     if (code === ErrorCode.UrlElicitationRequired && data) {
       const errorData = data;
       if (errorData.elicitations) {
-        return new UrlElicitationRequiredError(errorData.elicitations, message);
+        return new UrlElicitationRequiredError(errorData.elicitations, message2);
       }
     }
-    return new _McpError(code, message, data);
+    return new _McpError(code, message2, data);
   }
 };
 var UrlElicitationRequiredError = class extends McpError {
-  constructor(elicitations, message = `URL elicitation${elicitations.length > 1 ? "s" : ""} required`) {
-    super(ErrorCode.UrlElicitationRequired, message, {
+  constructor(elicitations, message2 = `URL elicitation${elicitations.length > 1 ? "s" : ""} required`) {
+    super(ErrorCode.UrlElicitationRequired, message2, {
       elicitations
     });
   }
@@ -21284,15 +21284,15 @@ var Protocol = class {
             let queuedMessage;
             while (queuedMessage = await this._taskMessageQueue.dequeue(taskId, extra.sessionId)) {
               if (queuedMessage.type === "response" || queuedMessage.type === "error") {
-                const message = queuedMessage.message;
-                const requestId = message.id;
+                const message2 = queuedMessage.message;
+                const requestId = message2.id;
                 const resolver = this._requestResolvers.get(requestId);
                 if (resolver) {
                   this._requestResolvers.delete(requestId);
                   if (queuedMessage.type === "response") {
-                    resolver(message);
+                    resolver(message2);
                   } else {
-                    const errorMessage = message;
+                    const errorMessage = message2;
                     const error2 = new McpError(errorMessage.error.code, errorMessage.error.message, errorMessage.error.data);
                     resolver(error2);
                   }
@@ -21431,16 +21431,16 @@ var Protocol = class {
       this._onerror(error2);
     };
     const _onmessage = this._transport?.onmessage;
-    this._transport.onmessage = (message, extra) => {
-      _onmessage?.(message, extra);
-      if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
-        this._onresponse(message);
-      } else if (isJSONRPCRequest(message)) {
-        this._onrequest(message, extra);
-      } else if (isJSONRPCNotification(message)) {
-        this._onnotification(message);
+    this._transport.onmessage = (message2, extra) => {
+      _onmessage?.(message2, extra);
+      if (isJSONRPCResultResponse(message2) || isJSONRPCErrorResponse(message2)) {
+        this._onresponse(message2);
+      } else if (isJSONRPCRequest(message2)) {
+        this._onrequest(message2, extra);
+      } else if (isJSONRPCNotification(message2)) {
+        this._onnotification(message2);
       } else {
-        this._onerror(new Error(`Unknown message type: ${JSON.stringify(message)}`));
+        this._onerror(new Error(`Unknown message type: ${JSON.stringify(message2)}`));
       }
     };
     await this._transport.start();
@@ -22050,12 +22050,12 @@ var Protocol = class {
    * the error appropriately (e.g., by failing the task, logging, etc.). The Protocol layer
    * simply propagates the error.
    */
-  async _enqueueTaskMessage(taskId, message, sessionId) {
+  async _enqueueTaskMessage(taskId, message2, sessionId) {
     if (!this._taskStore || !this._taskMessageQueue) {
       throw new Error("Cannot enqueue task message: taskStore and taskMessageQueue are not configured");
     }
     const maxQueueSize = this._options?.maxTaskQueueSize;
-    await this._taskMessageQueue.enqueue(taskId, message, sessionId, maxQueueSize);
+    await this._taskMessageQueue.enqueue(taskId, message2, sessionId, maxQueueSize);
   }
   /**
    * Clears the message queue for a task and rejects any pending request resolvers.
@@ -22065,9 +22065,9 @@ var Protocol = class {
   async _clearTaskQueue(taskId, sessionId) {
     if (this._taskMessageQueue) {
       const messages = await this._taskMessageQueue.dequeueAll(taskId, sessionId);
-      for (const message of messages) {
-        if (message.type === "request" && isJSONRPCRequest(message.message)) {
-          const requestId = message.message.id;
+      for (const message2 of messages) {
+        if (message2.type === "request" && isJSONRPCRequest(message2.message)) {
+          const requestId = message2.message.id;
           const resolver = this._requestResolvers.get(requestId);
           if (resolver) {
             resolver(new McpError(ErrorCode.InternalError, "Task cancelled or completed"));
@@ -22916,8 +22916,8 @@ var ReadBuffer = class {
 function deserializeMessage(line) {
   return JSONRPCMessageSchema.parse(JSON.parse(line));
 }
-function serializeMessage(message) {
-  return JSON.stringify(message) + "\n";
+function serializeMessage(message2) {
+  return JSON.stringify(message2) + "\n";
 }
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
@@ -22949,11 +22949,11 @@ var StdioServerTransport = class {
   processReadBuffer() {
     while (true) {
       try {
-        const message = this._readBuffer.readMessage();
-        if (message === null) {
+        const message2 = this._readBuffer.readMessage();
+        if (message2 === null) {
           break;
         }
-        this.onmessage?.(message);
+        this.onmessage?.(message2);
       } catch (error2) {
         this.onerror?.(error2);
       }
@@ -22969,9 +22969,9 @@ var StdioServerTransport = class {
     this._readBuffer.clear();
     this.onclose?.();
   }
-  send(message) {
+  send(message2) {
     return new Promise((resolve) => {
-      const json = serializeMessage(message);
+      const json = serializeMessage(message2);
       if (this._stdout.write(json)) {
         resolve();
       } else {
@@ -23037,9 +23037,9 @@ var ExperimentalClientTasks = class {
     };
     const stream = clientInternal.requestStream({ method: "tools/call", params }, resultSchema, optionsWithTask);
     const validator = clientInternal.getToolOutputValidator(params.name);
-    for await (const message of stream) {
-      if (message.type === "result" && validator) {
-        const result = message.result;
+    for await (const message2 of stream) {
+      if (message2.type === "result" && validator) {
+        const result = message2.result;
         if (!result.structuredContent && !result.isError) {
           yield {
             type: "error",
@@ -23070,7 +23070,7 @@ var ExperimentalClientTasks = class {
           }
         }
       }
-      yield message;
+      yield message2;
     }
   }
   /**
@@ -23896,8 +23896,8 @@ function checkResourceAllowed({ requestedResource, configuredResource }) {
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
 var OAuthError = class extends Error {
-  constructor(message, errorUri) {
-    super(message);
+  constructor(message2, errorUri) {
+    super(message2);
     this.errorUri = errorUri;
     this.name = this.constructor.name;
   }
@@ -23991,8 +23991,8 @@ var OAUTH_ERRORS = {
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
 var UnauthorizedError = class extends Error {
-  constructor(message) {
-    super(message ?? "Unauthorized");
+  constructor(message2) {
+    super(message2 ?? "Unauthorized");
   }
 };
 function isClientAuthMethod(method) {
@@ -24532,8 +24532,8 @@ async function registerClient(authorizationServerUrl, { metadata, clientMetadata
 
 // node_modules/eventsource-parser/dist/index.js
 var ParseError = class extends Error {
-  constructor(message, options) {
-    super(message), this.name = "ParseError", this.type = options.type, this.field = options.field, this.value = options.value, this.line = options.line;
+  constructor(message2, options) {
+    super(message2), this.name = "ParseError", this.type = options.type, this.field = options.field, this.value = options.value, this.line = options.line;
   }
 };
 var LF = 10;
@@ -24739,8 +24739,8 @@ var DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
   maxRetries: 2
 };
 var StreamableHTTPError = class extends Error {
-  constructor(code, message) {
-    super(`Streamable HTTP error: ${message}`);
+  constructor(code, message2) {
+    super(`Streamable HTTP error: ${message2}`);
     this.code = code;
   }
 };
@@ -24892,14 +24892,14 @@ var StreamableHTTPClientTransport = class {
           }
           if (!event.event || event.event === "message") {
             try {
-              const message = JSONRPCMessageSchema.parse(JSON.parse(event.data));
-              if (isJSONRPCResultResponse(message)) {
+              const message2 = JSONRPCMessageSchema.parse(JSON.parse(event.data));
+              if (isJSONRPCResultResponse(message2)) {
                 receivedResponse = true;
                 if (replayMessageId !== void 0) {
-                  message.id = replayMessageId;
+                  message2.id = replayMessageId;
                 }
               }
-              this.onmessage?.(message);
+              this.onmessage?.(message2);
             } catch (error2) {
               this.onerror?.(error2);
             }
@@ -24965,11 +24965,11 @@ var StreamableHTTPClientTransport = class {
     this._abortController?.abort();
     this.onclose?.();
   }
-  async send(message, options) {
+  async send(message2, options) {
     try {
       const { resumptionToken, onresumptiontoken } = options || {};
       if (resumptionToken) {
-        this._startOrAuthSse({ resumptionToken, replayMessageId: isJSONRPCRequest(message) ? message.id : void 0 }).catch((err) => this.onerror?.(err));
+        this._startOrAuthSse({ resumptionToken, replayMessageId: isJSONRPCRequest(message2) ? message2.id : void 0 }).catch((err) => this.onerror?.(err));
         return;
       }
       const headers = await this._commonHeaders();
@@ -24979,7 +24979,7 @@ var StreamableHTTPClientTransport = class {
         ...this._requestInit,
         method: "POST",
         headers,
-        body: JSON.stringify(message),
+        body: JSON.stringify(message2),
         signal: this._abortController?.signal
       };
       const response = await (this._fetch ?? fetch)(this._url, init);
@@ -25006,7 +25006,7 @@ var StreamableHTTPClientTransport = class {
             throw new UnauthorizedError();
           }
           this._hasCompletedAuthFlow = true;
-          return this.send(message);
+          return this.send(message2);
         }
         if (response.status === 403 && this._authProvider) {
           const { resourceMetadataUrl, scope, error: error2 } = extractWWWAuthenticateParams(response);
@@ -25031,7 +25031,7 @@ var StreamableHTTPClientTransport = class {
             if (result !== "AUTHORIZED") {
               throw new UnauthorizedError();
             }
-            return this.send(message);
+            return this.send(message2);
           }
         }
         throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
@@ -25040,12 +25040,12 @@ var StreamableHTTPClientTransport = class {
       this._lastUpscopingHeader = void 0;
       if (response.status === 202) {
         await response.body?.cancel();
-        if (isInitializedNotification(message)) {
+        if (isInitializedNotification(message2)) {
           this._startOrAuthSse({ resumptionToken: void 0 }).catch((err) => this.onerror?.(err));
         }
         return;
       }
-      const messages = Array.isArray(message) ? message : [message];
+      const messages = Array.isArray(message2) ? message2 : [message2];
       const hasRequests = messages.filter((msg) => "method" in msg && "id" in msg && msg.id !== void 0).length > 0;
       const contentType = response.headers.get("content-type");
       if (hasRequests) {
@@ -25160,12 +25160,12 @@ function buildGatewayMetadataHeader(chatSessionId) {
     ...encodeStringField(2, GLEAN_PLUGIN),
     ...encodeStringField(3, GLEAN_PLUGIN)
   ];
-  const message = [
+  const message2 = [
     ...encodeStringField(1, GLEAN_PLUGIN),
     ...chatSessionId ? encodeStringField(2, chatSessionId) : [],
     ...encodeMessageField(4, sourceInfo)
   ];
-  return Buffer.from(new Uint8Array(message)).toString("base64");
+  return Buffer.from(new Uint8Array(message2)).toString("base64");
 }
 function loggingFetch(input, init) {
   const method = init?.method ?? "GET";
@@ -25773,8 +25773,8 @@ async function writeApprovalArgsFile(toolName, args) {
 var DEFAULT_FILE_ARG_MAX_BYTES = 1 * 1024 * 1024;
 var defaultHitlTimeoutMs = 3e5;
 var FileArgsError = class extends Error {
-  constructor(message) {
-    super(message);
+  constructor(message2) {
+    super(message2);
     this.name = "FileArgsError";
   }
 };
@@ -25890,7 +25890,7 @@ async function buildApprovalMessage(mcpServer, toolName, args) {
     return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
   }
   const { lines, needsFile } = buildCompactArgs(args);
-  const message = [
+  const message2 = [
     `Action: ${toolName}`,
     "Arguments:",
     ...lines.map((line) => `  ${line}`)
@@ -25898,12 +25898,12 @@ async function buildApprovalMessage(mcpServer, toolName, args) {
   if (needsFile) {
     try {
       const filePath = await writeApprovalArgsFile(toolName, args);
-      message.push(`  Full arguments: ${filePath}`);
+      message2.push(`  Full arguments: ${filePath}`);
     } catch {
-      message.push("  (some arguments truncated; full-args file unavailable)");
+      message2.push("  (some arguments truncated; full-args file unavailable)");
     }
   }
-  return message.join("\n");
+  return message2.join("\n");
 }
 var elicitationIdPrimed = /* @__PURE__ */ new WeakSet();
 function primeElicitationCancellation(mcpServer) {
@@ -25959,7 +25959,7 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
   if (hitlEnabled && toolMeta?.requires_approval && !isCursorClient(mcpServer) && mcpServer.getClientCapabilities()?.elicitation) {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
-      const message = await buildApprovalMessage(
+      const message2 = await buildApprovalMessage(
         mcpServer,
         toolName,
         resolvedArgs
@@ -25969,7 +25969,7 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
       try {
         const result = await mcpServer.elicitInput(
           {
-            message,
+            message: message2,
             requestedSchema: { type: "object", properties: {} }
           },
           { timeout }
@@ -26013,6 +26013,379 @@ function buildRemoteArgs(serverId, toolName, resolvedArgs) {
 }
 function runToolAnnotations(enableHitl, clientSupportsElicitation, isCursor) {
   return enableHitl && clientSupportsElicitation && !isCursor ? { readOnlyHint: true } : void 0;
+}
+
+// src/skills-catalog.ts
+var import_yaml2 = __toESM(require_dist2(), 1);
+import { createHash } from "node:crypto";
+import { isUtf8 } from "node:buffer";
+
+// src/zip.ts
+import { inflateRawSync } from "node:zlib";
+var EOCD_SIG = 101010256;
+var CD_ENTRY_SIG = 33639248;
+var LOCAL_SIG = 67324752;
+var MAX_COMMENT = 65535;
+function isZip(buf) {
+  return buf.length >= 4 && buf.readUInt32LE(0) === LOCAL_SIG;
+}
+function unzip(buf) {
+  const eocd = findEocd(buf);
+  const totalEntries = buf.readUInt16LE(eocd + 10);
+  const cdOffset = buf.readUInt32LE(eocd + 16);
+  if (totalEntries === 65535 || cdOffset === 4294967295) {
+    throw new Error("zip64 archives are not supported");
+  }
+  const files = /* @__PURE__ */ new Map();
+  let p = cdOffset;
+  for (let i = 0; i < totalEntries; i++) {
+    if (p + 46 > buf.length || buf.readUInt32LE(p) !== CD_ENTRY_SIG) {
+      throw new Error(`malformed zip: bad central directory entry ${i}`);
+    }
+    const method = buf.readUInt16LE(p + 10);
+    const compSize = buf.readUInt32LE(p + 20);
+    const uncompSize = buf.readUInt32LE(p + 24);
+    const nameLen = buf.readUInt16LE(p + 28);
+    const extraLen = buf.readUInt16LE(p + 30);
+    const commentLen = buf.readUInt16LE(p + 32);
+    const localOffset = buf.readUInt32LE(p + 42);
+    const name = buf.subarray(p + 46, p + 46 + nameLen).toString("utf-8");
+    p += 46 + nameLen + extraLen + commentLen;
+    if (name.endsWith("/")) continue;
+    if (compSize === 4294967295 || uncompSize === 4294967295) {
+      throw new Error(`zip64 entry is not supported: ${name}`);
+    }
+    if (localOffset + 30 > buf.length) {
+      throw new Error(`malformed zip: local header out of range for ${name}`);
+    }
+    const localNameLen = buf.readUInt16LE(localOffset + 26);
+    const localExtraLen = buf.readUInt16LE(localOffset + 28);
+    const start = localOffset + 30 + localNameLen + localExtraLen;
+    if (start + compSize > buf.length) {
+      throw new Error(`malformed zip: truncated entry ${name}`);
+    }
+    const raw = buf.subarray(start, start + compSize);
+    if (method === 0) {
+      files.set(name, Buffer.from(raw));
+    } else if (method === 8) {
+      files.set(name, inflateRawSync(raw));
+    } else {
+      throw new Error(
+        `unsupported zip compression method ${method} for ${name}`
+      );
+    }
+  }
+  return files;
+}
+function findEocd(buf) {
+  const start = Math.max(0, buf.length - (MAX_COMMENT + 22));
+  for (let i = buf.length - 22; i >= start; i--) {
+    if (buf.readUInt32LE(i) === EOCD_SIG) return i;
+  }
+  throw new Error("malformed zip: end-of-central-directory record not found");
+}
+
+// src/skills-catalog.ts
+var SKILLS_CAPABILITY = "io.modelcontextprotocol/skills";
+var URI_PREFIX = "skill://glean/";
+var PAGE_SIZE = 10;
+var MAX_SKILL_MD_BYTES = 256 * 1024;
+var MAX_FILE_BYTES = 1024 * 1024;
+var MAX_SKILL_BYTES = 5 * 1024 * 1024;
+var MAX_FILES = 100;
+var MAX_CRAWL_PAGES = 10;
+function createSkillsCatalog(deps) {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const entries = /* @__PURE__ */ new Map();
+  const resources = /* @__PURE__ */ new Map();
+  const skillIdByName = /* @__PURE__ */ new Map();
+  let crawled = false;
+  async function apiGet(pathAndQuery) {
+    const auth2 = deps.getAuth();
+    if (!auth2) throw new NotSignedInError();
+    const res = await doFetch(`${auth2.origin}${pathAndQuery}`, {
+      headers: {
+        Authorization: `Bearer ${auth2.token}`,
+        "X-Glean-Include-Experimental": "true",
+        Accept: "*/*"
+      }
+    });
+    if (!res.ok) {
+      throw new Error(`GET ${pathAndQuery} failed: ${res.status}`);
+    }
+    return res;
+  }
+  async function fetchPage(cursor) {
+    const params = new URLSearchParams({ page_size: String(PAGE_SIZE) });
+    if (cursor) params.set("cursor", cursor);
+    const res = await apiGet(`/api/skills?${params.toString()}`);
+    const body = await res.json();
+    return {
+      skills: Array.isArray(body.skills) ? body.skills : [],
+      nextCursor: body.has_more && body.next_cursor ? body.next_cursor : void 0
+    };
+  }
+  async function fetchBundle(skillId) {
+    const res = await apiGet(
+      `/api/skills/${encodeURIComponent(skillId)}/content`
+    );
+    const buf = Buffer.from(await res.arrayBuffer());
+    return isZip(buf) ? unzip(buf) : /* @__PURE__ */ new Map([["SKILL.md", buf]]);
+  }
+  function cache(entry, files) {
+    entries.set(entry.uri, entry);
+    for (const file of files) resources.set(file.uri, file);
+  }
+  async function loadSkill(skill) {
+    if (skill.status && skill.status !== "ENABLED") {
+      deps.log("skills.skipped", { id: skill.id, reason: skill.status });
+      return void 0;
+    }
+    let bundle;
+    try {
+      bundle = await fetchBundle(skill.id);
+    } catch (err) {
+      deps.log("skills.bundle-failed", { id: skill.id, msg: message(err) });
+      return void 0;
+    }
+    const built = buildSkillEntry(skill, bundle, deps.log);
+    if (!built) return void 0;
+    const owner = skillIdByName.get(built.name);
+    if (owner && owner !== skill.id) {
+      deps.log("skills.duplicate-name", { id: skill.id, name: built.name });
+      return void 0;
+    }
+    skillIdByName.set(built.name, skill.id);
+    cache(built.entry, built.files);
+    return built.entry;
+  }
+  async function list(cursor) {
+    const page = await fetchPage(cursor);
+    const loaded = await Promise.all(
+      page.skills.map((skill) => loadSkill(skill).catch(() => void 0))
+    );
+    const skills = loaded.filter((e) => !!e);
+    deps.log("skills-list.served", {
+      requested: page.skills.length,
+      served: skills.length,
+      hasMore: !!page.nextCursor
+    });
+    return { skills, nextCursor: page.nextCursor };
+  }
+  async function crawl() {
+    let cursor;
+    try {
+      for (let page = 0; page < MAX_CRAWL_PAGES; page++) {
+        const res = await list(cursor);
+        cursor = res.nextCursor;
+        if (!cursor) break;
+      }
+    } catch (err) {
+      if (err instanceof NotSignedInError) {
+        throw new McpError(ErrorCode.InvalidRequest, err.message);
+      }
+      throw err;
+    }
+    crawled = true;
+  }
+  return {
+    list,
+    async get(uri) {
+      const hit = entries.get(uri);
+      if (hit) return hit;
+      if (!crawled) await crawl();
+      const entry = entries.get(uri);
+      if (!entry) {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown skill: ${uri}`);
+      }
+      return entry;
+    },
+    async read(uri) {
+      const hit = resources.get(uri);
+      if (hit) return hit;
+      if (!crawled) await crawl();
+      const resource = resources.get(uri);
+      if (!resource) {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown resource: ${uri}`);
+      }
+      return resource;
+    },
+    // ponytail: only what this process has already listed. Enumerating every
+    // skill here would mean downloading every bundle on the host's startup
+    // resources/list — the skills flow (skills/list → resources/read) never
+    // needs it.
+    listResources() {
+      return [...resources.values()].map((r) => ({
+        uri: r.uri,
+        digest: digestOf(r.bytes)
+      }));
+    }
+  };
+}
+var NotSignedInError = class extends Error {
+  constructor() {
+    super("Glean is not configured or not signed in \u2014 run the `setup` tool.");
+  }
+};
+function buildSkillEntry(skill, bundle, log) {
+  const files = normalizeBundle(bundle);
+  const skillMd = files.get("SKILL.md");
+  if (!skillMd) {
+    log("skills.no-skill-md", { id: skill.id });
+    return void 0;
+  }
+  if (skillMd.length > MAX_SKILL_MD_BYTES) {
+    log("skills.skill-md-too-large", { id: skill.id, bytes: skillMd.length });
+    return void 0;
+  }
+  const frontmatter = parseFrontmatter2(skillMd.toString("utf-8"));
+  const name = resolveSkillName(frontmatter.name, skill);
+  frontmatter.name = name;
+  if (typeof frontmatter.description !== "string" || !frontmatter.description) {
+    frontmatter.description = skill.description ?? "";
+  }
+  const resources = [];
+  let total = 0;
+  for (const [relPath, bytes] of files) {
+    if (bytes.length > MAX_FILE_BYTES) {
+      log("skills.file-too-large", { id: skill.id, path: relPath });
+      continue;
+    }
+    if (resources.length >= MAX_FILES) {
+      log("skills.file-count-capped", { id: skill.id, path: relPath });
+      continue;
+    }
+    total += bytes.length;
+    if (total > MAX_SKILL_BYTES) {
+      log("skills.bundle-too-large", { id: skill.id, bytes: total });
+      return void 0;
+    }
+    resources.push({
+      uri: `${URI_PREFIX}${name}/${relPath}`,
+      bytes,
+      mimeType: mimeTypeFor(relPath, bytes)
+    });
+  }
+  const uri = `${URI_PREFIX}${name}/SKILL.md`;
+  return {
+    name,
+    entry: {
+      uri,
+      frontmatter,
+      resources: resources.map((r) => ({
+        uri: r.uri,
+        digest: digestOf(r.bytes)
+      }))
+    },
+    files: resources
+  };
+}
+function normalizeBundle(bundle) {
+  const safe = /* @__PURE__ */ new Map();
+  for (const [rawPath, bytes] of bundle) {
+    const relPath = rawPath.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (!relPath || relPath.split("/").includes("..")) continue;
+    safe.set(relPath, bytes);
+  }
+  if (safe.has("SKILL.md")) return safe;
+  const paths = [...safe.keys()];
+  const prefix = paths[0]?.includes("/") ? `${paths[0].split("/")[0]}/` : "";
+  if (!prefix || !paths.every((p) => p.startsWith(prefix))) return safe;
+  return new Map(
+    paths.map((p) => [p.slice(prefix.length), safe.get(p)])
+  );
+}
+function digestOf(bytes) {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+function parseFrontmatter2(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  try {
+    const parsed = import_yaml2.default.parse(match[1]);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return JSON.parse(JSON.stringify(parsed));
+  } catch {
+    return {};
+  }
+}
+var SAFE_NAME = /^[a-z0-9][a-z0-9._-]*$/;
+function resolveSkillName(frontmatterName, skill) {
+  if (typeof frontmatterName === "string" && SAFE_NAME.test(frontmatterName)) {
+    return frontmatterName;
+  }
+  const fallback = typeof frontmatterName === "string" && frontmatterName ? frontmatterName : skill.display_name || skill.id;
+  return fallback.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^[-.]+|-+$/g, "").slice(0, 64) || skill.id;
+}
+function mimeTypeFor(relPath, bytes) {
+  const ext = relPath.slice(relPath.lastIndexOf(".")).toLowerCase();
+  switch (ext) {
+    case ".md":
+      return "text/markdown";
+    case ".json":
+      return "application/json";
+    case ".yaml":
+    case ".yml":
+      return "application/yaml";
+    case ".txt":
+      return "text/plain";
+    case ".csv":
+      return "text/csv";
+    default:
+      return isUtf8(bytes) ? "text/plain" : "application/octet-stream";
+  }
+}
+function message(err) {
+  return err instanceof Error ? err.message : String(err);
+}
+var SkillsListRequestSchema = RequestSchema.extend({
+  method: literal("skills/list"),
+  params: looseObject({ cursor: string2().optional() }).optional()
+});
+var SkillsGetRequestSchema = RequestSchema.extend({
+  method: literal("skills/get"),
+  params: looseObject({ uri: string2() })
+});
+function registerSkillsExtension(server2, deps) {
+  const catalog = createSkillsCatalog(deps);
+  server2.setRequestHandler(SkillsListRequestSchema, async (request) => {
+    try {
+      const page = await catalog.list(request.params?.cursor);
+      return { skills: page.skills, nextCursor: page.nextCursor };
+    } catch (err) {
+      if (err instanceof NotSignedInError) {
+        deps.log("skills-list.not-signed-in");
+        return { skills: [] };
+      }
+      deps.log("skills-list.failed", { msg: message(err) });
+      throw err instanceof McpError ? err : new McpError(ErrorCode.InternalError, message(err));
+    }
+  });
+  server2.setRequestHandler(SkillsGetRequestSchema, async (request) => {
+    return { skill: await catalog.get(request.params.uri) };
+  });
+  server2.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: catalog.listResources().map((r) => ({
+      uri: r.uri,
+      name: r.uri.slice(URI_PREFIX.length)
+    }))
+  }));
+  server2.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const resource = await catalog.read(request.params.uri);
+    const isText = resource.mimeType !== "application/octet-stream" && isUtf8(resource.bytes);
+    return {
+      contents: [
+        {
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          ...isText ? { text: resource.bytes.toString("utf-8") } : { blob: resource.bytes.toString("base64") }
+        }
+      ]
+    };
+  });
+  return catalog;
 }
 
 // src/url-config-store.ts
@@ -26340,7 +26713,15 @@ function resolveSkillsBaseDir() {
 }
 var server = new Server(
   { name: "glean", version: "1.0.0" },
-  { capabilities: { tools: { listChanged: true } } }
+  {
+    capabilities: {
+      tools: { listChanged: true },
+      // `resources` is required to register resources/read, which the skills
+      // extension uses to serve SKILL.md and its supporting files.
+      resources: {},
+      extensions: { [SKILLS_CAPABILITY]: {} }
+    }
+  }
 );
 var oauthProvider;
 var cachedRemoteTools = loadRemoteTools(resolveServerUrl() ?? "");
@@ -26357,6 +26738,15 @@ function getOAuthProvider() {
 function getRemoteClientOpts() {
   return { authProvider: getOAuthProvider() };
 }
+registerSkillsExtension(server, {
+  getAuth: () => {
+    const serverUrl = resolveServerUrl();
+    const token = getOAuthProvider().tokens()?.access_token;
+    if (!serverUrl || !token) return void 0;
+    return { origin: new URL(serverUrl).origin, token };
+  },
+  log: logLine
+});
 var FIND_SKILLS_TOOL = {
   name: "find_skills",
   annotations: { readOnlyHint: true },

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ import {
 } from "./tools/run-tool.js";
 import { evictStaleSkills } from "./skill-writer.js";
 import {
+  SKILLS_CAPABILITY,
+  registerSkillsExtension,
+} from "./skills-catalog.js";
+import {
   loadServerUrl,
   saveServerUrl,
   clearServerUrl,
@@ -127,7 +131,15 @@ function resolveSkillsBaseDir(): string {
 
 const server = new Server(
   { name: "glean", version: "1.0.0" },
-  { capabilities: { tools: { listChanged: true } } },
+  {
+    capabilities: {
+      tools: { listChanged: true },
+      // `resources` is required to register resources/read, which the skills
+      // extension uses to serve SKILL.md and its supporting files.
+      resources: {},
+      extensions: { [SKILLS_CAPABILITY]: {} },
+    },
+  },
 );
 
 let oauthProvider: GleanOAuthClientProvider | undefined;
@@ -163,6 +175,20 @@ function getOAuthProvider(): GleanOAuthClientProvider {
 function getRemoteClientOpts(): RemoteClientOptions {
   return { authProvider: getOAuthProvider() };
 }
+
+// Glean-hosted skills, served over the MCP skills extension for hosts that
+// import skills from the server (e.g. ChatGPT plugins) instead of from the
+// packaged plugin directory. Unconfigured/signed-out sessions serve an empty
+// catalog; `setup` is still the only path that drives OAuth.
+registerSkillsExtension(server, {
+  getAuth: () => {
+    const serverUrl = resolveServerUrl();
+    const token = getOAuthProvider().tokens()?.access_token;
+    if (!serverUrl || !token) return undefined;
+    return { origin: new URL(serverUrl).origin, token };
+  },
+  log: logLine,
+});
 
 const FIND_SKILLS_TOOL: Tool = {
   name: "find_skills",

--- a/src/skills-catalog.ts
+++ b/src/skills-catalog.ts
@@ -1,0 +1,489 @@
+// MCP skills extension (`io.modelcontextprotocol/skills`, draft SEP-2640),
+// backed by Glean's Platform Skills API.
+//
+// Hosts that support the extension (e.g. ChatGPT's plugin importer) call
+// `skills/list` to get a catalog of skills, each entry naming its SKILL.md
+// plus every supporting resource with a sha256 digest, then `resources/read`
+// to fetch the bytes. We build that catalog from:
+//
+//   GET /api/skills                  → skill metadata, cursor-paginated
+//   GET /api/skills/{id}/content     → the installable bundle (zip or a bare
+//                                      SKILL.md)
+//
+// Both are experimental Platform APIs, so requests carry
+// `X-Glean-Include-Experimental: true`. Auth reuses the OAuth access token
+// `setup` already captured — the Platform API lives on the same origin as the
+// MCP gateway and takes the same bearer token.
+import { createHash } from "node:crypto";
+import { isUtf8 } from "node:buffer";
+import yaml from "yaml";
+// Match the MCP SDK's own zod entrypoint (`zod/v4`) so the bundle carries one
+// copy of zod, not two.
+import * as z from "zod/v4";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ErrorCode,
+  McpError,
+  RequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { isZip, unzip } from "./zip.js";
+
+export const SKILLS_CAPABILITY = "io.modelcontextprotocol/skills";
+
+/** `skill://<server>/<skill-name>/<path>` — the dir must match the skill name. */
+const URI_PREFIX = "skill://glean/";
+
+const PAGE_SIZE = 10;
+
+// Import limits from the MCP-skills spec. Anything over is dropped (and
+// logged) here rather than failing the whole catalog on the importer side.
+const MAX_SKILL_MD_BYTES = 256 * 1024;
+const MAX_FILE_BYTES = 1024 * 1024;
+const MAX_SKILL_BYTES = 5 * 1024 * 1024;
+const MAX_FILES = 100;
+
+// Bound the crawl a `resources/read` cache miss can trigger (see read()).
+const MAX_CRAWL_PAGES = 10;
+
+type LogFn = (label: string, detail?: Record<string, unknown>) => void;
+
+export interface CatalogAuth {
+  /** Glean backend origin, e.g. `https://acme-be.glean.com`. */
+  origin: string;
+  /** OAuth access token captured by `setup`. */
+  token: string;
+}
+
+export interface CatalogDeps {
+  /** Undefined when Glean is unconfigured or the user isn't signed in. */
+  getAuth: () => CatalogAuth | undefined;
+  log: LogFn;
+  fetchImpl?: typeof fetch;
+}
+
+export interface SkillResourceRef {
+  uri: string;
+  digest: string;
+}
+
+export interface SkillCatalogEntry {
+  uri: string;
+  frontmatter: Record<string, unknown>;
+  resources: SkillResourceRef[];
+}
+
+interface CachedResource {
+  uri: string;
+  bytes: Buffer;
+  mimeType: string;
+}
+
+interface PlatformSkill {
+  id: string;
+  display_name?: string;
+  description?: string;
+  status?: string;
+}
+
+export interface SkillsCatalog {
+  list(cursor?: string): Promise<{
+    skills: SkillCatalogEntry[];
+    nextCursor?: string;
+  }>;
+  get(uri: string): Promise<SkillCatalogEntry>;
+  read(uri: string): Promise<CachedResource>;
+  listResources(): SkillResourceRef[];
+}
+
+export function createSkillsCatalog(deps: CatalogDeps): SkillsCatalog {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const entries = new Map<string, SkillCatalogEntry>(); // SKILL.md uri → entry
+  const resources = new Map<string, CachedResource>(); // resource uri → bytes
+  const skillIdByName = new Map<string, string>();
+  let crawled = false;
+
+  async function apiGet(pathAndQuery: string): Promise<Response> {
+    const auth = deps.getAuth();
+    if (!auth) throw new NotSignedInError();
+    const res = await doFetch(`${auth.origin}${pathAndQuery}`, {
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        "X-Glean-Include-Experimental": "true",
+        Accept: "*/*",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`GET ${pathAndQuery} failed: ${res.status}`);
+    }
+    return res;
+  }
+
+  async function fetchPage(
+    cursor?: string,
+  ): Promise<{ skills: PlatformSkill[]; nextCursor?: string }> {
+    const params = new URLSearchParams({ page_size: String(PAGE_SIZE) });
+    if (cursor) params.set("cursor", cursor);
+    const res = await apiGet(`/api/skills?${params.toString()}`);
+    const body = (await res.json()) as {
+      skills?: PlatformSkill[];
+      has_more?: boolean;
+      next_cursor?: string | null;
+    };
+    return {
+      skills: Array.isArray(body.skills) ? body.skills : [],
+      nextCursor:
+        body.has_more && body.next_cursor ? body.next_cursor : undefined,
+    };
+  }
+
+  async function fetchBundle(skillId: string): Promise<Map<string, Buffer>> {
+    const res = await apiGet(
+      `/api/skills/${encodeURIComponent(skillId)}/content`,
+    );
+    const buf = Buffer.from(await res.arrayBuffer());
+    // A single-file skill can come back as a bare SKILL.md rather than an
+    // archive.
+    return isZip(buf) ? unzip(buf) : new Map([["SKILL.md", buf]]);
+  }
+
+  /** Cache an entry + its bytes, so `resources/read` needs no refetch. */
+  function cache(entry: SkillCatalogEntry, files: CachedResource[]): void {
+    entries.set(entry.uri, entry);
+    for (const file of files) resources.set(file.uri, file);
+  }
+
+  async function loadSkill(
+    skill: PlatformSkill,
+  ): Promise<SkillCatalogEntry | undefined> {
+    if (skill.status && skill.status !== "ENABLED") {
+      deps.log("skills.skipped", { id: skill.id, reason: skill.status });
+      return undefined;
+    }
+    let bundle: Map<string, Buffer>;
+    try {
+      bundle = await fetchBundle(skill.id);
+    } catch (err) {
+      deps.log("skills.bundle-failed", { id: skill.id, msg: message(err) });
+      return undefined;
+    }
+    const built = buildSkillEntry(skill, bundle, deps.log);
+    if (!built) return undefined;
+
+    const owner = skillIdByName.get(built.name);
+    if (owner && owner !== skill.id) {
+      // Importers require unique skill names; keep the first one we saw.
+      deps.log("skills.duplicate-name", { id: skill.id, name: built.name });
+      return undefined;
+    }
+    skillIdByName.set(built.name, skill.id);
+    cache(built.entry, built.files);
+    return built.entry;
+  }
+
+  async function list(
+    cursor?: string,
+  ): Promise<{ skills: SkillCatalogEntry[]; nextCursor?: string }> {
+    const page = await fetchPage(cursor);
+    const loaded = await Promise.all(
+      page.skills.map((skill) => loadSkill(skill).catch(() => undefined)),
+    );
+    const skills = loaded.filter((e): e is SkillCatalogEntry => !!e);
+    deps.log("skills-list.served", {
+      requested: page.skills.length,
+      served: skills.length,
+      hasMore: !!page.nextCursor,
+    });
+    return { skills, nextCursor: page.nextCursor };
+  }
+
+  /**
+   * Walk every page once. Only used to recover from a `resources/read` for a
+   * URI this process never listed (e.g. the host reconnected between
+   * `skills/list` and the reads).
+   */
+  async function crawl(): Promise<void> {
+    let cursor: string | undefined;
+    try {
+      for (let page = 0; page < MAX_CRAWL_PAGES; page++) {
+        const res = await list(cursor);
+        cursor = res.nextCursor;
+        if (!cursor) break;
+      }
+    } catch (err) {
+      if (err instanceof NotSignedInError) {
+        throw new McpError(ErrorCode.InvalidRequest, err.message);
+      }
+      throw err;
+    }
+    crawled = true;
+  }
+
+  return {
+    list,
+
+    async get(uri: string): Promise<SkillCatalogEntry> {
+      const hit = entries.get(uri);
+      if (hit) return hit;
+      if (!crawled) await crawl();
+      const entry = entries.get(uri);
+      if (!entry) {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown skill: ${uri}`);
+      }
+      return entry;
+    },
+
+    async read(uri: string): Promise<CachedResource> {
+      const hit = resources.get(uri);
+      if (hit) return hit;
+      if (!crawled) await crawl();
+      const resource = resources.get(uri);
+      if (!resource) {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown resource: ${uri}`);
+      }
+      return resource;
+    },
+
+    // ponytail: only what this process has already listed. Enumerating every
+    // skill here would mean downloading every bundle on the host's startup
+    // resources/list — the skills flow (skills/list → resources/read) never
+    // needs it.
+    listResources(): SkillResourceRef[] {
+      return [...resources.values()].map((r) => ({
+        uri: r.uri,
+        digest: digestOf(r.bytes),
+      }));
+    },
+  };
+}
+
+class NotSignedInError extends Error {
+  constructor() {
+    super("Glean is not configured or not signed in — run the `setup` tool.");
+  }
+}
+
+/**
+ * Turn a downloaded bundle into a catalog entry plus its resource bytes.
+ * Returns undefined (after logging) for bundles we can't serve.
+ */
+export function buildSkillEntry(
+  skill: PlatformSkill,
+  bundle: Map<string, Buffer>,
+  log: LogFn,
+): { name: string; entry: SkillCatalogEntry; files: CachedResource[] } | undefined {
+  const files = normalizeBundle(bundle);
+  const skillMd = files.get("SKILL.md");
+  if (!skillMd) {
+    log("skills.no-skill-md", { id: skill.id });
+    return undefined;
+  }
+  if (skillMd.length > MAX_SKILL_MD_BYTES) {
+    log("skills.skill-md-too-large", { id: skill.id, bytes: skillMd.length });
+    return undefined;
+  }
+
+  const frontmatter = parseFrontmatter(skillMd.toString("utf-8"));
+  const name = resolveSkillName(frontmatter.name, skill);
+  frontmatter.name = name; // the directory in the URI must match the name
+  if (typeof frontmatter.description !== "string" || !frontmatter.description) {
+    frontmatter.description = skill.description ?? "";
+  }
+
+  const resources: CachedResource[] = [];
+  let total = 0;
+  for (const [relPath, bytes] of files) {
+    if (bytes.length > MAX_FILE_BYTES) {
+      log("skills.file-too-large", { id: skill.id, path: relPath });
+      continue;
+    }
+    if (resources.length >= MAX_FILES) {
+      log("skills.file-count-capped", { id: skill.id, path: relPath });
+      continue;
+    }
+    total += bytes.length;
+    if (total > MAX_SKILL_BYTES) {
+      log("skills.bundle-too-large", { id: skill.id, bytes: total });
+      return undefined;
+    }
+    resources.push({
+      uri: `${URI_PREFIX}${name}/${relPath}`,
+      bytes,
+      mimeType: mimeTypeFor(relPath, bytes),
+    });
+  }
+
+  const uri = `${URI_PREFIX}${name}/SKILL.md`;
+  return {
+    name,
+    entry: {
+      uri,
+      frontmatter,
+      resources: resources.map((r) => ({
+        uri: r.uri,
+        digest: digestOf(r.bytes),
+      })),
+    },
+    files: resources,
+  };
+}
+
+/**
+ * Bundles may wrap their files in a single top-level directory. Strip it so
+ * SKILL.md sits at the root, and drop anything that escapes the bundle.
+ */
+export function normalizeBundle(
+  bundle: Map<string, Buffer>,
+): Map<string, Buffer> {
+  const safe = new Map<string, Buffer>();
+  for (const [rawPath, bytes] of bundle) {
+    const relPath = rawPath.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (!relPath || relPath.split("/").includes("..")) continue;
+    safe.set(relPath, bytes);
+  }
+  if (safe.has("SKILL.md")) return safe;
+
+  const paths = [...safe.keys()];
+  const prefix = paths[0]?.includes("/") ? `${paths[0].split("/")[0]}/` : "";
+  if (!prefix || !paths.every((p) => p.startsWith(prefix))) return safe;
+  return new Map(
+    paths.map((p) => [p.slice(prefix.length), safe.get(p) as Buffer]),
+  );
+}
+
+export function digestOf(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  try {
+    const parsed = yaml.parse(match[1]);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    // Round-trip so dates and other YAML scalars land on the wire as JSON.
+    return JSON.parse(JSON.stringify(parsed)) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+const SAFE_NAME = /^[a-z0-9][a-z0-9._-]*$/;
+
+function resolveSkillName(
+  frontmatterName: unknown,
+  skill: PlatformSkill,
+): string {
+  if (typeof frontmatterName === "string" && SAFE_NAME.test(frontmatterName)) {
+    return frontmatterName;
+  }
+  const fallback =
+    typeof frontmatterName === "string" && frontmatterName
+      ? frontmatterName
+      : skill.display_name || skill.id;
+  return (
+    fallback
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^[-.]+|-+$/g, "")
+      .slice(0, 64) || skill.id
+  );
+}
+
+function mimeTypeFor(relPath: string, bytes: Buffer): string {
+  const ext = relPath.slice(relPath.lastIndexOf(".")).toLowerCase();
+  switch (ext) {
+    case ".md":
+      return "text/markdown";
+    case ".json":
+      return "application/json";
+    case ".yaml":
+    case ".yml":
+      return "application/yaml";
+    case ".txt":
+      return "text/plain";
+    case ".csv":
+      return "text/csv";
+    default:
+      return isUtf8(bytes) ? "text/plain" : "application/octet-stream";
+  }
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export const SkillsListRequestSchema = RequestSchema.extend({
+  method: z.literal("skills/list"),
+  params: z.looseObject({ cursor: z.string().optional() }).optional(),
+});
+
+export const SkillsGetRequestSchema = RequestSchema.extend({
+  method: z.literal("skills/get"),
+  params: z.looseObject({ uri: z.string() }),
+});
+
+/**
+ * Wire `skills/list`, `skills/get` and `resources/read` onto the server. The
+ * caller must advertise both the `resources` capability and the
+ * `io.modelcontextprotocol/skills` extension for hosts to use these.
+ */
+export function registerSkillsExtension(
+  server: Server,
+  deps: CatalogDeps,
+): SkillsCatalog {
+  const catalog = createSkillsCatalog(deps);
+
+  server.setRequestHandler(SkillsListRequestSchema, async (request) => {
+    try {
+      const page = await catalog.list(request.params?.cursor);
+      return { skills: page.skills, nextCursor: page.nextCursor };
+    } catch (err) {
+      // An unconfigured or signed-out user is the normal state on a fresh
+      // install; an empty catalog beats a protocol error the host surfaces.
+      if (err instanceof NotSignedInError) {
+        deps.log("skills-list.not-signed-in");
+        return { skills: [] };
+      }
+      deps.log("skills-list.failed", { msg: message(err) });
+      throw err instanceof McpError
+        ? err
+        : new McpError(ErrorCode.InternalError, message(err));
+    }
+  });
+
+  server.setRequestHandler(SkillsGetRequestSchema, async (request) => {
+    return { skill: await catalog.get(request.params.uri) };
+  });
+
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: catalog.listResources().map((r) => ({
+      uri: r.uri,
+      name: r.uri.slice(URI_PREFIX.length),
+    })),
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const resource = await catalog.read(request.params.uri);
+    const isText =
+      resource.mimeType !== "application/octet-stream" &&
+      isUtf8(resource.bytes);
+    return {
+      contents: [
+        {
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          ...(isText
+            ? { text: resource.bytes.toString("utf-8") }
+            : { blob: resource.bytes.toString("base64") }),
+        },
+      ],
+    };
+  });
+
+  return catalog;
+}

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,0 +1,85 @@
+// Minimal ZIP reader for skill bundles downloaded from Glean's Platform API
+// (`GET /api/skills/{id}/content` returns a .zip / .skill archive). Node has
+// no stdlib zip reader and the plugin ships as a single bundled file, so a
+// ~60-line central-directory reader beats adding a dependency.
+//
+// ponytail: stored + deflate only, no zip64, no CRC verification. Skill
+// bundles are small text archives; if Glean ever emits zip64 or another
+// compression method we throw a clear error rather than guess.
+import { inflateRawSync } from "node:zlib";
+
+const EOCD_SIG = 0x06054b50;
+const CD_ENTRY_SIG = 0x02014b50;
+const LOCAL_SIG = 0x04034b50;
+const MAX_COMMENT = 0xffff;
+
+export function isZip(buf: Buffer): boolean {
+  return buf.length >= 4 && buf.readUInt32LE(0) === LOCAL_SIG;
+}
+
+/**
+ * Extract every file entry from a ZIP archive. Returns a map of
+ * slash-separated entry path to raw bytes. Directory entries are skipped.
+ */
+export function unzip(buf: Buffer): Map<string, Buffer> {
+  const eocd = findEocd(buf);
+  const totalEntries = buf.readUInt16LE(eocd + 10);
+  const cdOffset = buf.readUInt32LE(eocd + 16);
+  if (totalEntries === 0xffff || cdOffset === 0xffffffff) {
+    throw new Error("zip64 archives are not supported");
+  }
+
+  const files = new Map<string, Buffer>();
+  let p = cdOffset;
+  for (let i = 0; i < totalEntries; i++) {
+    if (p + 46 > buf.length || buf.readUInt32LE(p) !== CD_ENTRY_SIG) {
+      throw new Error(`malformed zip: bad central directory entry ${i}`);
+    }
+    const method = buf.readUInt16LE(p + 10);
+    const compSize = buf.readUInt32LE(p + 20);
+    const uncompSize = buf.readUInt32LE(p + 24);
+    const nameLen = buf.readUInt16LE(p + 28);
+    const extraLen = buf.readUInt16LE(p + 30);
+    const commentLen = buf.readUInt16LE(p + 32);
+    const localOffset = buf.readUInt32LE(p + 42);
+    const name = buf.subarray(p + 46, p + 46 + nameLen).toString("utf-8");
+    p += 46 + nameLen + extraLen + commentLen;
+
+    if (name.endsWith("/")) continue;
+    if (compSize === 0xffffffff || uncompSize === 0xffffffff) {
+      throw new Error(`zip64 entry is not supported: ${name}`);
+    }
+
+    // Data sits after the *local* header, whose extra field can differ in
+    // length from the central directory's, so read the length from there.
+    if (localOffset + 30 > buf.length) {
+      throw new Error(`malformed zip: local header out of range for ${name}`);
+    }
+    const localNameLen = buf.readUInt16LE(localOffset + 26);
+    const localExtraLen = buf.readUInt16LE(localOffset + 28);
+    const start = localOffset + 30 + localNameLen + localExtraLen;
+    if (start + compSize > buf.length) {
+      throw new Error(`malformed zip: truncated entry ${name}`);
+    }
+    const raw = buf.subarray(start, start + compSize);
+
+    if (method === 0) {
+      files.set(name, Buffer.from(raw));
+    } else if (method === 8) {
+      files.set(name, inflateRawSync(raw));
+    } else {
+      throw new Error(
+        `unsupported zip compression method ${method} for ${name}`,
+      );
+    }
+  }
+  return files;
+}
+
+function findEocd(buf: Buffer): number {
+  const start = Math.max(0, buf.length - (MAX_COMMENT + 22));
+  for (let i = buf.length - 22; i >= start; i--) {
+    if (buf.readUInt32LE(i) === EOCD_SIG) return i;
+  }
+  throw new Error("malformed zip: end-of-central-directory record not found");
+}

--- a/tests/skills-catalog.test.ts
+++ b/tests/skills-catalog.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { deflateRawSync } from "node:zlib";
+import {
+  createSkillsCatalog,
+  normalizeBundle,
+  digestOf,
+} from "../src/skills-catalog.js";
+import { unzip, isZip } from "../src/zip.js";
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (const b of buf) {
+    let c = (crc ^ b) & 0xff;
+    for (let k = 0; k < 8; k++) c = c & 1 ? (c >>> 1) ^ 0xedb88320 : c >>> 1;
+    crc = (crc >>> 8) ^ c;
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** Build a real ZIP so the reader is exercised end to end. */
+function makeZip(entries: [string, string, number][]): Buffer {
+  const locals: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const [name, content, method] of entries) {
+    const raw = Buffer.from(content);
+    const data = method === 8 ? deflateRawSync(raw) : raw;
+    const nameBuf = Buffer.from(name);
+    const lh = Buffer.alloc(30);
+    lh.writeUInt32LE(0x04034b50, 0);
+    lh.writeUInt16LE(20, 4);
+    lh.writeUInt16LE(method, 8);
+    lh.writeUInt32LE(crc32(raw), 14);
+    lh.writeUInt32LE(data.length, 18);
+    lh.writeUInt32LE(raw.length, 22);
+    lh.writeUInt16LE(nameBuf.length, 26);
+    locals.push(lh, nameBuf, data);
+
+    const cd = Buffer.alloc(46);
+    cd.writeUInt32LE(0x02014b50, 0);
+    cd.writeUInt16LE(20, 6);
+    cd.writeUInt16LE(method, 10);
+    cd.writeUInt32LE(crc32(raw), 16);
+    cd.writeUInt32LE(data.length, 20);
+    cd.writeUInt32LE(raw.length, 24);
+    cd.writeUInt16LE(nameBuf.length, 28);
+    cd.writeUInt32LE(offset, 42);
+    central.push(cd, nameBuf);
+    offset += 30 + nameBuf.length + data.length;
+  }
+  const localBuf = Buffer.concat(locals);
+  const cdBuf = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cdBuf.length, 12);
+  eocd.writeUInt32LE(localBuf.length, 16);
+  return Buffer.concat([localBuf, cdBuf, eocd]);
+}
+
+const SKILL_MD =
+  "---\nname: search-jira\ndescription: Search Jira issues\nallowed-tools:\n  - Read\n---\n# Search Jira\n";
+
+interface StubOptions {
+  pages?: {
+    skills: unknown[];
+    has_more?: boolean;
+    next_cursor?: string | null;
+  }[];
+  bundles?: Record<string, Buffer>;
+}
+
+function stubFetch(opts: StubOptions) {
+  const calls: string[] = [];
+  const pages = opts.pages ?? [];
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const target = String(url);
+    calls.push(target);
+    void init;
+    const contentMatch = target.match(/\/api\/skills\/([^/]+)\/content$/);
+    if (contentMatch) {
+      const bundle = opts.bundles?.[decodeURIComponent(contentMatch[1])];
+      if (!bundle) return new Response(null, { status: 404 });
+      return new Response(new Uint8Array(bundle), { status: 200 });
+    }
+    const cursor = new URL(target).searchParams.get("cursor");
+    const page = cursor ? pages[Number(cursor)] : pages[0];
+    return new Response(JSON.stringify(page ?? { skills: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function catalogWith(opts: StubOptions, signedIn = true) {
+  const { fetchImpl, calls } = stubFetch(opts);
+  const logs: string[] = [];
+  const catalog = createSkillsCatalog({
+    getAuth: () =>
+      signedIn
+        ? { origin: "https://acme-be.glean.com", token: "tok" }
+        : undefined,
+    log: (label) => logs.push(label),
+    fetchImpl,
+  });
+  return { catalog, calls, logs };
+}
+
+describe("unzip", () => {
+  it("reads stored and deflated entries and skips directories", () => {
+    const zip = makeZip([
+      ["SKILL.md", SKILL_MD, 0],
+      ["references/notation.md", "deflate me ".repeat(50), 8],
+      ["refs/", "", 0],
+    ]);
+    expect(isZip(zip)).toBe(true);
+
+    const files = unzip(zip);
+    expect([...files.keys()]).toEqual(["SKILL.md", "references/notation.md"]);
+    expect(files.get("SKILL.md")!.toString()).toBe(SKILL_MD);
+    expect(files.get("references/notation.md")!.toString()).toBe(
+      "deflate me ".repeat(50),
+    );
+  });
+
+  it("rejects a buffer with no end-of-central-directory record", () => {
+    expect(() => unzip(Buffer.from("not a zip at all........"))).toThrow(
+      /end-of-central-directory/,
+    );
+  });
+});
+
+describe("normalizeBundle", () => {
+  it("strips a single wrapping directory", () => {
+    const normalized = normalizeBundle(
+      new Map([
+        ["search-jira/SKILL.md", Buffer.from("a")],
+        ["search-jira/tools/x.json", Buffer.from("b")],
+      ]),
+    );
+    expect([...normalized.keys()]).toEqual(["SKILL.md", "tools/x.json"]);
+  });
+
+  it("drops path traversal entries", () => {
+    const normalized = normalizeBundle(
+      new Map([
+        ["SKILL.md", Buffer.from("a")],
+        ["../escape.md", Buffer.from("b")],
+      ]),
+    );
+    expect([...normalized.keys()]).toEqual(["SKILL.md"]);
+  });
+});
+
+describe("skills catalog", () => {
+  const bundle = makeZip([
+    ["SKILL.md", SKILL_MD, 8],
+    ["references/notation.md", "see the notation", 0],
+  ]);
+
+  const onePage: StubOptions = {
+    pages: [
+      {
+        skills: [
+          {
+            id: "skill-1",
+            display_name: "Search Jira",
+            description: "api description",
+            status: "ENABLED",
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      },
+    ],
+    bundles: { "skill-1": bundle },
+  };
+
+  it("lists skills with frontmatter and digested resources", async () => {
+    const { catalog } = catalogWith(onePage);
+    const page = await catalog.list();
+
+    expect(page.nextCursor).toBeUndefined();
+    expect(page.skills).toHaveLength(1);
+    const entry = page.skills[0];
+    expect(entry.uri).toBe("skill://glean/search-jira/SKILL.md");
+    expect(entry.frontmatter.name).toBe("search-jira");
+    expect(entry.frontmatter.description).toBe("Search Jira issues");
+    // Every frontmatter entry is forwarded, not just name/description.
+    expect(entry.frontmatter["allowed-tools"]).toEqual(["Read"]);
+    expect(entry.resources.map((r) => r.uri)).toEqual([
+      "skill://glean/search-jira/SKILL.md",
+      "skill://glean/search-jira/references/notation.md",
+    ]);
+    const expected = `sha256:${createHash("sha256")
+      .update(Buffer.from(SKILL_MD))
+      .digest("hex")}`;
+    expect(entry.resources[0].digest).toBe(expected);
+  });
+
+  it("serves resource bytes for a listed uri", async () => {
+    const { catalog } = catalogWith(onePage);
+    await catalog.list();
+
+    const resource = await catalog.read(
+      "skill://glean/search-jira/references/notation.md",
+    );
+    expect(resource.bytes.toString()).toBe("see the notation");
+    expect(resource.mimeType).toBe("text/markdown");
+    expect(digestOf(resource.bytes)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("crawls pages when a read misses the cache", async () => {
+    const { catalog, calls } = catalogWith({
+      pages: [
+        {
+          skills: [{ id: "skill-1", status: "ENABLED" }],
+          has_more: true,
+          next_cursor: "1",
+        },
+        { skills: [], has_more: false, next_cursor: null },
+      ],
+      bundles: { "skill-1": bundle },
+    });
+
+    const resource = await catalog.read("skill://glean/search-jira/SKILL.md");
+    expect(resource.bytes.toString()).toBe(SKILL_MD);
+    expect(calls.some((c) => c.includes("cursor=1"))).toBe(true);
+  });
+
+  it("reports an unknown resource once the crawl finds nothing", async () => {
+    const { catalog } = catalogWith(onePage);
+    await expect(catalog.read("skill://glean/nope/SKILL.md")).rejects.toThrow(
+      /Unknown resource/,
+    );
+  });
+
+  it("skips skills that are not enabled and bundles that fail", async () => {
+    const { catalog, logs } = catalogWith({
+      pages: [
+        {
+          skills: [
+            { id: "skill-1", status: "DRAFT" },
+            { id: "missing", status: "ENABLED" },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      ],
+      bundles: {},
+    });
+
+    const page = await catalog.list();
+    expect(page.skills).toEqual([]);
+    expect(logs).toContain("skills.skipped");
+    expect(logs).toContain("skills.bundle-failed");
+  });
+
+  it("passes the cursor through and reports the next one", async () => {
+    const { catalog, calls } = catalogWith({
+      pages: [
+        { skills: [], has_more: true, next_cursor: "1" },
+        { skills: [], has_more: true, next_cursor: "2" },
+      ],
+    });
+
+    const page = await catalog.list("1");
+    expect(page.nextCursor).toBe("2");
+    expect(calls[0]).toContain("cursor=1");
+    expect(calls[0]).toContain("page_size=10");
+  });
+
+  it("sends the bearer token and experimental header", async () => {
+    let seen: Headers | undefined;
+    const catalog = createSkillsCatalog({
+      getAuth: () => ({ origin: "https://acme-be.glean.com", token: "tok" }),
+      log: () => {},
+      fetchImpl: (async (_url: string, init?: RequestInit) => {
+        seen = new Headers(init?.headers);
+        return new Response(JSON.stringify({ skills: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+
+    await catalog.list();
+    expect(seen?.get("authorization")).toBe("Bearer tok");
+    expect(seen?.get("x-glean-include-experimental")).toBe("true");
+  });
+
+  it("fails the list when the user is not signed in", async () => {
+    const { catalog } = catalogWith(onePage, false);
+    await expect(catalog.list()).rejects.toThrow(/setup/);
+  });
+});


### PR DESCRIPTION
Implements OpenAI's [Import skills from the MCP server](https://developers.openai.com/plugins/build/mcp-server#import-skills-from-the-mcp-server) flow, so hosts that import skills from the MCP server (ChatGPT plugins) pick up the skills the signed-in user has in Glean instead of only the one skill packaged under `plugins/glean/skills/`.

Skills come from the experimental [Platform Skills API](https://developers.glean.com/api/platform-api/platform-skills-list): `GET /api/skills` for metadata (cursor-paginated), `GET /api/skills/{id}/content` for the bundle — same origin and bearer token `setup` already captured, with `X-Glean-Include-Experimental: true`.

## Surface

`capabilities.extensions["io.modelcontextprotocol/skills"]` is advertised at initialize, alongside `resources` (required to register `resources/read`).

| Method | Behavior |
| --- | --- |
| `skills/list` | One page (10 skills); `cursor` maps to the Platform API cursor. Each entry: `skill://glean/<name>/SKILL.md` uri, full parsed SKILL.md frontmatter, every bundle file with a `sha256:` digest. |
| `skills/get` | The catalog entry for one SKILL.md uri. |
| `resources/read` | Bytes for any listed uri — `text` for UTF-8, `blob` otherwise. Served from an in-process cache, with a bounded crawl as fallback when the host reads a uri this process never listed. |
| `resources/list` | Only what was already listed, so host startup never triggers bundle downloads. |

Unconfigured or signed-out sessions serve an empty catalog; `setup` remains the only path that drives OAuth. Non-`ENABLED`, oversized (spec import limits: 256 KiB SKILL.md, 1 MiB/file, 5 MiB/skill, 100 files) and duplicate-named skills are skipped and logged to `glean-server.log`.

## Changes

- `src/skills-catalog.ts` — catalog build, caching, and the three handlers
- `src/zip.ts` — minimal central-directory ZIP reader (stored + deflate), so bundles need no new dependency
- `src/index.ts` — capabilities + registration
- `zod` promoted to a direct dependency, imported as `zod/v4` to match the SDK's entrypoint (bundle grows ~25 KB, not ~400 KB)
- README section

## Verification

- `npm run typecheck` clean; `npm test` 201 passing (12 new in `tests/skills-catalog.test.ts`, covering the zip reader, bundle normalization, digests, cursor passthrough, auth headers, skip/crawl paths)
- dist rebuilt and in sync
- End-to-end run of the built server over stdio against a fake Platform API: `skills/list` → `skills/get` → `resources/read`, wrapper directory stripped, advertised digests matching the served bytes

## Notes

- The Platform Skills API is experimental; response shape changes would need a matching update here.
- Not implemented: skills list-changed notifications, zip64/CRC verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)