### PR TITLE
Bake the plugin version into the bundle

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "glean-vnext",
   "displayName": "Glean vNext",
   "version": "0.2.44",
-  "description": "Search and act across your company's apps \u2014 Jira, Slack, Salesforce, Google Workspace, and more \u2014 without leaving Cursor.",
+  "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"
   },

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.43",
-  "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
+  "version": "0.2.44",
+  "description": "Search and act across your company's apps \u2014 Jira, Slack, Salesforce, Google Workspace, and more \u2014 without leaving Cursor.",
   "author": {
     "name": "Glean"
   },

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25127,6 +25127,16 @@ var StreamableHTTPClientTransport = class {
   }
 };
 
+// src/version.ts
+var BUILD_VERSION = true ? "0.2.44" : void 0;
+function pluginVersion() {
+  if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
+  return { version: "0.0.0", source: "unknown" };
+}
+function pluginVersionString() {
+  return pluginVersion().version;
+}
+
 // src/remote-client.ts
 var GLEAN_PLUGIN = "GLEAN_PLUGIN";
 var DEFAULT_REMOTE_TOOL_TIMEOUT_MS = 3e5;
@@ -25241,7 +25251,7 @@ async function createRemoteClient(serverUrl, opts, chatSessionId) {
     await authProvider.invalidateCredentials("all");
   }
   const client = new Client(
-    { name: "glean", version: "1.0.0" },
+    { name: "glean", version: pluginVersionString() },
     { capabilities: {} }
   );
   const transport = buildTransport(serverUrl, opts, chatSessionId);
@@ -26339,7 +26349,7 @@ function resolveSkillsBaseDir() {
   return path7.join(tmpdir(), "glean-skills-cache");
 }
 var server = new Server(
-  { name: "glean", version: "1.0.0" },
+  { name: "glean", version: pluginVersionString() },
   { capabilities: { tools: { listChanged: true } } }
 );
 var oauthProvider;

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -38,31 +38,58 @@ const nodeBuiltins = [
 // Baking it in makes this step load-bearing: a silently absent constant would make
 // every install report an unknown version and disable any version-dependent
 // behaviour fleet-wide, which is a far worse outcome than a red build.
-const MANIFEST = "plugins/glean/.claude-plugin/plugin.json";
+//
+// Every host manifest is read, not just one. Reading a single manifest would bake in
+// whichever host happened to be picked and silently disagree with the others if they
+// ever drifted. scripts/check-version-bump.sh enforces that all three match, but only
+// in CI — a local build has to catch it too, since that is where the constant is made.
+const MANIFESTS = [
+  "plugins/glean/.claude-plugin/plugin.json",
+  "plugins/glean/.codex-plugin/plugin.json",
+  "plugins/glean/.cursor-plugin/plugin.json",
+];
+
+// Same pattern as SEMVER_RE in scripts/check-version-bump.sh, and deliberately stricter
+// than \d+: that would accept a non-canonical "01.02.003", which CI then rejects. The
+// two checks must agree, or a local build can produce a version CI refuses.
+const SEMVER_RE = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
 
 function pluginVersionFromManifest() {
-  let raw;
-  try {
-    raw = JSON.parse(readFileSync(MANIFEST, "utf-8"));
-  } catch (err) {
-    throw new Error(`build: cannot read ${MANIFEST}: ${err.message}`);
-  }
-  const version = raw.version;
-  if (typeof version !== "string" || !/^\d+\.\d+\.\d+$/.test(version)) {
+  const found = MANIFESTS.map((manifest) => {
+    let raw;
+    try {
+      raw = JSON.parse(readFileSync(manifest, "utf-8"));
+    } catch (err) {
+      throw new Error(`build: cannot read ${manifest}: ${err.message}`);
+    }
+    const version = raw.version;
+    if (typeof version !== "string" || !SEMVER_RE.test(version)) {
+      throw new Error(
+        `build: ${manifest} must declare a plain x.y.z version, got ${JSON.stringify(version)}. ` +
+          `The bundled constant is what the plugin reports about itself, so an absent or ` +
+          `malformed value fails the build rather than shipping.`,
+      );
+    }
+    return { manifest, version };
+  });
+
+  const versions = [...new Set(found.map((f) => f.version))];
+  if (versions.length > 1) {
     throw new Error(
-      `build: ${MANIFEST} must declare a plain x.y.z version, got ${JSON.stringify(version)}. ` +
-        `The bundled constant is what the plugin reports about itself, so an absent or ` +
-        `malformed value fails the build rather than shipping.`,
+      `build: plugin manifests disagree on the version, so there is no single value to ` +
+        `bake in:\n` +
+        found.map((f) => `  ${f.version}  ${f.manifest}`).join("\n"),
     );
   }
-  return version;
+  return versions[0];
 }
 
 const pluginVersion = pluginVersionFromManifest();
+const OUTFILE = "plugins/glean/dist/index.js";
 
 await build({
   entryPoints: ["src/index.ts"],
-  outfile: "plugins/glean/dist/index.js",
+  outfile: OUTFILE,
   bundle: true,
   platform: "node",
   format: "esm",
@@ -93,3 +120,29 @@ await build({
   conditions: ["import", "node", "default"],
   mainFields: ["module", "main"],
 });
+
+// Assert on the OUTPUT, not just the manifest that fed it.
+//
+// Validating the manifest proves the value existed; it does not prove the value reached
+// the bundle. If the define ever stops applying -- the identifier renamed in
+// src/version.ts but not here, or the define key dropped in a merge -- the build still
+// succeeds, `dist/` still matches a fresh build so CI's diff check passes, and every
+// install silently reports an unknown version with version enforcement off fleet-wide.
+// That is the failure this whole approach trades for, so it gets a check rather than a
+// comment. CI runs `npm run build`, so this covers CI too, with no separate job.
+const bundled = readFileSync(OUTFILE, "utf-8");
+if (bundled.includes("__GLEAN_PLUGIN_VERSION__")) {
+  throw new Error(
+    `build: ${OUTFILE} still contains the __GLEAN_PLUGIN_VERSION__ placeholder, so the ` +
+      `esbuild define did not substitute it. The bundle would report an unknown version ` +
+      `and disable version-dependent behaviour. Check that the identifier in ` +
+      `src/version.ts matches the define key here.`,
+  );
+}
+if (!bundled.includes(JSON.stringify(pluginVersion))) {
+  throw new Error(
+    `build: ${OUTFILE} does not contain the version literal ${JSON.stringify(pluginVersion)}, ` +
+      `so the plugin has no version baked in.`,
+  );
+}
+console.log(`Baked plugin version ${pluginVersion} into ${OUTFILE}`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,11 +18,47 @@
 
 import { build } from "esbuild";
 import { builtinModules } from "node:module";
+import { readFileSync } from "node:fs";
 
 const nodeBuiltins = [
   ...builtinModules,
   ...builtinModules.map((m) => `node:${m}`),
 ];
+
+// Bake the plugin version into the bundle as a literal.
+//
+// Why at build time rather than read at runtime: the value is what a remote policy
+// uses to decide whether this plugin is outdated, blocked, or unsupported, so it has
+// to be the version of the code that is actually running. A manifest read at runtime
+// reports only what an editable file next to the bundle claims. CI already verifies
+// that `dist/` is in sync with source, so a compiled-in literal cannot drift from the
+// manifest unnoticed.
+//
+// The build FAILS rather than emitting a bundle with a missing or malformed version.
+// Baking it in makes this step load-bearing: a silently absent constant would make
+// every install report an unknown version and disable any version-dependent
+// behaviour fleet-wide, which is a far worse outcome than a red build.
+const MANIFEST = "plugins/glean/.claude-plugin/plugin.json";
+
+function pluginVersionFromManifest() {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(MANIFEST, "utf-8"));
+  } catch (err) {
+    throw new Error(`build: cannot read ${MANIFEST}: ${err.message}`);
+  }
+  const version = raw.version;
+  if (typeof version !== "string" || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+      `build: ${MANIFEST} must declare a plain x.y.z version, got ${JSON.stringify(version)}. ` +
+        `The bundled constant is what the plugin reports about itself, so an absent or ` +
+        `malformed value fails the build rather than shipping.`,
+    );
+  }
+  return version;
+}
+
+const pluginVersion = pluginVersionFromManifest();
 
 await build({
   entryPoints: ["src/index.ts"],
@@ -31,6 +67,10 @@ await build({
   platform: "node",
   format: "esm",
   target: "node20",
+  // Substituted into src/version.ts. JSON.stringify so it lands as a quoted literal.
+  define: {
+    __GLEAN_PLUGIN_VERSION__: JSON.stringify(pluginVersion),
+  },
   // Not setting `packages` — esbuild only accepts `"external"` here, which
   // would ship every dep as a runtime lookup (defeating the purpose). The
   // default when `bundle:true` is to inline every import whose specifier

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
 } from "./tools/remote-passthrough.js";
 import { resolveSessionId } from "./session-id.js";
 import { resolveServerUrlFromEmail } from "./config-search.js";
+import { pluginVersionString } from "./version.js";
 
 function readEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -126,7 +127,7 @@ function resolveSkillsBaseDir(): string {
 }
 
 const server = new Server(
-  { name: "glean", version: "1.0.0" },
+  { name: "glean", version: pluginVersionString() },
   { capabilities: { tools: { listChanged: true } } },
 );
 

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { GleanOAuthClientProvider } from "./auth-provider.js";
+import { pluginVersionString } from "./version.js";
 
 const GLEAN_PLUGIN = "GLEAN_PLUGIN";
 
@@ -185,7 +186,7 @@ export async function createRemoteClient(
   }
 
   const client = new Client(
-    { name: "glean", version: "1.0.0" },
+    { name: "glean", version: pluginVersionString() },
     { capabilities: {} },
   );
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,51 @@
+// The plugin's own version, as a build-time constant.
+//
+// `scripts/build.mjs` substitutes `__GLEAN_PLUGIN_VERSION__` with a literal read from
+// the plugin manifest, and fails the build if that value is missing or is not a plain
+// `x.y.z`. Baking it in is what makes the value trustworthy: the shipped bundle cannot
+// disagree with the release it was built from, and editing a manifest after install
+// does not change what the plugin reports. CI already verifies that `dist/` is in sync
+// with source, so the constant cannot drift from the manifest unnoticed.
+//
+// There is deliberately no runtime fallback to reading a manifest or an environment
+// variable. Both are user-editable, so falling back would turn "the constant is
+// missing" into "here is a version the user can edit". That matters because this value
+// is what a remote policy would use to decide whether a plugin is outdated, blocked,
+// or unsupported: a fallback would be a downgrade path for anyone able to make the
+// constant unreadable. `unknown` is the honest answer, and callers are expected to skip
+// version-dependent behaviour rather than guess.
+declare const __GLEAN_PLUGIN_VERSION__: string | undefined;
+
+/** How the version was obtained, and therefore how far it can be trusted. */
+export type VersionSource = "build" | "unknown";
+
+export interface ResolvedVersion {
+  version: string;
+  source: VersionSource;
+}
+
+// `typeof` on an undeclared identifier is safe in JS and yields "undefined", so a dev
+// run through `tsx` -- where esbuild never applied the define -- resolves to `unknown`
+// instead of throwing a ReferenceError.
+const BUILD_VERSION: string | undefined =
+  typeof __GLEAN_PLUGIN_VERSION__ === "string"
+    ? __GLEAN_PLUGIN_VERSION__
+    : undefined;
+
+/**
+ * The version this build reports, plus whether it is trustworthy.
+ *
+ * `source: "build"` in every shipped release; `source: "unknown"` only for a dev run
+ * or a broken build, where the placeholder version must not be treated as real.
+ */
+export function pluginVersion(): ResolvedVersion {
+  if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
+  // A placeholder rather than an empty string, so callers never have to handle a
+  // missing value; `source` is what signals that the number means nothing.
+  return { version: "0.0.0", source: "unknown" };
+}
+
+/** Convenience for the MCP `serverInfo` / `clientInfo` version field. */
+export function pluginVersionString(): string {
+  return pluginVersion().version;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -35,8 +35,15 @@ const BUILD_VERSION: string | undefined =
 /**
  * The version this build reports, plus whether it is trustworthy.
  *
- * `source: "build"` in every shipped release; `source: "unknown"` only for a dev run
- * or a broken build, where the placeholder version must not be treated as real.
+ * `source: "build"` in every bundle produced by scripts/build.mjs, which fails rather
+ * than emitting one without the constant, and now also asserts the substitution landed
+ * in the output.
+ *
+ * `source: "unknown"` is therefore not a broken-bundle case — it is the path taken when
+ * the code runs without having been bundled at all: `npm run dev` and any other tsx
+ * entry, where esbuild never applied the define. Reachable in development, unreachable
+ * in anything shipped. Callers skip version-dependent behaviour rather than treat the
+ * placeholder as real, which is what makes a dev run enforce no version policy.
  */
 export function pluginVersion(): ResolvedVersion {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { pluginVersion, pluginVersionString } from "../src/version.js";
+
+// These tests run through vitest, which does not apply esbuild's `define`, so the
+// build constant is absent here exactly as it is during a `tsx` dev run. That makes
+// the unknown path the one under test, and it is the path that matters: it must report
+// honestly rather than invent a version.
+describe("pluginVersion", () => {
+  it("reports unknown when no build constant was substituted", () => {
+    expect(pluginVersion()).toEqual({ version: "0.0.0", source: "unknown" });
+  });
+
+  it("does not throw on an undeclared identifier", () => {
+    // `typeof` on a missing global is safe; a bare reference would be a
+    // ReferenceError and would take the whole server down at import time.
+    expect(() => pluginVersion()).not.toThrow();
+  });
+
+  it("exposes a bare string for MCP serverInfo/clientInfo", () => {
+    expect(pluginVersionString()).toBe("0.0.0");
+  });
+});


### PR DESCRIPTION
## Problem

The shipped bundle contains no version of its own. On `main`:

```
$ grep -c "0.2.43" plugins/glean/dist/index.js
0
```

Meanwhile both MCP constructors report a hardcoded `"1.0.0"` that has never matched a release — `src/index.ts:129` and `src/remote-client.ts:188`. The real version lives only in the three host manifests.

So today the plugin cannot tell a remote which version is running, and the version it *does* report is wrong.

## Change

`scripts/build.mjs` reads the version from `.claude-plugin/plugin.json` and substitutes it via esbuild `define` into a new `src/version.ts`. Both constructors now report it, so the version is visible on the MCP handshake in each direction.

After this change:

```
$ grep -c "0.2.44" plugins/glean/dist/index.js
1
```

## Why a build constant rather than reading a manifest at runtime

This value is what a remote policy would use to decide whether a plugin is outdated, blocked, or unsupported, so it has to describe the code that is actually running.

A manifest sits beside the bundle as editable JSON, so a runtime read reports only what the plugin *claims*. Worse, a *fallback* to one would convert "the constant is missing" into "here is a version the user can edit" — a downgrade path for anyone able to make the constant unreadable.

`pluginVersion()` therefore reports `source: "build"` or `source: "unknown"` and never guesses. A dev run through `tsx` has no `define` applied and correctly reports `unknown`; callers are expected to skip version-dependent behaviour rather than treat the placeholder as real.

CI already verifies `dist/` is in sync with source, so the compiled literal cannot drift from the manifest unnoticed.

## The trade-off, and its mitigation

Baking it in makes the build step load-bearing: a silently missing constant would make every install report an unknown version and disable version-dependent behaviour fleet-wide — a wider blast radius than any single fallback.

So the build **fails** if the manifest version is absent or is not a plain `x.y.z`:

```
Error: build: plugins/glean/.claude-plugin/plugin.json must declare a plain x.y.z
version, got "not-a-version". The bundled constant is what the plugin reports about
itself, so an absent or malformed value fails the build rather than shipping.
```

Verified by temporarily corrupting the manifest.

## Testing

- `npm run typecheck` clean
- `npm test` — 192 passing (189 existing + 3 new)
- `npm run build` — dist committed and in sync
- version-bump gate: `0.2.43 → 0.2.44 (all manifests aligned)`
- confirmed the literal lands in `dist/index.js`, and that a malformed manifest version fails the build

The new tests deliberately exercise the `unknown` path, since vitest does not apply esbuild's `define` — the same condition as a `tsx` dev run.

## Context

This is a prerequisite for remote capability/policy negotiation ([scio#273428](https://github.com/askscio/scio/pull/273428)), where version rules can deactivate a plugin. It stands on its own, though: reporting an accurate version on the MCP handshake is worth having regardless.