### PR TITLE
Capability and policy negotiation: report context, record policy

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "description": "Search and act across your company's apps \u2014 Jira, Slack, Salesforce, Google Workspace, and more \u2014 without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "glean-vnext",
   "displayName": "Glean vNext",
   "version": "0.2.45",
-  "description": "Search and act across your company's apps \u2014 Jira, Slack, Salesforce, Google Workspace, and more \u2014 without leaving Cursor.",
+  "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"
   },

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25414,15 +25414,6 @@ function savePolicy(serverUrl, policy) {
   };
   writeAll(all);
 }
-function clearCache(serverUrl) {
-  if (!serverUrl) {
-    writeAll({});
-    return;
-  }
-  const all = readAll();
-  delete all[serverUrl];
-  writeAll(all);
-}
 
 // src/policy/protocol-version.ts
 var ProtocolVersionObserver = class {
@@ -25517,10 +25508,6 @@ function initPolicySession(server2, log) {
 }
 function setPolicyServerUrl(url2) {
   cacheKeyUrl = url2;
-}
-function clearPolicyCache() {
-  clearCache();
-  decision = void 0;
 }
 function negotiationRequest() {
   const host = hostIdentityFromHandshake(
@@ -27260,7 +27247,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         oauthProvider = void 0;
         cachedRemoteTools = [];
         setPolicyServerUrl(void 0);
-        clearPolicyCache();
         logLine2("setup.reset");
         server.sendToolListChanged().catch(() => {
         });

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25429,12 +25429,7 @@ function loadCachedPolicy(serverUrl) {
 }
 function savePolicy(serverUrl, policy) {
   const all = readAll();
-  const entry = all[serverUrl] ?? {};
-  all[serverUrl] = {
-    ...entry,
-    policy,
-    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
-  };
+  all[serverUrl] = { policy, updatedAt: (/* @__PURE__ */ new Date()).toISOString() };
   writeAll(all);
 }
 

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25414,6 +25414,15 @@ function savePolicy(serverUrl, policy) {
   };
   writeAll(all);
 }
+function clearCache(serverUrl) {
+  if (!serverUrl) {
+    writeAll({});
+    return;
+  }
+  const all = readAll();
+  delete all[serverUrl];
+  writeAll(all);
+}
 
 // src/policy/protocol-version.ts
 var ProtocolVersionObserver = class {
@@ -25508,6 +25517,10 @@ function initPolicySession(server2, log) {
 }
 function setPolicyServerUrl(url2) {
   cacheKeyUrl = url2;
+}
+function clearPolicyCache() {
+  clearCache();
+  decision = void 0;
 }
 function negotiationRequest() {
   const host = hostIdentityFromHandshake(
@@ -27247,6 +27260,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         oauthProvider = void 0;
         cachedRemoteTools = [];
         setPolicyServerUrl(void 0);
+        clearPolicyCache();
         logLine2("setup.reset");
         server.sendToolListChanged().catch(() => {
         });

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -3236,8 +3236,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path8) {
-      let input = path8;
+    function removeDotSegments(path9) {
+      let input = path9;
       const output = [];
       let nextSlash = -1;
       let len = 0;
@@ -3489,8 +3489,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path8, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path8 && path8 !== "/" ? path8 : void 0;
+        const [path9, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path9 && path9 !== "/" ? path9 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -6883,12 +6883,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs8, exportName) {
+    function addFormats(ajv, list, fs9, exportName) {
       var _a3;
       var _b;
       (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 ? _a3 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs8[f]);
+        ajv.addFormat(f, fs9[f]);
     }
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -6973,17 +6973,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path8) {
-      const ctrl = callVisitor(key, node, visitor, path8);
+    function visit_(key, node, visitor, path9) {
+      const ctrl = callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visit_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visit_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path8);
+            const ci = visit_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -6994,13 +6994,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = visit_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = visit_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path8);
+          const cv = visit_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -7021,17 +7021,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path8) {
-      const ctrl = await callVisitor(key, node, visitor, path8);
+    async function visitAsync_(key, node, visitor, path9) {
+      const ctrl = await callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visitAsync_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visitAsync_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path8);
+            const ci = await visitAsync_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -7042,13 +7042,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path8);
+          const cv = await visitAsync_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -7075,23 +7075,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path8) {
+    function callVisitor(key, node, visitor, path9) {
       if (typeof visitor === "function")
-        return visitor(key, node, path8);
+        return visitor(key, node, path9);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path8);
+        return visitor.Map?.(key, node, path9);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path8);
+        return visitor.Seq?.(key, node, path9);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path8);
+        return visitor.Pair?.(key, node, path9);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path8);
+        return visitor.Scalar?.(key, node, path9);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path8);
+        return visitor.Alias?.(key, node, path9);
       return void 0;
     }
-    function replaceNode(key, path8, node) {
-      const parent = path8[path8.length - 1];
+    function replaceNode(key, path9, node) {
+      const parent = path9[path9.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -7701,10 +7701,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path8, value) {
+    function collectionFromPath(schema, path9, value) {
       let v = value;
-      for (let i = path8.length - 1; i >= 0; --i) {
-        const k = path8[i];
+      for (let i = path9.length - 1; i >= 0; --i) {
+        const k = path9[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -7723,7 +7723,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
+    var isEmptyPath = (path9) => path9 == null || typeof path9 === "object" && !!path9[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -7753,11 +7753,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path8, value) {
-        if (isEmptyPath(path8))
+      addIn(path9, value) {
+        if (isEmptyPath(path9))
           this.add(value);
         else {
-          const [key, ...rest] = path8;
+          const [key, ...rest] = path9;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -7771,8 +7771,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        const [key, ...rest] = path8;
+      deleteIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -7786,8 +7786,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        const [key, ...rest] = path8;
+      getIn(path9, keepScalar) {
+        const [key, ...rest] = path9;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -7805,8 +7805,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path8) {
-        const [key, ...rest] = path8;
+      hasIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -7816,8 +7816,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        const [key, ...rest] = path8;
+      setIn(path9, value) {
+        const [key, ...rest] = path9;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -10332,9 +10332,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path8, value) {
+      addIn(path9, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path8, value);
+          this.contents.addIn(path9, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -10409,14 +10409,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        if (Collection.isEmptyPath(path8)) {
+      deleteIn(path9) {
+        if (Collection.isEmptyPath(path9)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path9) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -10431,10 +10431,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        if (Collection.isEmptyPath(path8))
+      getIn(path9, keepScalar) {
+        if (Collection.isEmptyPath(path9))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path9, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -10445,10 +10445,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path8) {
-        if (Collection.isEmptyPath(path8))
+      hasIn(path9) {
+        if (Collection.isEmptyPath(path9))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path9) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -10465,13 +10465,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        if (Collection.isEmptyPath(path8)) {
+      setIn(path9, value) {
+        if (Collection.isEmptyPath(path9)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path9), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path8, value);
+          this.contents.setIn(path9, value);
         }
       }
       /**
@@ -12431,9 +12431,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path8) => {
+    visit.itemAtPath = (cst, path9) => {
       let item = cst;
-      for (const [field, index] of path8) {
+      for (const [field, index] of path9) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -12442,23 +12442,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path8) => {
-      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
-      const field = path8[path8.length - 1][0];
+    visit.parentCollection = (cst, path9) => {
+      const parent = visit.itemAtPath(cst, path9.slice(0, -1));
+      const field = path9[path9.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path8, item, visitor) {
-      let ctrl = visitor(item, path8);
+    function _visit(path9, item, visitor) {
+      let ctrl = visitor(item, path9);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path9.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -12469,10 +12469,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path8);
+            ctrl = ctrl(item, path9);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path9) : ctrl;
     }
     exports.visit = visit;
   }
@@ -13774,14 +13774,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs8 = this.flowScalar(this.type);
+              const fs9 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs8, sep: [] });
+                map.items.push({ start, key: fs9, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs8);
+                this.stack.push(fs9);
               } else {
-                Object.assign(it, { key: fs8, sep: [] });
+                Object.assign(it, { key: fs9, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -13909,13 +13909,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs8 = this.flowScalar(this.type);
+              const fs9 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs8, sep: [] });
+                fc.items.push({ start: [], key: fs9, sep: [] });
               else if (it.sep)
-                this.stack.push(fs8);
+                this.stack.push(fs9);
               else
-                Object.assign(it, { key: fs8, sep: [] });
+                Object.assign(it, { key: fs9, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -14466,10 +14466,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path8) {
-  if (!path8)
+function getElementAtPath(obj, path9) {
+  if (!path9)
     return obj;
-  return path8.reduce((acc, key) => acc?.[key], obj);
+  return path9.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -14878,11 +14878,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path8, issues) {
+function prefixIssues(path9, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path8);
+    iss.path.unshift(path9);
     return iss;
   });
 }
@@ -15029,16 +15029,16 @@ function flattenError(error2, mapper = (issue2) => issue2.message) {
 }
 function formatError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error3, path8 = []) => {
+  const processError = (error3, path9 = []) => {
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path8, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path9, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path8, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path9, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path8, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path9, ...issue2.path]);
       } else {
-        const fullpath = [...path8, ...issue2.path];
+        const fullpath = [...path9, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -22732,9 +22732,9 @@ var Server = class extends Protocol {
     const requestedVersion = request.params.protocolVersion;
     this._clientCapabilities = request.params.capabilities;
     this._clientVersion = request.params.clientInfo;
-    const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion) ? requestedVersion : LATEST_PROTOCOL_VERSION;
+    const protocolVersion2 = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion) ? requestedVersion : LATEST_PROTOCOL_VERSION;
     return {
-      protocolVersion,
+      protocolVersion: protocolVersion2,
       capabilities: this.getCapabilities(),
       serverInfo: this._serverInfo,
       ...this._instructions && { instructions: this._instructions }
@@ -22982,8 +22982,8 @@ var StdioServerTransport = class {
 };
 
 // src/index.ts
-import path7 from "node:path";
-import fs7 from "node:fs";
+import path8 from "node:path";
+import fs8 from "node:fs";
 import { homedir as homedir4, tmpdir } from "node:os";
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
@@ -24288,9 +24288,9 @@ function buildWellKnownPath(wellKnownPrefix, pathname = "", options = {}) {
   }
   return options.prependPathname ? `${pathname}/.well-known/${wellKnownPrefix}` : `/.well-known/${wellKnownPrefix}${pathname}`;
 }
-async function tryMetadataDiscovery(url2, protocolVersion, fetchFn = fetch) {
+async function tryMetadataDiscovery(url2, protocolVersion2, fetchFn = fetch) {
   const headers = {
-    "MCP-Protocol-Version": protocolVersion
+    "MCP-Protocol-Version": protocolVersion2
   };
   return await fetchWithCorsRetry(url2, headers, fetchFn);
 }
@@ -24299,7 +24299,7 @@ function shouldAttemptFallback(response, pathname) {
 }
 async function discoverMetadataWithFallback(serverUrl, wellKnownType, fetchFn, opts) {
   const issuer = new URL(serverUrl);
-  const protocolVersion = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
+  const protocolVersion2 = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
   let url2;
   if (opts?.metadataUrl) {
     url2 = new URL(opts.metadataUrl);
@@ -24308,10 +24308,10 @@ async function discoverMetadataWithFallback(serverUrl, wellKnownType, fetchFn, o
     url2 = new URL(wellKnownPath, opts?.metadataServerUrl ?? issuer);
     url2.search = issuer.search;
   }
-  let response = await tryMetadataDiscovery(url2, protocolVersion, fetchFn);
+  let response = await tryMetadataDiscovery(url2, protocolVersion2, fetchFn);
   if (!opts?.metadataUrl && shouldAttemptFallback(response, issuer.pathname)) {
     const rootUrl = new URL(`/.well-known/${wellKnownType}`, issuer);
-    response = await tryMetadataDiscovery(rootUrl, protocolVersion, fetchFn);
+    response = await tryMetadataDiscovery(rootUrl, protocolVersion2, fetchFn);
   }
   return response;
 }
@@ -24348,9 +24348,9 @@ function buildDiscoveryUrls(authorizationServerUrl) {
   });
   return urlsToTry;
 }
-async function discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn = fetch, protocolVersion = LATEST_PROTOCOL_VERSION } = {}) {
+async function discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn = fetch, protocolVersion: protocolVersion2 = LATEST_PROTOCOL_VERSION } = {}) {
   const headers = {
-    "MCP-Protocol-Version": protocolVersion,
+    "MCP-Protocol-Version": protocolVersion2,
     Accept: "application/json"
   };
   const urlsToTry = buildDiscoveryUrls(authorizationServerUrl);
@@ -25128,13 +25128,457 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/version.ts
-var BUILD_VERSION = true ? "0.2.44" : void 0;
+var BUILD_VERSION = true ? "0.2.45" : void 0;
 function pluginVersion() {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
   return { version: "0.0.0", source: "unknown" };
 }
 function pluginVersionString() {
   return pluginVersion().version;
+}
+
+// src/policy/key.ts
+var CAPABILITY_POLICY_KEY = "com.glean.mcp/capabilityPolicy";
+var FEATURE_NAMES = [
+  "toolPromotion",
+  "metaTools",
+  "hitl",
+  "fileArgs"
+];
+
+// src/policy/context.ts
+function hostIdentityFromHandshake(clientInfo, capabilities, mcpProtocolVersion) {
+  if (!clientInfo?.name) {
+    return { id: "unknown", mcpProtocolVersion, source: "unknown" };
+  }
+  return {
+    id: clientInfo.name,
+    version: clientInfo.version,
+    mcpProtocolVersion,
+    capabilities,
+    source: "handshake"
+  };
+}
+function inventory() {
+  return { source: "unavailable" };
+}
+function supportedFeatures() {
+  return Object.fromEntries(FEATURE_NAMES.map((f) => [f, true]));
+}
+function buildNegotiationRequest(host) {
+  const { version: version2, source } = pluginVersion();
+  return {
+    plugin: {
+      id: "glean",
+      version: version2,
+      versionSource: source,
+      supportedFeatures: supportedFeatures()
+    },
+    host,
+    configuredServers: inventory()
+  };
+}
+
+// src/policy/negotiate.ts
+function metaFor(request) {
+  return { _meta: { [CAPABILITY_POLICY_KEY]: request } };
+}
+function isRecord(v) {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+var KNOWN_TOP_LEVEL = /* @__PURE__ */ new Set([
+  "plugin",
+  "features",
+  "message"
+]);
+var KNOWN_PLUGIN = /* @__PURE__ */ new Set([
+  "latestVersion",
+  "minimumSupportedVersion",
+  "blockedVersions",
+  "upgradeRecommendation"
+]);
+var KNOWN_UPGRADE = /* @__PURE__ */ new Set([
+  "show",
+  "dailyCap",
+  "weeklyCap",
+  "message"
+]);
+function unknownIn(obj, known, prefix) {
+  if (!isRecord(obj)) return [];
+  return Object.keys(obj).filter((k) => !known.has(k)).map((k) => `${prefix}${k}`);
+}
+function validatePolicy(value) {
+  if (!isRecord(value)) return { ok: false, reason: "policy is not an object" };
+  const plugin = value.plugin;
+  if (plugin !== void 0) {
+    if (!isRecord(plugin)) {
+      return { ok: false, reason: "plugin must be an object" };
+    }
+    for (const key of ["latestVersion", "minimumSupportedVersion"]) {
+      const v = plugin[key];
+      if (v !== void 0 && typeof v !== "string") {
+        return { ok: false, reason: `plugin.${key} must be a string` };
+      }
+    }
+    const blocked = plugin.blockedVersions;
+    if (blocked !== void 0 && (!Array.isArray(blocked) || blocked.some((b) => typeof b !== "string"))) {
+      return { ok: false, reason: "plugin.blockedVersions must be string[]" };
+    }
+    const rec = plugin.upgradeRecommendation;
+    if (rec !== void 0 && !isRecord(rec)) {
+      return { ok: false, reason: "plugin.upgradeRecommendation must be an object" };
+    }
+  }
+  const features = value.features;
+  if (features !== void 0) {
+    if (!isRecord(features)) {
+      return { ok: false, reason: "features must be an object" };
+    }
+    for (const [name, entry] of Object.entries(features)) {
+      if (!isRecord(entry)) {
+        return { ok: false, reason: `features.${name} must be an object` };
+      }
+      if (entry.enabled !== void 0 && typeof entry.enabled !== "boolean") {
+        return { ok: false, reason: `features.${name}.enabled must be boolean` };
+      }
+    }
+  }
+  if (value.message !== void 0 && typeof value.message !== "string") {
+    return { ok: false, reason: "message must be a string" };
+  }
+  const unknownKeys = [
+    ...unknownIn(value, KNOWN_TOP_LEVEL, ""),
+    ...unknownIn(value.plugin, KNOWN_PLUGIN, "plugin."),
+    ...unknownIn(
+      isRecord(value.plugin) ? value.plugin.upgradeRecommendation : void 0,
+      KNOWN_UPGRADE,
+      "plugin.upgradeRecommendation."
+    ),
+    ...unknownIn(value.features, new Set(FEATURE_NAMES), "features.")
+  ];
+  return { ok: true, policy: value, unknownKeys };
+}
+function classifyResult(result) {
+  const meta2 = isRecord(result) ? result._meta : void 0;
+  const candidate = isRecord(meta2) ? meta2[CAPABILITY_POLICY_KEY] : void 0;
+  if (candidate === void 0) return { kind: "no-policy" };
+  const validated = validatePolicy(candidate);
+  if (!validated.ok) return { kind: "malformed", reason: validated.reason };
+  return {
+    kind: "policy",
+    policy: validated.policy,
+    unknownKeys: validated.unknownKeys
+  };
+}
+
+// src/policy/evaluate.ts
+function parseVersion(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+  if (!m) return void 0;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+function compareVersions(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return void 0;
+  for (let i = 0; i < 3; i++) {
+    const x = pa[i];
+    const y = pb[i];
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+function allFeatures(value) {
+  return Object.fromEntries(FEATURE_NAMES.map((f) => [f, value]));
+}
+function evaluate(input) {
+  const { pluginVersion: pluginVersion2, versionSource, supportedFeatures: supportedFeatures2, policy } = input;
+  const reasons = [];
+  if (!policy) {
+    reasons.push(
+      "no policy available: enabling all supported features, applying no version policy"
+    );
+    return {
+      deactivated: false,
+      versionState: "unenforced",
+      features: { ...supportedFeatures2 },
+      showUpgrade: false,
+      reasons
+    };
+  }
+  let versionState = "ok";
+  let deactivated = false;
+  if (versionSource === "unknown") {
+    versionState = "unenforced";
+    reasons.push(
+      "version source is unknown: version policy not enforced (never deactivate on an unverifiable version)"
+    );
+  } else {
+    const blocked = policy.plugin?.blockedVersions ?? [];
+    const min = policy.plugin?.minimumSupportedVersion;
+    if (min) {
+      const cmp = compareVersions(pluginVersion2, min);
+      if (cmp === void 0) {
+        reasons.push(
+          `cannot compare ${pluginVersion2} against minimum ${min}: skipping minimum check`
+        );
+      } else if (cmp < 0) {
+        versionState = "below-minimum";
+        deactivated = true;
+        reasons.push(
+          `version ${pluginVersion2} is below the minimum supported ${min}: deactivated`
+        );
+      }
+    }
+    if (!deactivated && blocked.includes(pluginVersion2)) {
+      versionState = "blocked";
+      deactivated = true;
+      reasons.push(`version ${pluginVersion2} is explicitly blocked: deactivated`);
+    }
+    if (!deactivated) {
+      const latest = policy.plugin?.latestVersion;
+      if (latest && compareVersions(pluginVersion2, latest) === -1) {
+        versionState = "outdated-supported";
+        reasons.push(
+          `version ${pluginVersion2} is older than latest ${latest} but supported`
+        );
+      }
+    }
+  }
+  if (deactivated) {
+    return {
+      deactivated: true,
+      versionState,
+      features: allFeatures(false),
+      showUpgrade: true,
+      message: policy.message,
+      reasons
+    };
+  }
+  const features = {};
+  for (const name of FEATURE_NAMES) {
+    const supported = supportedFeatures2[name] === true;
+    if (!supported) {
+      features[name] = false;
+      continue;
+    }
+    const entry = policy.features?.[name];
+    const enabled = entry?.enabled !== false;
+    features[name] = enabled;
+    if (!enabled) reasons.push(`feature "${name}" disabled by remote policy`);
+  }
+  return {
+    deactivated: false,
+    versionState,
+    features,
+    showUpgrade: versionState === "outdated-supported" && policy.plugin?.upgradeRecommendation?.show === true,
+    message: policy.message,
+    reasons
+  };
+}
+
+// src/policy/cache.ts
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+function cachePath() {
+  const base = process.env.PLUGIN_DATA_DIR || path.join(os.homedir(), ".glean");
+  return path.join(base, "policy-cache.json");
+}
+function readAll() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath(), "utf-8"));
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+function writeAll(data) {
+  const file = cachePath();
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 448 });
+    fs.writeFileSync(file, JSON.stringify(data, null, 2), { mode: 384 });
+  } catch {
+  }
+}
+function loadCached(serverUrl) {
+  return readAll()[serverUrl] ?? {};
+}
+function savePolicy(serverUrl, policy) {
+  const all = readAll();
+  const entry = all[serverUrl] ?? {};
+  all[serverUrl] = {
+    ...entry,
+    policy,
+    updatedAt: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  writeAll(all);
+}
+
+// src/policy/protocol-version.ts
+var ProtocolVersionObserver = class {
+  negotiated;
+  proposed;
+  initializeId;
+  /** The agreed revision, or undefined when it could not be observed. */
+  get version() {
+    return this.negotiated;
+  }
+  /** What the host asked for. Retained for diagnostics, not reported as the answer. */
+  get requested() {
+    return this.proposed;
+  }
+  /**
+   * Wrap a transport so the initialize exchange is observed as it passes through.
+   * Delegates everything; the only additions are two taps that never throw, since a
+   * failed observation must degrade to "unknown" rather than break the connection.
+   */
+  wrap(inner) {
+    const observer = this;
+    const wrapped = {
+      start: () => inner.start(),
+      close: () => inner.close(),
+      send: async (message, options) => {
+        observer.observeOutgoing(message);
+        return inner.send(message, options);
+      },
+      get sessionId() {
+        return inner.sessionId;
+      },
+      set onmessage(handler) {
+        inner.onmessage = handler ? (message, extra) => {
+          observer.observeIncoming(message);
+          handler(message, extra);
+        } : void 0;
+      },
+      get onmessage() {
+        return inner.onmessage;
+      },
+      set onclose(handler) {
+        inner.onclose = handler;
+      },
+      get onclose() {
+        return inner.onclose;
+      },
+      set onerror(handler) {
+        inner.onerror = handler;
+      },
+      get onerror() {
+        return inner.onerror;
+      }
+    };
+    return wrapped;
+  }
+  observeIncoming(message) {
+    try {
+      const m = message;
+      if (m.method !== "initialize" || m.id === void 0) return;
+      this.initializeId = m.id;
+      const params = m.params;
+      if (typeof params?.protocolVersion === "string") {
+        this.proposed = params.protocolVersion;
+      }
+    } catch {
+    }
+  }
+  observeOutgoing(message) {
+    try {
+      const m = message;
+      if (m.id === void 0 || m.id !== this.initializeId) return;
+      const result = m.result;
+      if (typeof result?.protocolVersion === "string") {
+        this.negotiated = result.protocolVersion;
+      }
+    } catch {
+    }
+  }
+};
+
+// src/policy/session.ts
+var mcpServer;
+var logLine = () => {
+};
+var decision;
+var lastRequest;
+var cacheKeyUrl;
+var protocolVersion = new ProtocolVersionObserver();
+function initPolicySession(server2, log) {
+  mcpServer = server2;
+  logLine = log;
+}
+function setPolicyServerUrl(url2) {
+  cacheKeyUrl = url2;
+}
+function negotiationRequest() {
+  const host = hostIdentityFromHandshake(
+    mcpServer?.getClientVersion(),
+    mcpServer?.getClientCapabilities(),
+    protocolVersion.version
+  );
+  lastRequest = buildNegotiationRequest(host);
+  return lastRequest;
+}
+function negotiationMeta() {
+  return metaFor(negotiationRequest());
+}
+function recordPolicyFromResult(result, label) {
+  const serverUrl = cacheKeyUrl;
+  if (!serverUrl) return;
+  const outcome = classifyResult(result);
+  const cached2 = loadCached(serverUrl);
+  let policy;
+  switch (outcome.kind) {
+    case "policy":
+      policy = outcome.policy;
+      savePolicy(serverUrl, outcome.policy);
+      if (outcome.unknownKeys.length > 0) {
+        logLine("policy.unknown-keys", { label, keys: outcome.unknownKeys });
+      }
+      break;
+    case "malformed":
+      logLine("policy.malformed", { label, reason: outcome.reason });
+      policy = cached2.policy;
+      break;
+    case "no-policy":
+      policy = void 0;
+      break;
+  }
+  const request = lastRequest ?? negotiationRequest();
+  const next = evaluate({
+    pluginVersion: request.plugin.version,
+    versionSource: request.plugin.versionSource,
+    supportedFeatures: request.plugin.supportedFeatures,
+    policy
+  });
+  const changed = !decision || JSON.stringify([decision.deactivated, decision.features]) !== JSON.stringify([next.deactivated, next.features]);
+  decision = next;
+  if (changed) {
+    logLine("policy.resolved", {
+      label,
+      outcome: outcome.kind,
+      versionState: next.versionState,
+      deactivated: next.deactivated,
+      features: next.features,
+      reasons: next.reasons
+    });
+  }
+}
+function policySummary() {
+  const r = lastRequest;
+  const d = decision;
+  const lines = [
+    `Plugin version: ${r?.plugin.version ?? "?"} (source: ${r?.plugin.versionSource ?? "?"})`,
+    `Host: ${r?.host.id ?? "?"} ${r?.host.version ?? ""} (source: ${r?.host.source ?? "?"})`,
+    `MCP revision: ${r?.host.mcpProtocolVersion ?? "not observed"}`,
+    `Server inventory: ${r?.configuredServers.source ?? "?"}`
+  ];
+  if (d) {
+    lines.push(`Policy: version ${d.versionState}, features ${JSON.stringify(d.features)}`);
+    if (d.message) lines.push(`Notice: ${d.message}`);
+  } else {
+    lines.push("Policy: not yet negotiated");
+  }
+  return lines;
 }
 
 // src/remote-client.ts
@@ -25267,9 +25711,12 @@ async function createRemoteClient(serverUrl, opts, chatSessionId) {
   return client;
 }
 async function callRemoteTool(client, name, args) {
-  const result = await client.callTool({ name, arguments: args }, void 0, {
-    timeout: remoteToolTimeoutMs()
-  });
+  const result = await client.callTool(
+    { name, arguments: args, ...negotiationMeta() },
+    void 0,
+    { timeout: remoteToolTimeoutMs() }
+  );
+  recordPolicyFromResult(result, `tools/call(${name})`);
   if (!("content" in result)) {
     return { content: [] };
   }
@@ -25361,21 +25808,21 @@ function closeCallbackServer() {
 }
 
 // src/token-store.ts
-import fs from "node:fs";
-import path from "node:path";
+import fs2 from "node:fs";
+import path2 from "node:path";
 import { homedir } from "node:os";
 var CREDENTIALS_FILENAME = "mcp-credentials.json";
 var DIR_MODE = 448;
 var FILE_MODE = 384;
 function resolveCredentialsDir() {
-  return process.env.PLUGIN_DATA_DIR || path.join(homedir(), ".glean");
+  return process.env.PLUGIN_DATA_DIR || path2.join(homedir(), ".glean");
 }
 function credentialsFile() {
-  return path.join(resolveCredentialsDir(), CREDENTIALS_FILENAME);
+  return path2.join(resolveCredentialsDir(), CREDENTIALS_FILENAME);
 }
 function loadCredentials() {
   try {
-    const raw = fs.readFileSync(credentialsFile(), "utf-8");
+    const raw = fs2.readFileSync(credentialsFile(), "utf-8");
     return JSON.parse(raw);
   } catch {
     return void 0;
@@ -25384,15 +25831,15 @@ function loadCredentials() {
 function saveCredentials(tokens, clientInfo) {
   try {
     const filePath = credentialsFile();
-    const dir = path.dirname(filePath);
-    fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
-    fs.chmodSync(dir, DIR_MODE);
+    const dir = path2.dirname(filePath);
+    fs2.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+    fs2.chmodSync(dir, DIR_MODE);
     const data = { tokens, clientInfo };
-    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+    fs2.writeFileSync(filePath, JSON.stringify(data, null, 2), {
       encoding: "utf-8",
       mode: FILE_MODE
     });
-    fs.chmodSync(filePath, FILE_MODE);
+    fs2.chmodSync(filePath, FILE_MODE);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[auth] Failed to persist credentials: ${msg}`);
@@ -25400,7 +25847,7 @@ function saveCredentials(tokens, clientInfo) {
 }
 function clearCredentials() {
   try {
-    fs.rmSync(credentialsFile(), { force: true });
+    fs2.rmSync(credentialsFile(), { force: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[auth] Failed to clear credentials: ${msg}`);
@@ -25538,11 +25985,11 @@ var GleanOAuthClientProvider = class {
 
 // src/skill-writer.ts
 var import_yaml = __toESM(require_dist2(), 1);
-import fs2 from "node:fs/promises";
-import path2 from "node:path";
+import fs3 from "node:fs/promises";
+import path3 from "node:path";
 function isInsideDir(filePath, dir) {
-  const resolved = path2.resolve(filePath);
-  return resolved.startsWith(path2.resolve(dir) + path2.sep);
+  const resolved = path3.resolve(filePath);
+  return resolved.startsWith(path3.resolve(dir) + path3.sep);
 }
 function parseFrontmatter(content) {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -25567,7 +26014,7 @@ function parseFrontmatter(content) {
 async function evictStaleSkills(baseDir, maxAgeMs, log, now = Date.now()) {
   let entries;
   try {
-    entries = await fs2.readdir(baseDir, { withFileTypes: true });
+    entries = await fs3.readdir(baseDir, { withFileTypes: true });
   } catch {
     return;
   }
@@ -25575,12 +26022,12 @@ async function evictStaleSkills(baseDir, maxAgeMs, log, now = Date.now()) {
   await Promise.all(
     entries.map(async (entry) => {
       if (!entry.isDirectory()) return;
-      const skillDir = path2.resolve(baseDir, entry.name);
+      const skillDir = path3.resolve(baseDir, entry.name);
       if (!isInsideDir(skillDir, baseDir)) return;
       try {
-        const stat = await fs2.stat(skillDir);
+        const stat = await fs3.stat(skillDir);
         if (stat.mtimeMs < cutoff) {
-          await fs2.rm(skillDir, { recursive: true, force: true });
+          await fs3.rm(skillDir, { recursive: true, force: true });
           log?.("evict-stale-skill", { skill: entry.name });
         }
       } catch (err) {
@@ -25593,21 +26040,21 @@ async function evictStaleSkills(baseDir, maxAgeMs, log, now = Date.now()) {
 async function writeSkillsToDisk(skills, baseDir) {
   const index = [];
   for (const [skillName, fileMap] of Object.entries(skills)) {
-    const skillDir = path2.resolve(baseDir, skillName);
+    const skillDir = path3.resolve(baseDir, skillName);
     if (!isInsideDir(skillDir, baseDir)) {
       continue;
     }
-    await fs2.rm(skillDir, { recursive: true, force: true });
-    await fs2.mkdir(skillDir, { recursive: true });
+    await fs3.rm(skillDir, { recursive: true, force: true });
+    await fs3.mkdir(skillDir, { recursive: true });
     const writtenFiles = [];
     for (const [filePath, content] of Object.entries(fileMap)) {
-      const fullPath = path2.resolve(skillDir, filePath);
+      const fullPath = path3.resolve(skillDir, filePath);
       if (!isInsideDir(fullPath, skillDir)) {
         continue;
       }
-      await fs2.mkdir(path2.dirname(fullPath), { recursive: true });
+      await fs3.mkdir(path3.dirname(fullPath), { recursive: true });
       const text = typeof content === "string" ? content : JSON.stringify(content);
-      await fs2.writeFile(fullPath, text, "utf-8");
+      await fs3.writeFile(fullPath, text, "utf-8");
       writtenFiles.push(fullPath);
     }
     const rawSkillMd = fileMap["SKILL.md"] ?? "";
@@ -25675,14 +26122,14 @@ async function handleFindSkills(remoteClient, skillsBaseDir, args) {
 }
 
 // src/tools/run-tool.ts
-import fs4 from "node:fs/promises";
-import os2 from "node:os";
-import path4 from "node:path";
+import fs5 from "node:fs/promises";
+import os3 from "node:os";
+import path5 from "node:path";
 
 // src/tools/approval-args.ts
-import fs3 from "node:fs/promises";
-import path3 from "node:path";
-import os from "node:os";
+import fs4 from "node:fs/promises";
+import path4 from "node:path";
+import os2 from "node:os";
 
 // src/session-id.ts
 import { randomUUID } from "node:crypto";
@@ -25770,12 +26217,12 @@ function formatArgumentsForFile(toolName, args) {
   return out.join("\n");
 }
 async function writeApprovalArgsFile(toolName, args) {
-  const base = process.env.PLUGIN_DATA_DIR || process.env.CLAUDE_PLUGIN_DATA || os.tmpdir();
+  const base = process.env.PLUGIN_DATA_DIR || process.env.CLAUDE_PLUGIN_DATA || os2.tmpdir();
   const sessionId = resolveSessionId().replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 64);
-  const dir = path3.join(base, "glean-approvals", sessionId);
-  await fs3.mkdir(dir, { recursive: true });
-  const file = path3.join(dir, "glean-approval-args.md");
-  await fs3.writeFile(file, formatArgumentsForFile(toolName, args), "utf-8");
+  const dir = path4.join(base, "glean-approvals", sessionId);
+  await fs4.mkdir(dir, { recursive: true });
+  const file = path4.join(dir, "glean-approval-args.md");
+  await fs4.writeFile(file, formatArgumentsForFile(toolName, args), "utf-8");
   return file;
 }
 
@@ -25825,7 +26272,7 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
         `file_args.${argName} must be a non-empty string path`
       );
     }
-    if (!path4.isAbsolute(filePathRaw)) {
+    if (!path5.isAbsolute(filePathRaw)) {
       throw new FileArgsError(
         `file_args.${argName} must be an absolute path; got "${filePathRaw}"`
       );
@@ -25837,7 +26284,7 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
     }
     let stat;
     try {
-      stat = await fs4.stat(filePathRaw);
+      stat = await fs5.stat(filePathRaw);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new FileArgsError(
@@ -25854,7 +26301,7 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
         `file_args.${argName}: "${filePathRaw}" is ${stat.size} bytes, exceeds ${maxBytes} byte limit (set GLEAN_FILE_ARG_MAX_BYTES to override)`
       );
     }
-    const content = await fs4.readFile(filePathRaw, "utf-8");
+    const content = await fs5.readFile(filePathRaw, "utf-8");
     const types = declaredParamTypes(inputSchema, argName);
     if (types.has("object") || types.has("array")) {
       try {
@@ -25877,12 +26324,12 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
 }
 async function findToolJson(skillsBaseDir, toolName) {
   try {
-    const skillDirs = await fs4.readdir(skillsBaseDir, { withFileTypes: true });
+    const skillDirs = await fs5.readdir(skillsBaseDir, { withFileTypes: true });
     for (const dir of skillDirs) {
       if (!dir.isDirectory()) continue;
-      const toolPath = path4.join(skillsBaseDir, dir.name, "tools", `${toolName}.json`);
+      const toolPath = path5.join(skillsBaseDir, dir.name, "tools", `${toolName}.json`);
       try {
-        const content = await fs4.readFile(toolPath, "utf-8");
+        const content = await fs5.readFile(toolPath, "utf-8");
         return JSON.parse(content);
       } catch {
         continue;
@@ -25892,11 +26339,11 @@ async function findToolJson(skillsBaseDir, toolName) {
   }
   return null;
 }
-function isCursorClient(mcpServer) {
-  return (mcpServer.getClientVersion()?.name ?? "").toLowerCase().startsWith("cursor");
+function isCursorClient(mcpServer2) {
+  return (mcpServer2.getClientVersion()?.name ?? "").toLowerCase().startsWith("cursor");
 }
-async function buildApprovalMessage(mcpServer, toolName, args) {
-  if (isCursorClient(mcpServer)) {
+async function buildApprovalMessage(mcpServer2, toolName, args) {
+  if (isCursorClient(mcpServer2)) {
     return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
   }
   const { lines, needsFile } = buildCompactArgs(args);
@@ -25916,27 +26363,27 @@ async function buildApprovalMessage(mcpServer, toolName, args) {
   return message.join("\n");
 }
 var elicitationIdPrimed = /* @__PURE__ */ new WeakSet();
-function primeElicitationCancellation(mcpServer) {
-  if (elicitationIdPrimed.has(mcpServer)) return;
-  elicitationIdPrimed.add(mcpServer);
-  void mcpServer.request({ method: "ping" }, EmptyResultSchema).catch(() => {
+function primeElicitationCancellation(mcpServer2) {
+  if (elicitationIdPrimed.has(mcpServer2)) return;
+  elicitationIdPrimed.add(mcpServer2);
+  void mcpServer2.request({ method: "ping" }, EmptyResultSchema).catch(() => {
   });
 }
 function permissionModeMarkerPath() {
-  const base = process.env.CLAUDE_PLUGIN_DATA || path4.join(os2.homedir(), ".glean");
+  const base = process.env.CLAUDE_PLUGIN_DATA || path5.join(os3.homedir(), ".glean");
   const sessionId = resolveSessionId().replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 64);
-  return path4.join(base, "glean-hitl-mode", `${sessionId}.json`);
+  return path5.join(base, "glean-hitl-mode", `${sessionId}.json`);
 }
 async function currentPermissionMode() {
   try {
-    const raw = await fs4.readFile(permissionModeMarkerPath(), "utf-8");
+    const raw = await fs5.readFile(permissionModeMarkerPath(), "utf-8");
     const parsed = JSON.parse(raw);
     return typeof parsed.permission_mode === "string" ? parsed.permission_mode : null;
   } catch {
     return null;
   }
 }
-async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
+async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
   if (typeof serverId !== "string" || typeof toolName !== "string") {
@@ -25966,18 +26413,18 @@ async function handleRunTool(remoteClient, mcpServer, skillsBaseDir, args) {
     throw err;
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
-  if (hitlEnabled && toolMeta?.requires_approval && !isCursorClient(mcpServer) && mcpServer.getClientCapabilities()?.elicitation) {
+  if (hitlEnabled && toolMeta?.requires_approval && !isCursorClient(mcpServer2) && mcpServer2.getClientCapabilities()?.elicitation) {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
       const message = await buildApprovalMessage(
-        mcpServer,
+        mcpServer2,
         toolName,
         resolvedArgs
       );
       const timeout = hitlTimeoutMs();
-      primeElicitationCancellation(mcpServer);
+      primeElicitationCancellation(mcpServer2);
       try {
-        const result = await mcpServer.elicitInput(
+        const result = await mcpServer2.elicitInput(
           {
             message,
             requestedSchema: { type: "object", properties: {} }
@@ -26026,21 +26473,21 @@ function runToolAnnotations(enableHitl, clientSupportsElicitation, isCursor) {
 }
 
 // src/url-config-store.ts
-import fs5 from "node:fs";
-import path5 from "node:path";
+import fs6 from "node:fs";
+import path6 from "node:path";
 import { homedir as homedir2 } from "node:os";
 var CONFIG_FILENAME = "mcp-server-url.json";
 var DIR_MODE2 = 448;
 var FILE_MODE2 = 384;
 function resolveConfigDir() {
-  return process.env.PLUGIN_DATA_DIR || path5.join(homedir2(), ".glean");
+  return process.env.PLUGIN_DATA_DIR || path6.join(homedir2(), ".glean");
 }
 function configFile() {
-  return path5.join(resolveConfigDir(), CONFIG_FILENAME);
+  return path6.join(resolveConfigDir(), CONFIG_FILENAME);
 }
 function loadServerUrl() {
   try {
-    const raw = fs5.readFileSync(configFile(), "utf-8");
+    const raw = fs6.readFileSync(configFile(), "utf-8");
     const data = JSON.parse(raw);
     if (typeof data.serverUrl !== "string" || !data.serverUrl) return void 0;
     return data.serverUrl;
@@ -26050,39 +26497,39 @@ function loadServerUrl() {
 }
 function saveServerUrl(url2) {
   const filePath = configFile();
-  const dir = path5.dirname(filePath);
-  fs5.mkdirSync(dir, { recursive: true, mode: DIR_MODE2 });
-  fs5.chmodSync(dir, DIR_MODE2);
+  const dir = path6.dirname(filePath);
+  fs6.mkdirSync(dir, { recursive: true, mode: DIR_MODE2 });
+  fs6.chmodSync(dir, DIR_MODE2);
   const data = { serverUrl: url2 };
-  fs5.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+  fs6.writeFileSync(filePath, JSON.stringify(data, null, 2), {
     encoding: "utf-8",
     mode: FILE_MODE2
   });
-  fs5.chmodSync(filePath, FILE_MODE2);
+  fs6.chmodSync(filePath, FILE_MODE2);
 }
 function clearServerUrl() {
   try {
-    fs5.rmSync(configFile(), { force: true });
+    fs6.rmSync(configFile(), { force: true });
   } catch {
   }
 }
 
 // src/remote-tools-cache-store.ts
-import fs6 from "node:fs";
-import path6 from "node:path";
+import fs7 from "node:fs";
+import path7 from "node:path";
 import { homedir as homedir3 } from "node:os";
 var CACHE_FILENAME = "remote-tools-cache.json";
 var DIR_MODE3 = 448;
 var FILE_MODE3 = 384;
 function resolveCacheDir() {
-  return process.env.PLUGIN_DATA_DIR || path6.join(homedir3(), ".glean");
+  return process.env.PLUGIN_DATA_DIR || path7.join(homedir3(), ".glean");
 }
 function cacheFile() {
-  return path6.join(resolveCacheDir(), CACHE_FILENAME);
+  return path7.join(resolveCacheDir(), CACHE_FILENAME);
 }
 function readStore() {
   try {
-    const raw = fs6.readFileSync(cacheFile(), "utf-8");
+    const raw = fs7.readFileSync(cacheFile(), "utf-8");
     const data = JSON.parse(raw);
     if (data && typeof data === "object" && !Array.isArray(data)) {
       return data;
@@ -26094,14 +26541,14 @@ function readStore() {
 }
 function writeStore(store) {
   const filePath = cacheFile();
-  const dir = path6.dirname(filePath);
-  fs6.mkdirSync(dir, { recursive: true, mode: DIR_MODE3 });
-  fs6.chmodSync(dir, DIR_MODE3);
-  fs6.writeFileSync(filePath, JSON.stringify(store, null, 2), {
+  const dir = path7.dirname(filePath);
+  fs7.mkdirSync(dir, { recursive: true, mode: DIR_MODE3 });
+  fs7.chmodSync(dir, DIR_MODE3);
+  fs7.writeFileSync(filePath, JSON.stringify(store, null, 2), {
     encoding: "utf-8",
     mode: FILE_MODE3
   });
-  fs6.chmodSync(filePath, FILE_MODE3);
+  fs7.chmodSync(filePath, FILE_MODE3);
 }
 function loadRemoteTools(serverUrl) {
   if (!serverUrl) return [];
@@ -26124,14 +26571,14 @@ function saveRemoteTools(serverUrl, tools) {
 function clearRemoteTools(serverUrl) {
   try {
     if (!serverUrl) {
-      fs6.rmSync(cacheFile(), { force: true });
+      fs7.rmSync(cacheFile(), { force: true });
       return;
     }
     const store = readStore();
     if (store[serverUrl] !== void 0) {
       delete store[serverUrl];
       if (Object.keys(store).length === 0) {
-        fs6.rmSync(cacheFile(), { force: true });
+        fs7.rmSync(cacheFile(), { force: true });
       } else {
         writeStore(store);
       }
@@ -26167,9 +26614,11 @@ async function fetchAllowedRemoteTools(remoteClient) {
   const collected = [];
   let cursor;
   do {
-    const page = await remoteClient.listTools(
-      cursor ? { cursor } : void 0
-    );
+    const page = await remoteClient.listTools({
+      ...cursor ? { cursor } : {},
+      ...negotiationMeta()
+    });
+    recordPolicyFromResult(page, "tools/list");
     for (const tool of page.tools) {
       if (!REMOTE_TOOLS_ALLOWLIST.has(tool.name)) continue;
       collected.push({
@@ -26320,24 +26769,24 @@ var EMAIL_RESOLVE_FAILED_TEXT = `Double-check the email for typos and try again 
 var SETUP_NEEDED_ERROR = "Glean is not configured yet. Call the `setup` tool first to provide your Glean Server URL before using find_skills or run_tool.";
 var AUTH_REDIRECT_TO_SETUP_TEXT = "[SETUP_REQUIRED]\n\nAuthentication is required. Call the `setup` tool (no arguments) to sign in to Glean, then retry this tool.";
 function resolveLogPath() {
-  const base = process.env.PLUGIN_DATA_DIR || path7.join(homedir4(), ".glean");
-  return path7.join(base, "glean-server.log");
+  const base = process.env.PLUGIN_DATA_DIR || path8.join(homedir4(), ".glean");
+  return path8.join(base, "glean-server.log");
 }
 var LOG_PATH = resolveLogPath();
 try {
-  const logDir = path7.dirname(LOG_PATH);
-  fs7.mkdirSync(logDir, { recursive: true, mode: 448 });
-  fs7.chmodSync(logDir, 448);
+  const logDir = path8.dirname(LOG_PATH);
+  fs8.mkdirSync(logDir, { recursive: true, mode: 448 });
+  fs8.chmodSync(logDir, 448);
 } catch {
 }
-function logLine(label, detail) {
+function logLine2(label, detail) {
   const ts = (/* @__PURE__ */ new Date()).toISOString();
   const suffix = detail ? ` ${JSON.stringify(detail)}` : "";
   const line = `${ts} ${label}${suffix}
 `;
   try {
-    fs7.appendFileSync(LOG_PATH, line, { mode: 384 });
-    fs7.chmodSync(LOG_PATH, 384);
+    fs8.appendFileSync(LOG_PATH, line, { mode: 384 });
+    fs8.chmodSync(LOG_PATH, 384);
   } catch {
   }
   console.error(line.trimEnd());
@@ -26346,12 +26795,14 @@ function resolveSkillsBaseDir() {
   if (process.env.SKILLS_BASE_DIR) {
     return process.env.SKILLS_BASE_DIR;
   }
-  return path7.join(tmpdir(), "glean-skills-cache");
+  return path8.join(tmpdir(), "glean-skills-cache");
 }
 var server = new Server(
   { name: "glean", version: pluginVersionString() },
   { capabilities: { tools: { listChanged: true } } }
 );
+initPolicySession(server, logLine2);
+setPolicyServerUrl(resolveServerUrl());
 var oauthProvider;
 var cachedRemoteTools = loadRemoteTools(resolveServerUrl() ?? "");
 function getOAuthProvider() {
@@ -26445,7 +26896,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   };
   const staticTools = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];
   const serve = (state, dynamic) => {
-    logLine("tools-list.served", {
+    logLine2("tools-list.served", {
       static: staticTools.length,
       dynamic: dynamic.length,
       names: dynamic.map((t) => t.name),
@@ -26470,7 +26921,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logLine("connect.backend-error", { label: "tools/list", msg });
+    logLine2("connect.backend-error", { label: "tools/list", msg });
     return serve("connect-error", cachedRemoteTools);
   }
   try {
@@ -26480,7 +26931,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     return serve("fetched", remoteTools);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logLine("tools-list.fetch-failed", { label: "tools/list", msg });
+    logLine2("tools-list.fetch-failed", { label: "tools/list", msg });
     return serve("fetch-failed", cachedRemoteTools);
   } finally {
     await remoteClient.close();
@@ -26507,7 +26958,7 @@ function withTimeout(p, ms) {
 }
 function backendErrorResult(label, err) {
   const msg = err instanceof Error ? err.message : String(err);
-  logLine("connect.backend-error", { label, msg });
+  logLine2("connect.backend-error", { label, msg });
   return {
     content: [
       { type: "text", text: `Failed to connect to Glean backend: ${msg}` }
@@ -26536,7 +26987,7 @@ async function connectWithSignIn(serverUrl) {
     handle = await startCallbackServer();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logLine("setup.callback-server-failed", { msg });
+    logLine2("setup.callback-server-failed", { msg });
     return {
       ok: false,
       result: {
@@ -26571,7 +27022,7 @@ async function connectWithSignIn(serverUrl) {
       code = await withTimeout(handle.code, SIGN_IN_WAIT_MS);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      logLine("setup.sign-in-wait-failed", { msg });
+      logLine2("setup.sign-in-wait-failed", { msg });
       return {
         ok: false,
         result: {
@@ -26594,7 +27045,7 @@ async function connectWithSignIn(serverUrl) {
       );
       return { ok: true, client };
     } catch (err) {
-      logLine("setup.finish-auth-failed", {
+      logLine2("setup.finish-auth-failed", {
         msg: err instanceof Error ? err.message : String(err)
       });
       return { ok: false, result: backendErrorResult("setup", err) };
@@ -26624,6 +27075,7 @@ async function advanceSetup() {
 Server URL: ${serverUrl}
 Authenticated: yes
 Remote tools: ${toolNames}
+${policySummary().join("\n")}
 
 You can now use find_skills, run_tool, and any of the listed remote tools.`
         }
@@ -26631,7 +27083,7 @@ You can now use find_skills, run_tool, and any of the listed remote tools.`
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logLine("setup.fetch-tools-failed", { msg });
+    logLine2("setup.fetch-tools-failed", { msg });
     return {
       content: [
         {
@@ -26667,7 +27119,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       serverUrl,
       remoteClientOpts: getRemoteClientOpts(),
       authRedirectText: AUTH_REDIRECT_TO_SETUP_TEXT,
-      logLine
+      logLine: logLine2
     };
     return await dispatchRemoteTool(name, args, dispatchCtx);
   }
@@ -26701,7 +27153,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
         }
         const msg = err instanceof Error ? err.message : String(err);
-        logLine("connect.backend-error", { label: "find_skills", msg });
+        logLine2("connect.backend-error", { label: "find_skills", msg });
         return {
           content: [
             {
@@ -26758,7 +27210,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
         }
         const msg = err instanceof Error ? err.message : String(err);
-        logLine("connect.backend-error", { label: "run_tool", msg });
+        logLine2("connect.backend-error", { label: "run_tool", msg });
         return {
           content: [
             {
@@ -26784,7 +27236,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
     }
     case "setup": {
-      logLine("client.capabilities", {
+      logLine2("client.capabilities", {
         elicitation: server.getClientCapabilities()?.elicitation ?? null,
         clientInfo: server.getClientVersion() ?? null
       });
@@ -26794,7 +27246,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         clearRemoteTools();
         oauthProvider = void 0;
         cachedRemoteTools = [];
-        logLine("setup.reset");
+        setPolicyServerUrl(void 0);
+        logLine2("setup.reset");
         server.sendToolListChanged().catch(() => {
         });
         return {
@@ -26811,7 +27264,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       if (!rawUrl && email2) {
         const resolved = await resolveServerUrlFromEmail(email2);
         if (!resolved.ok) {
-          logLine("setup.email-resolve-failed", { email: email2, error: resolved.error });
+          logLine2("setup.email-resolve-failed", { email: email2, error: resolved.error });
           return {
             content: [
               {
@@ -26825,7 +27278,7 @@ ${EMAIL_RESOLVE_FAILED_TEXT}`
           };
         }
         rawUrl = resolved.queryUrl;
-        logLine("setup.email-resolved", { email: email2, queryUrl: rawUrl });
+        logLine2("setup.email-resolved", { email: email2, queryUrl: rawUrl });
       }
       if (rawUrl) {
         let normalized;
@@ -26856,7 +27309,8 @@ ${EMAIL_RESOLVE_FAILED_TEXT}`
         clearCredentials();
         oauthProvider = void 0;
         cachedRemoteTools = loadRemoteTools(normalized);
-        logLine("setup.configured", { serverUrl: normalized });
+        setPolicyServerUrl(normalized);
+        logLine2("setup.configured", { serverUrl: normalized });
       }
       return await advanceSetup();
     }
@@ -26870,12 +27324,12 @@ ${EMAIL_RESOLVE_FAILED_TEXT}`
 async function main() {
   const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1e3;
   try {
-    await evictStaleSkills(resolveSkillsBaseDir(), ONE_WEEK_MS, logLine);
+    await evictStaleSkills(resolveSkillsBaseDir(), ONE_WEEK_MS, logLine2);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logLine("evict-stale-skills.failed", { msg });
+    logLine2("evict-stale-skills.failed", { msg });
   }
-  const transport = new StdioServerTransport();
+  const transport = protocolVersion.wrap(new StdioServerTransport());
   await server.connect(transport);
 }
 main().catch((err) => {

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25517,6 +25517,7 @@ var mcpServer;
 var logLine = () => {
 };
 var decision;
+var loggedLabels = /* @__PURE__ */ new Set();
 var lastRequest;
 var cacheKeyUrl;
 var protocolVersion = new ProtocolVersionObserver();
@@ -25570,7 +25571,9 @@ function recordPolicyFromResult(result, label) {
   });
   const changed = !decision || JSON.stringify([decision.deactivated, decision.features]) !== JSON.stringify([next.deactivated, next.features]);
   decision = next;
-  if (changed) {
+  const firstForLabel = !loggedLabels.has(label);
+  loggedLabels.add(label);
+  if (changed || firstForLabel) {
     logLine("policy.resolved", {
       label,
       outcome: outcome.kind,

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26799,7 +26799,7 @@ try {
 function logLine2(label, detail) {
   const ts = (/* @__PURE__ */ new Date()).toISOString();
   const suffix = detail ? ` ${JSON.stringify(detail)}` : "";
-  const line = `${ts} ${label}${suffix}
+  const line = `${ts} [${process.pid}] ${label}${suffix}
 `;
   try {
     fs9.appendFileSync(LOG_PATH, line, { mode: 384 });

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -3236,8 +3236,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path9) {
-      let input = path9;
+    function removeDotSegments(path10) {
+      let input = path10;
       const output = [];
       let nextSlash = -1;
       let len = 0;
@@ -3489,8 +3489,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path9, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path9 && path9 !== "/" ? path9 : void 0;
+        const [path10, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path10 && path10 !== "/" ? path10 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -6883,12 +6883,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs9, exportName) {
+    function addFormats(ajv, list, fs10, exportName) {
       var _a3;
       var _b;
       (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 ? _a3 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs9[f]);
+        ajv.addFormat(f, fs10[f]);
     }
     module.exports = exports = formatsPlugin;
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -6973,17 +6973,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path9) {
-      const ctrl = callVisitor(key, node, visitor, path9);
+    function visit_(key, node, visitor, path10) {
+      const ctrl = callVisitor(key, node, visitor, path10);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path9, ctrl);
-        return visit_(key, ctrl, visitor, path9);
+        replaceNode(key, path10, ctrl);
+        return visit_(key, ctrl, visitor, path10);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path9 = Object.freeze(path9.concat(node));
+          path10 = Object.freeze(path10.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path9);
+            const ci = visit_(i, node.items[i], visitor, path10);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -6994,13 +6994,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path9 = Object.freeze(path9.concat(node));
-          const ck = visit_("key", node.key, visitor, path9);
+          path10 = Object.freeze(path10.concat(node));
+          const ck = visit_("key", node.key, visitor, path10);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path9);
+          const cv = visit_("value", node.value, visitor, path10);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -7021,17 +7021,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path9) {
-      const ctrl = await callVisitor(key, node, visitor, path9);
+    async function visitAsync_(key, node, visitor, path10) {
+      const ctrl = await callVisitor(key, node, visitor, path10);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path9, ctrl);
-        return visitAsync_(key, ctrl, visitor, path9);
+        replaceNode(key, path10, ctrl);
+        return visitAsync_(key, ctrl, visitor, path10);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path9 = Object.freeze(path9.concat(node));
+          path10 = Object.freeze(path10.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path9);
+            const ci = await visitAsync_(i, node.items[i], visitor, path10);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -7042,13 +7042,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path9 = Object.freeze(path9.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path9);
+          path10 = Object.freeze(path10.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path10);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path9);
+          const cv = await visitAsync_("value", node.value, visitor, path10);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -7075,23 +7075,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path9) {
+    function callVisitor(key, node, visitor, path10) {
       if (typeof visitor === "function")
-        return visitor(key, node, path9);
+        return visitor(key, node, path10);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path9);
+        return visitor.Map?.(key, node, path10);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path9);
+        return visitor.Seq?.(key, node, path10);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path9);
+        return visitor.Pair?.(key, node, path10);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path9);
+        return visitor.Scalar?.(key, node, path10);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path9);
+        return visitor.Alias?.(key, node, path10);
       return void 0;
     }
-    function replaceNode(key, path9, node) {
-      const parent = path9[path9.length - 1];
+    function replaceNode(key, path10, node) {
+      const parent = path10[path10.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -7701,10 +7701,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path9, value) {
+    function collectionFromPath(schema, path10, value) {
       let v = value;
-      for (let i = path9.length - 1; i >= 0; --i) {
-        const k = path9[i];
+      for (let i = path10.length - 1; i >= 0; --i) {
+        const k = path10[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -7723,7 +7723,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path9) => path9 == null || typeof path9 === "object" && !!path9[Symbol.iterator]().next().done;
+    var isEmptyPath = (path10) => path10 == null || typeof path10 === "object" && !!path10[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -7753,11 +7753,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path9, value) {
-        if (isEmptyPath(path9))
+      addIn(path10, value) {
+        if (isEmptyPath(path10))
           this.add(value);
         else {
-          const [key, ...rest] = path9;
+          const [key, ...rest] = path10;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -7771,8 +7771,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path9) {
-        const [key, ...rest] = path9;
+      deleteIn(path10) {
+        const [key, ...rest] = path10;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -7786,8 +7786,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path9, keepScalar) {
-        const [key, ...rest] = path9;
+      getIn(path10, keepScalar) {
+        const [key, ...rest] = path10;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -7805,8 +7805,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path9) {
-        const [key, ...rest] = path9;
+      hasIn(path10) {
+        const [key, ...rest] = path10;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -7816,8 +7816,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path9, value) {
-        const [key, ...rest] = path9;
+      setIn(path10, value) {
+        const [key, ...rest] = path10;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -10332,9 +10332,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path9, value) {
+      addIn(path10, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path9, value);
+          this.contents.addIn(path10, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -10409,14 +10409,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path9) {
-        if (Collection.isEmptyPath(path9)) {
+      deleteIn(path10) {
+        if (Collection.isEmptyPath(path10)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path9) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path10) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -10431,10 +10431,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path9, keepScalar) {
-        if (Collection.isEmptyPath(path9))
+      getIn(path10, keepScalar) {
+        if (Collection.isEmptyPath(path10))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path9, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path10, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -10445,10 +10445,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path9) {
-        if (Collection.isEmptyPath(path9))
+      hasIn(path10) {
+        if (Collection.isEmptyPath(path10))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path9) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path10) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -10465,13 +10465,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path9, value) {
-        if (Collection.isEmptyPath(path9)) {
+      setIn(path10, value) {
+        if (Collection.isEmptyPath(path10)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path9), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path10), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path9, value);
+          this.contents.setIn(path10, value);
         }
       }
       /**
@@ -12431,9 +12431,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path9) => {
+    visit.itemAtPath = (cst, path10) => {
       let item = cst;
-      for (const [field, index] of path9) {
+      for (const [field, index] of path10) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -12442,23 +12442,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path9) => {
-      const parent = visit.itemAtPath(cst, path9.slice(0, -1));
-      const field = path9[path9.length - 1][0];
+    visit.parentCollection = (cst, path10) => {
+      const parent = visit.itemAtPath(cst, path10.slice(0, -1));
+      const field = path10[path10.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path9, item, visitor) {
-      let ctrl = visitor(item, path9);
+    function _visit(path10, item, visitor) {
+      let ctrl = visitor(item, path10);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path9.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path10.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -12469,10 +12469,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path9);
+            ctrl = ctrl(item, path10);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path9) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path10) : ctrl;
     }
     exports.visit = visit;
   }
@@ -13774,14 +13774,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs9 = this.flowScalar(this.type);
+              const fs10 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs9, sep: [] });
+                map.items.push({ start, key: fs10, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs9);
+                this.stack.push(fs10);
               } else {
-                Object.assign(it, { key: fs9, sep: [] });
+                Object.assign(it, { key: fs10, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -13909,13 +13909,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs9 = this.flowScalar(this.type);
+              const fs10 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs9, sep: [] });
+                fc.items.push({ start: [], key: fs10, sep: [] });
               else if (it.sep)
-                this.stack.push(fs9);
+                this.stack.push(fs10);
               else
-                Object.assign(it, { key: fs9, sep: [] });
+                Object.assign(it, { key: fs10, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -14466,10 +14466,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path9) {
-  if (!path9)
+function getElementAtPath(obj, path10) {
+  if (!path10)
     return obj;
-  return path9.reduce((acc, key) => acc?.[key], obj);
+  return path10.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -14878,11 +14878,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path9, issues) {
+function prefixIssues(path10, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path9);
+    iss.path.unshift(path10);
     return iss;
   });
 }
@@ -15029,16 +15029,16 @@ function flattenError(error2, mapper = (issue2) => issue2.message) {
 }
 function formatError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error3, path9 = []) => {
+  const processError = (error3, path10 = []) => {
     for (const issue2 of error3.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path9, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path10, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path9, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path10, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path9, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path10, ...issue2.path]);
       } else {
-        const fullpath = [...path9, ...issue2.path];
+        const fullpath = [...path10, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -22982,8 +22982,8 @@ var StdioServerTransport = class {
 };
 
 // src/index.ts
-import path8 from "node:path";
-import fs8 from "node:fs";
+import path9 from "node:path";
+import fs9 from "node:fs";
 import { homedir as homedir4, tmpdir } from "node:os";
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
@@ -25378,16 +25378,39 @@ function evaluate(input) {
 }
 
 // src/policy/cache.ts
+import fs2 from "node:fs";
+import path2 from "node:path";
+import os from "node:os";
+
+// src/atomic-write.ts
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+function writeFileAtomicSync(filePath, data, mode) {
+  const tmpPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.tmp`
+  );
+  try {
+    fs.writeFileSync(tmpPath, data, { encoding: "utf-8", mode });
+    fs.chmodSync(tmpPath, mode);
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+    }
+    throw err;
+  }
+}
+
+// src/policy/cache.ts
 function cachePath() {
-  const base = process.env.PLUGIN_DATA_DIR || path.join(os.homedir(), ".glean");
-  return path.join(base, "policy-cache.json");
+  const base = process.env.PLUGIN_DATA_DIR || path2.join(os.homedir(), ".glean");
+  return path2.join(base, "policy-cache.json");
 }
 function readAll() {
   try {
-    const parsed = JSON.parse(fs.readFileSync(cachePath(), "utf-8"));
+    const parsed = JSON.parse(fs2.readFileSync(cachePath(), "utf-8"));
     return typeof parsed === "object" && parsed !== null ? parsed : {};
   } catch {
     return {};
@@ -25396,8 +25419,8 @@ function readAll() {
 function writeAll(data) {
   const file = cachePath();
   try {
-    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 448 });
-    fs.writeFileSync(file, JSON.stringify(data, null, 2), { mode: 384 });
+    fs2.mkdirSync(path2.dirname(file), { recursive: true, mode: 448 });
+    writeFileAtomicSync(file, JSON.stringify(data, null, 2), 384);
   } catch {
   }
 }
@@ -25808,21 +25831,21 @@ function closeCallbackServer() {
 }
 
 // src/token-store.ts
-import fs2 from "node:fs";
-import path2 from "node:path";
+import fs3 from "node:fs";
+import path3 from "node:path";
 import { homedir } from "node:os";
 var CREDENTIALS_FILENAME = "mcp-credentials.json";
 var DIR_MODE = 448;
 var FILE_MODE = 384;
 function resolveCredentialsDir() {
-  return process.env.PLUGIN_DATA_DIR || path2.join(homedir(), ".glean");
+  return process.env.PLUGIN_DATA_DIR || path3.join(homedir(), ".glean");
 }
 function credentialsFile() {
-  return path2.join(resolveCredentialsDir(), CREDENTIALS_FILENAME);
+  return path3.join(resolveCredentialsDir(), CREDENTIALS_FILENAME);
 }
 function loadCredentials() {
   try {
-    const raw = fs2.readFileSync(credentialsFile(), "utf-8");
+    const raw = fs3.readFileSync(credentialsFile(), "utf-8");
     return JSON.parse(raw);
   } catch {
     return void 0;
@@ -25831,15 +25854,15 @@ function loadCredentials() {
 function saveCredentials(tokens, clientInfo) {
   try {
     const filePath = credentialsFile();
-    const dir = path2.dirname(filePath);
-    fs2.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
-    fs2.chmodSync(dir, DIR_MODE);
+    const dir = path3.dirname(filePath);
+    fs3.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+    fs3.chmodSync(dir, DIR_MODE);
     const data = { tokens, clientInfo };
-    fs2.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+    fs3.writeFileSync(filePath, JSON.stringify(data, null, 2), {
       encoding: "utf-8",
       mode: FILE_MODE
     });
-    fs2.chmodSync(filePath, FILE_MODE);
+    fs3.chmodSync(filePath, FILE_MODE);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[auth] Failed to persist credentials: ${msg}`);
@@ -25847,7 +25870,7 @@ function saveCredentials(tokens, clientInfo) {
 }
 function clearCredentials() {
   try {
-    fs2.rmSync(credentialsFile(), { force: true });
+    fs3.rmSync(credentialsFile(), { force: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[auth] Failed to clear credentials: ${msg}`);
@@ -25985,11 +26008,11 @@ var GleanOAuthClientProvider = class {
 
 // src/skill-writer.ts
 var import_yaml = __toESM(require_dist2(), 1);
-import fs3 from "node:fs/promises";
-import path3 from "node:path";
+import fs4 from "node:fs/promises";
+import path4 from "node:path";
 function isInsideDir(filePath, dir) {
-  const resolved = path3.resolve(filePath);
-  return resolved.startsWith(path3.resolve(dir) + path3.sep);
+  const resolved = path4.resolve(filePath);
+  return resolved.startsWith(path4.resolve(dir) + path4.sep);
 }
 function parseFrontmatter(content) {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -26014,7 +26037,7 @@ function parseFrontmatter(content) {
 async function evictStaleSkills(baseDir, maxAgeMs, log, now = Date.now()) {
   let entries;
   try {
-    entries = await fs3.readdir(baseDir, { withFileTypes: true });
+    entries = await fs4.readdir(baseDir, { withFileTypes: true });
   } catch {
     return;
   }
@@ -26022,12 +26045,12 @@ async function evictStaleSkills(baseDir, maxAgeMs, log, now = Date.now()) {
   await Promise.all(
     entries.map(async (entry) => {
       if (!entry.isDirectory()) return;
-      const skillDir = path3.resolve(baseDir, entry.name);
+      const skillDir = path4.resolve(baseDir, entry.name);
       if (!isInsideDir(skillDir, baseDir)) return;
       try {
-        const stat = await fs3.stat(skillDir);
+        const stat = await fs4.stat(skillDir);
         if (stat.mtimeMs < cutoff) {
-          await fs3.rm(skillDir, { recursive: true, force: true });
+          await fs4.rm(skillDir, { recursive: true, force: true });
           log?.("evict-stale-skill", { skill: entry.name });
         }
       } catch (err) {
@@ -26040,21 +26063,21 @@ async function evictStaleSkills(baseDir, maxAgeMs, log, now = Date.now()) {
 async function writeSkillsToDisk(skills, baseDir) {
   const index = [];
   for (const [skillName, fileMap] of Object.entries(skills)) {
-    const skillDir = path3.resolve(baseDir, skillName);
+    const skillDir = path4.resolve(baseDir, skillName);
     if (!isInsideDir(skillDir, baseDir)) {
       continue;
     }
-    await fs3.rm(skillDir, { recursive: true, force: true });
-    await fs3.mkdir(skillDir, { recursive: true });
+    await fs4.rm(skillDir, { recursive: true, force: true });
+    await fs4.mkdir(skillDir, { recursive: true });
     const writtenFiles = [];
     for (const [filePath, content] of Object.entries(fileMap)) {
-      const fullPath = path3.resolve(skillDir, filePath);
+      const fullPath = path4.resolve(skillDir, filePath);
       if (!isInsideDir(fullPath, skillDir)) {
         continue;
       }
-      await fs3.mkdir(path3.dirname(fullPath), { recursive: true });
+      await fs4.mkdir(path4.dirname(fullPath), { recursive: true });
       const text = typeof content === "string" ? content : JSON.stringify(content);
-      await fs3.writeFile(fullPath, text, "utf-8");
+      await fs4.writeFile(fullPath, text, "utf-8");
       writtenFiles.push(fullPath);
     }
     const rawSkillMd = fileMap["SKILL.md"] ?? "";
@@ -26122,13 +26145,13 @@ async function handleFindSkills(remoteClient, skillsBaseDir, args) {
 }
 
 // src/tools/run-tool.ts
-import fs5 from "node:fs/promises";
+import fs6 from "node:fs/promises";
 import os3 from "node:os";
-import path5 from "node:path";
+import path6 from "node:path";
 
 // src/tools/approval-args.ts
-import fs4 from "node:fs/promises";
-import path4 from "node:path";
+import fs5 from "node:fs/promises";
+import path5 from "node:path";
 import os2 from "node:os";
 
 // src/session-id.ts
@@ -26219,10 +26242,10 @@ function formatArgumentsForFile(toolName, args) {
 async function writeApprovalArgsFile(toolName, args) {
   const base = process.env.PLUGIN_DATA_DIR || process.env.CLAUDE_PLUGIN_DATA || os2.tmpdir();
   const sessionId = resolveSessionId().replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 64);
-  const dir = path4.join(base, "glean-approvals", sessionId);
-  await fs4.mkdir(dir, { recursive: true });
-  const file = path4.join(dir, "glean-approval-args.md");
-  await fs4.writeFile(file, formatArgumentsForFile(toolName, args), "utf-8");
+  const dir = path5.join(base, "glean-approvals", sessionId);
+  await fs5.mkdir(dir, { recursive: true });
+  const file = path5.join(dir, "glean-approval-args.md");
+  await fs5.writeFile(file, formatArgumentsForFile(toolName, args), "utf-8");
   return file;
 }
 
@@ -26272,7 +26295,7 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
         `file_args.${argName} must be a non-empty string path`
       );
     }
-    if (!path5.isAbsolute(filePathRaw)) {
+    if (!path6.isAbsolute(filePathRaw)) {
       throw new FileArgsError(
         `file_args.${argName} must be an absolute path; got "${filePathRaw}"`
       );
@@ -26284,7 +26307,7 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
     }
     let stat;
     try {
-      stat = await fs5.stat(filePathRaw);
+      stat = await fs6.stat(filePathRaw);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new FileArgsError(
@@ -26301,7 +26324,7 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
         `file_args.${argName}: "${filePathRaw}" is ${stat.size} bytes, exceeds ${maxBytes} byte limit (set GLEAN_FILE_ARG_MAX_BYTES to override)`
       );
     }
-    const content = await fs5.readFile(filePathRaw, "utf-8");
+    const content = await fs6.readFile(filePathRaw, "utf-8");
     const types = declaredParamTypes(inputSchema, argName);
     if (types.has("object") || types.has("array")) {
       try {
@@ -26324,12 +26347,12 @@ async function resolveFileArgs(fileArgs, baseArgs, inputSchema) {
 }
 async function findToolJson(skillsBaseDir, toolName) {
   try {
-    const skillDirs = await fs5.readdir(skillsBaseDir, { withFileTypes: true });
+    const skillDirs = await fs6.readdir(skillsBaseDir, { withFileTypes: true });
     for (const dir of skillDirs) {
       if (!dir.isDirectory()) continue;
-      const toolPath = path5.join(skillsBaseDir, dir.name, "tools", `${toolName}.json`);
+      const toolPath = path6.join(skillsBaseDir, dir.name, "tools", `${toolName}.json`);
       try {
-        const content = await fs5.readFile(toolPath, "utf-8");
+        const content = await fs6.readFile(toolPath, "utf-8");
         return JSON.parse(content);
       } catch {
         continue;
@@ -26370,13 +26393,13 @@ function primeElicitationCancellation(mcpServer2) {
   });
 }
 function permissionModeMarkerPath() {
-  const base = process.env.CLAUDE_PLUGIN_DATA || path5.join(os3.homedir(), ".glean");
+  const base = process.env.CLAUDE_PLUGIN_DATA || path6.join(os3.homedir(), ".glean");
   const sessionId = resolveSessionId().replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 64);
-  return path5.join(base, "glean-hitl-mode", `${sessionId}.json`);
+  return path6.join(base, "glean-hitl-mode", `${sessionId}.json`);
 }
 async function currentPermissionMode() {
   try {
-    const raw = await fs5.readFile(permissionModeMarkerPath(), "utf-8");
+    const raw = await fs6.readFile(permissionModeMarkerPath(), "utf-8");
     const parsed = JSON.parse(raw);
     return typeof parsed.permission_mode === "string" ? parsed.permission_mode : null;
   } catch {
@@ -26473,21 +26496,21 @@ function runToolAnnotations(enableHitl, clientSupportsElicitation, isCursor) {
 }
 
 // src/url-config-store.ts
-import fs6 from "node:fs";
-import path6 from "node:path";
+import fs7 from "node:fs";
+import path7 from "node:path";
 import { homedir as homedir2 } from "node:os";
 var CONFIG_FILENAME = "mcp-server-url.json";
 var DIR_MODE2 = 448;
 var FILE_MODE2 = 384;
 function resolveConfigDir() {
-  return process.env.PLUGIN_DATA_DIR || path6.join(homedir2(), ".glean");
+  return process.env.PLUGIN_DATA_DIR || path7.join(homedir2(), ".glean");
 }
 function configFile() {
-  return path6.join(resolveConfigDir(), CONFIG_FILENAME);
+  return path7.join(resolveConfigDir(), CONFIG_FILENAME);
 }
 function loadServerUrl() {
   try {
-    const raw = fs6.readFileSync(configFile(), "utf-8");
+    const raw = fs7.readFileSync(configFile(), "utf-8");
     const data = JSON.parse(raw);
     if (typeof data.serverUrl !== "string" || !data.serverUrl) return void 0;
     return data.serverUrl;
@@ -26497,39 +26520,39 @@ function loadServerUrl() {
 }
 function saveServerUrl(url2) {
   const filePath = configFile();
-  const dir = path6.dirname(filePath);
-  fs6.mkdirSync(dir, { recursive: true, mode: DIR_MODE2 });
-  fs6.chmodSync(dir, DIR_MODE2);
+  const dir = path7.dirname(filePath);
+  fs7.mkdirSync(dir, { recursive: true, mode: DIR_MODE2 });
+  fs7.chmodSync(dir, DIR_MODE2);
   const data = { serverUrl: url2 };
-  fs6.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+  fs7.writeFileSync(filePath, JSON.stringify(data, null, 2), {
     encoding: "utf-8",
     mode: FILE_MODE2
   });
-  fs6.chmodSync(filePath, FILE_MODE2);
+  fs7.chmodSync(filePath, FILE_MODE2);
 }
 function clearServerUrl() {
   try {
-    fs6.rmSync(configFile(), { force: true });
+    fs7.rmSync(configFile(), { force: true });
   } catch {
   }
 }
 
 // src/remote-tools-cache-store.ts
-import fs7 from "node:fs";
-import path7 from "node:path";
+import fs8 from "node:fs";
+import path8 from "node:path";
 import { homedir as homedir3 } from "node:os";
 var CACHE_FILENAME = "remote-tools-cache.json";
 var DIR_MODE3 = 448;
 var FILE_MODE3 = 384;
 function resolveCacheDir() {
-  return process.env.PLUGIN_DATA_DIR || path7.join(homedir3(), ".glean");
+  return process.env.PLUGIN_DATA_DIR || path8.join(homedir3(), ".glean");
 }
 function cacheFile() {
-  return path7.join(resolveCacheDir(), CACHE_FILENAME);
+  return path8.join(resolveCacheDir(), CACHE_FILENAME);
 }
 function readStore() {
   try {
-    const raw = fs7.readFileSync(cacheFile(), "utf-8");
+    const raw = fs8.readFileSync(cacheFile(), "utf-8");
     const data = JSON.parse(raw);
     if (data && typeof data === "object" && !Array.isArray(data)) {
       return data;
@@ -26541,14 +26564,10 @@ function readStore() {
 }
 function writeStore(store) {
   const filePath = cacheFile();
-  const dir = path7.dirname(filePath);
-  fs7.mkdirSync(dir, { recursive: true, mode: DIR_MODE3 });
-  fs7.chmodSync(dir, DIR_MODE3);
-  fs7.writeFileSync(filePath, JSON.stringify(store, null, 2), {
-    encoding: "utf-8",
-    mode: FILE_MODE3
-  });
-  fs7.chmodSync(filePath, FILE_MODE3);
+  const dir = path8.dirname(filePath);
+  fs8.mkdirSync(dir, { recursive: true, mode: DIR_MODE3 });
+  fs8.chmodSync(dir, DIR_MODE3);
+  writeFileAtomicSync(filePath, JSON.stringify(store, null, 2), FILE_MODE3);
 }
 function loadRemoteTools(serverUrl) {
   if (!serverUrl) return [];
@@ -26571,14 +26590,14 @@ function saveRemoteTools(serverUrl, tools) {
 function clearRemoteTools(serverUrl) {
   try {
     if (!serverUrl) {
-      fs7.rmSync(cacheFile(), { force: true });
+      fs8.rmSync(cacheFile(), { force: true });
       return;
     }
     const store = readStore();
     if (store[serverUrl] !== void 0) {
       delete store[serverUrl];
       if (Object.keys(store).length === 0) {
-        fs7.rmSync(cacheFile(), { force: true });
+        fs8.rmSync(cacheFile(), { force: true });
       } else {
         writeStore(store);
       }
@@ -26769,14 +26788,14 @@ var EMAIL_RESOLVE_FAILED_TEXT = `Double-check the email for typos and try again 
 var SETUP_NEEDED_ERROR = "Glean is not configured yet. Call the `setup` tool first to provide your Glean Server URL before using find_skills or run_tool.";
 var AUTH_REDIRECT_TO_SETUP_TEXT = "[SETUP_REQUIRED]\n\nAuthentication is required. Call the `setup` tool (no arguments) to sign in to Glean, then retry this tool.";
 function resolveLogPath() {
-  const base = process.env.PLUGIN_DATA_DIR || path8.join(homedir4(), ".glean");
-  return path8.join(base, "glean-server.log");
+  const base = process.env.PLUGIN_DATA_DIR || path9.join(homedir4(), ".glean");
+  return path9.join(base, "glean-server.log");
 }
 var LOG_PATH = resolveLogPath();
 try {
-  const logDir = path8.dirname(LOG_PATH);
-  fs8.mkdirSync(logDir, { recursive: true, mode: 448 });
-  fs8.chmodSync(logDir, 448);
+  const logDir = path9.dirname(LOG_PATH);
+  fs9.mkdirSync(logDir, { recursive: true, mode: 448 });
+  fs9.chmodSync(logDir, 448);
 } catch {
 }
 function logLine2(label, detail) {
@@ -26785,8 +26804,8 @@ function logLine2(label, detail) {
   const line = `${ts} ${label}${suffix}
 `;
   try {
-    fs8.appendFileSync(LOG_PATH, line, { mode: 384 });
-    fs8.chmodSync(LOG_PATH, 384);
+    fs9.appendFileSync(LOG_PATH, line, { mode: 384 });
+    fs9.chmodSync(LOG_PATH, 384);
   } catch {
   }
   console.error(line.trimEnd());
@@ -26795,7 +26814,7 @@ function resolveSkillsBaseDir() {
   if (process.env.SKILLS_BASE_DIR) {
     return process.env.SKILLS_BASE_DIR;
   }
-  return path8.join(tmpdir(), "glean-skills-cache");
+  return path9.join(tmpdir(), "glean-skills-cache");
 }
 var server = new Server(
   { name: "glean", version: pluginVersionString() },

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25401,8 +25401,8 @@ function writeAll(data) {
   } catch {
   }
 }
-function loadCached(serverUrl) {
-  return readAll()[serverUrl] ?? {};
+function loadCachedPolicy(serverUrl) {
+  return readAll()[serverUrl]?.policy;
 }
 function savePolicy(serverUrl, policy) {
   const all = readAll();
@@ -25525,7 +25525,7 @@ function recordPolicyFromResult(result, label) {
   const serverUrl = cacheKeyUrl;
   if (!serverUrl) return;
   const outcome = classifyResult(result);
-  const cached2 = loadCached(serverUrl);
+  const cachedPolicy = loadCachedPolicy(serverUrl);
   let policy;
   switch (outcome.kind) {
     case "policy":
@@ -25537,7 +25537,7 @@ function recordPolicyFromResult(result, label) {
       break;
     case "malformed":
       logLine("policy.malformed", { label, reason: outcome.reason });
-      policy = cached2.policy;
+      policy = cachedPolicy;
       break;
     case "no-policy":
       policy = void 0;

--- a/src/atomic-write.ts
+++ b/src/atomic-write.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Write a file so no reader can observe a partial one.
+ *
+ * `fs.writeFileSync` truncates and then writes, so a process killed mid-write leaves a
+ * truncated file behind. Every store here parses JSON and treats a parse failure as "no
+ * data", so a torn write does not surface as an error — it silently discards whatever was
+ * stored. For the policy cache that is the one outcome we have gone out of our way to
+ * prevent: nothing is allowed to clear it, precisely because a cached policy may carry a
+ * deactivation or a version block, and a crash mid-write would clear it anyway.
+ *
+ * Writing to a sibling temp file and renaming makes the swap atomic — a reader sees either
+ * the old contents or the new ones, never a mixture. The temp file must live in the same
+ * directory, since rename is only atomic within a filesystem, and it carries the pid
+ * because each host session runs its own plugin process and they share these files.
+ *
+ * This is NOT mutual exclusion. Two processes doing read-modify-write can still lose one
+ * update, last writer winning; they simply cannot corrupt the file. A lost update
+ * self-heals on the next negotiation, whereas a corrupt file discards every entry for
+ * every URL until something rewrites it.
+ *
+ * On failure the temp file is removed and the error rethrown, leaving whatever was
+ * already on disk intact. Windows can fail the rename with EPERM/EBUSY when another
+ * process holds the target open; callers already tolerate a failed write, so that
+ * degrades to "this write was skipped" rather than to corruption.
+ */
+export function writeFileAtomicSync(
+  filePath: string,
+  data: string,
+  mode: number,
+): void {
+  const tmpPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.tmp`,
+  );
+  try {
+    fs.writeFileSync(tmpPath, data, { encoding: "utf-8", mode });
+    // writeFileSync only applies `mode` when it creates the file, so a leftover temp
+    // from a previous crash could otherwise keep looser permissions.
+    fs.chmodSync(tmpPath, mode);
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // Nothing further to do; the target is untouched either way.
+    }
+    throw err;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { resolveSessionId } from "./session-id.js";
 import { resolveServerUrlFromEmail } from "./config-search.js";
 import { pluginVersionString } from "./version.js";
 import {
+  clearPolicyCache,
   initPolicySession,
   policySummary,
   protocolVersion,
@@ -752,6 +753,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         oauthProvider = undefined;
         cachedRemoteTools = [];
         setPolicyServerUrl(undefined);
+        clearPolicyCache();
         logLine("setup.reset");
         // Fire-and-forget — tools list is shorter without the dynamic
         // surface; the host should re-fetch on its next idle cycle.

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ import { resolveSessionId } from "./session-id.js";
 import { resolveServerUrlFromEmail } from "./config-search.js";
 import { pluginVersionString } from "./version.js";
 import {
-  clearPolicyCache,
   initPolicySession,
   policySummary,
   protocolVersion,
@@ -752,8 +751,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         clearRemoteTools();
         oauthProvider = undefined;
         cachedRemoteTools = [];
+        // The cached POLICY deliberately survives reset. Only a valid policy replaces
+        // it, so a user-invokable reset must not become a way to drop a cached
+        // deactivation or version block — the remote may be unreachable afterwards,
+        // in which case there is nothing to refresh it from. Re-keying is enough:
+        // the cache is keyed by remote URL, so a different instance never inherits it.
         setPolicyServerUrl(undefined);
-        clearPolicyCache();
         logLine("setup.reset");
         // Fire-and-forget — tools list is shorter without the dynamic
         // surface; the host should re-fetch on its next idle cycle.

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ import {
 import { resolveSessionId } from "./session-id.js";
 import { resolveServerUrlFromEmail } from "./config-search.js";
 import { pluginVersionString } from "./version.js";
+import {
+  initPolicySession,
+  policySummary,
+  protocolVersion,
+  setPolicyServerUrl,
+} from "./policy/session.js";
 
 function readEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -130,6 +136,11 @@ const server = new Server(
   { name: "glean", version: pluginVersionString() },
   { capabilities: { tools: { listChanged: true } } },
 );
+
+// Capability/policy negotiation. This reports the plugin's context to the remote and
+// records whatever policy comes back; it does not yet change what the plugin does.
+initPolicySession(server, logLine);
+setPolicyServerUrl(resolveServerUrl());
 
 let oauthProvider: GleanOAuthClientProvider | undefined;
 
@@ -539,7 +550,11 @@ async function advanceSetup(): Promise<CallToolResult> {
             `Glean setup is complete.\n` +
             `Server URL: ${serverUrl}\n` +
             `Authenticated: yes\n` +
-            `Remote tools: ${toolNames}\n\n` +
+            `Remote tools: ${toolNames}\n` +
+            // Surfacing the negotiated context here is what makes a build with a
+            // missing version constant, or an unobserved MCP revision, visible per
+            // install rather than only in logs.
+            `${policySummary().join("\n")}\n\n` +
             `You can now use find_skills, run_tool, and any of the listed ` +
             `remote tools.`,
         },
@@ -736,6 +751,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         clearRemoteTools();
         oauthProvider = undefined;
         cachedRemoteTools = [];
+        setPolicyServerUrl(undefined);
         logLine("setup.reset");
         // Fire-and-forget — tools list is shorter without the dynamic
         // surface; the host should re-fetch on its next idle cycle.
@@ -815,6 +831,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         clearCredentials();
         oauthProvider = undefined;
         cachedRemoteTools = loadRemoteTools(normalized);
+        // Re-key the policy cache: a different instance must not inherit the previous
+        // instance's policy.
+        setPolicyServerUrl(normalized);
         logLine("setup.configured", { serverUrl: normalized });
         // Fall through to advanceSetup, which will now find URL ✓ and try
         // to drive auth + tool fetch in the same call.
@@ -841,7 +860,10 @@ async function main() {
     logLine("evict-stale-skills.failed", { msg });
   }
 
-  const transport = new StdioServerTransport();
+  // Wrap the transport so the negotiated MCP revision can be observed: the SDK settles
+  // it internally during `initialize` and exposes no server-side accessor for the
+  // result. `Transport` is a plain interface, so this needs no subclassing.
+  const transport = protocolVersion.wrap(new StdioServerTransport());
   await server.connect(transport);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,10 +112,15 @@ try {
   /* ignore */
 }
 
+// Every line carries the pid. Hosts spawn and reap this server on their own schedule,
+// and several processes can be alive at once writing to this one shared log, so without
+// a pid an interleaved log cannot be split back into per-process histories — and
+// whether two lines came from one process or two is exactly the question that arises
+// when in-memory state (the negotiated decision, the session id) appears inconsistent.
 function logLine(label: string, detail?: Record<string, unknown>): void {
   const ts = new Date().toISOString();
   const suffix = detail ? ` ${JSON.stringify(detail)}` : "";
-  const line = `${ts} ${label}${suffix}\n`;
+  const line = `${ts} [${process.pid}] ${label}${suffix}\n`;
   try {
     fs.appendFileSync(LOG_PATH, line, { mode: 0o600 });
     fs.chmodSync(LOG_PATH, 0o600);

--- a/src/policy/cache.ts
+++ b/src/policy/cache.ts
@@ -3,17 +3,18 @@ import path from "node:path";
 import os from "node:os";
 import type { PolicyResponse } from "./types.js";
 
-// Two independently-updated cache entries, keyed by remote URL so switching
-// instances does not cross-contaminate:
+// The last VALID policy, keyed by remote URL so switching instances does not
+// cross-contaminate. It survives a response that carried no policy and survives a
+// malformed one; only a valid policy replaces it.
 //
-//   policy     - the last VALID policy. Survives a response that carried no
-//                policy and survives a malformed one; only a valid policy
-//                replaces it.
-//   toolsList  - the last successful tools/list result, replayed when the remote
-//                is unreachable so the advertised surface does not vanish.
+// tools/list is deliberately NOT cached here, even though the design pairs a cached
+// policy with a cached surface for the unreachable case. remote-tools-cache-store.ts
+// already owns that: it is typed as Tool[] rather than unknown, and is wired into the
+// startup, setup, and instance-switch paths. A second copy here would shadow a live
+// subsystem, and the two could then disagree about which surface belongs with which
+// policy. Anything replaying a cached surface reads it from there.
 interface CacheEntry {
   policy?: PolicyResponse;
-  toolsList?: unknown;
   updatedAt?: string;
 }
 
@@ -57,17 +58,6 @@ export function savePolicy(serverUrl: string, policy: PolicyResponse): void {
   all[serverUrl] = {
     ...entry,
     policy,
-    updatedAt: new Date().toISOString(),
-  };
-  writeAll(all);
-}
-
-export function saveToolsList(serverUrl: string, toolsList: unknown): void {
-  const all = readAll();
-  const entry = all[serverUrl] ?? {};
-  all[serverUrl] = {
-    ...entry,
-    toolsList,
     updatedAt: new Date().toISOString(),
   };
   writeAll(all);

--- a/src/policy/cache.ts
+++ b/src/policy/cache.ts
@@ -63,12 +63,13 @@ export function savePolicy(serverUrl: string, policy: PolicyResponse): void {
   writeAll(all);
 }
 
-export function clearCache(serverUrl?: string): void {
-  if (!serverUrl) {
-    writeAll({});
-    return;
-  }
-  const all = readAll();
-  delete all[serverUrl];
-  writeAll(all);
-}
+// There is deliberately no clear function. Only a valid policy replaces a cached
+// policy, and nothing removes one — including `setup({reset})`, which clears the
+// server URL, credentials, and tools cache. A cached policy may carry a deactivation
+// or a version block, so any local way to discard it is a way to shed one, and the
+// remote may be unreachable afterwards with nothing to re-fetch from. The design makes
+// the same point about process starts: a fresh plugin with no connection is not a
+// licence to ignore a cached policy, or every restart would silently undo it.
+//
+// Switching instances needs no clear either: entries are keyed by remote URL, so a
+// different instance simply reads a different (absent) entry.

--- a/src/policy/cache.ts
+++ b/src/policy/cache.ts
@@ -59,15 +59,15 @@ export function loadCachedPolicy(serverUrl: string): PolicyResponse | undefined 
   return readAll()[serverUrl]?.policy;
 }
 
-/** Replace the cached policy. Only ever called with a VALIDATED policy. */
+/**
+ * Replace the cached policy. Only ever called with a VALIDATED policy.
+ *
+ * Reads every entry to write one, because the file is a map over remote URLs and the
+ * other URLs' entries have to survive the write.
+ */
 export function savePolicy(serverUrl: string, policy: PolicyResponse): void {
   const all = readAll();
-  const entry = all[serverUrl] ?? {};
-  all[serverUrl] = {
-    ...entry,
-    policy,
-    updatedAt: new Date().toISOString(),
-  };
+  all[serverUrl] = { policy, updatedAt: new Date().toISOString() };
   writeAll(all);
 }
 

--- a/src/policy/cache.ts
+++ b/src/policy/cache.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import type { PolicyResponse } from "./types.js";
+
+// Two independently-updated cache entries, keyed by remote URL so switching
+// instances does not cross-contaminate:
+//
+//   policy     - the last VALID policy. Survives a response that carried no
+//                policy and survives a malformed one; only a valid policy
+//                replaces it.
+//   toolsList  - the last successful tools/list result, replayed when the remote
+//                is unreachable so the advertised surface does not vanish.
+interface CacheEntry {
+  policy?: PolicyResponse;
+  toolsList?: unknown;
+  updatedAt?: string;
+}
+
+type CacheFile = Record<string, CacheEntry>;
+
+// Same anchor as url-config-store and token-store: PLUGIN_DATA_DIR when the host
+// provides a managed data directory, else ~/.glean.
+function cachePath(): string {
+  const base = process.env.PLUGIN_DATA_DIR || path.join(os.homedir(), ".glean");
+  return path.join(base, "policy-cache.json");
+}
+
+function readAll(): CacheFile {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath(), "utf-8"));
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(data: CacheFile): void {
+  const file = cachePath();
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(file, JSON.stringify(data, null, 2), { mode: 0o600 });
+  } catch {
+    // A cache that cannot be written degrades to in-session-only behavior, which
+    // is a worse experience but never a wrong policy decision.
+  }
+}
+
+export function loadCached(serverUrl: string): CacheEntry {
+  return readAll()[serverUrl] ?? {};
+}
+
+/** Replace the cached policy. Only ever called with a VALIDATED policy. */
+export function savePolicy(serverUrl: string, policy: PolicyResponse): void {
+  const all = readAll();
+  const entry = all[serverUrl] ?? {};
+  all[serverUrl] = {
+    ...entry,
+    policy,
+    updatedAt: new Date().toISOString(),
+  };
+  writeAll(all);
+}
+
+export function saveToolsList(serverUrl: string, toolsList: unknown): void {
+  const all = readAll();
+  const entry = all[serverUrl] ?? {};
+  all[serverUrl] = {
+    ...entry,
+    toolsList,
+    updatedAt: new Date().toISOString(),
+  };
+  writeAll(all);
+}
+
+export function clearCache(serverUrl?: string): void {
+  if (!serverUrl) {
+    writeAll({});
+    return;
+  }
+  const all = readAll();
+  delete all[serverUrl];
+  writeAll(all);
+}

--- a/src/policy/cache.ts
+++ b/src/policy/cache.ts
@@ -13,12 +13,12 @@ import type { PolicyResponse } from "./types.js";
 // startup, setup, and instance-switch paths. A second copy here would shadow a live
 // subsystem, and the two could then disagree about which surface belongs with which
 // policy. Anything replaying a cached surface reads it from there.
-interface CacheEntry {
+interface PolicyCacheEntry {
   policy?: PolicyResponse;
   updatedAt?: string;
 }
 
-type CacheFile = Record<string, CacheEntry>;
+type PolicyCacheFile = Record<string, PolicyCacheEntry>;
 
 // Same anchor as url-config-store and token-store: PLUGIN_DATA_DIR when the host
 // provides a managed data directory, else ~/.glean.
@@ -27,7 +27,7 @@ function cachePath(): string {
   return path.join(base, "policy-cache.json");
 }
 
-function readAll(): CacheFile {
+function readAll(): PolicyCacheFile {
   try {
     const parsed = JSON.parse(fs.readFileSync(cachePath(), "utf-8"));
     return typeof parsed === "object" && parsed !== null ? parsed : {};
@@ -36,7 +36,7 @@ function readAll(): CacheFile {
   }
 }
 
-function writeAll(data: CacheFile): void {
+function writeAll(data: PolicyCacheFile): void {
   const file = cachePath();
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
@@ -47,8 +47,15 @@ function writeAll(data: CacheFile): void {
   }
 }
 
-export function loadCached(serverUrl: string): CacheEntry {
-  return readAll()[serverUrl] ?? {};
+/**
+ * The cached policy for a remote, or undefined if none has been stored.
+ *
+ * Returns the policy itself rather than the stored entry: `updatedAt` is written for
+ * anyone reading the file by hand and is deliberately not part of the API, so callers
+ * cannot come to depend on a timestamp that says nothing about the policy's validity.
+ */
+export function loadCachedPolicy(serverUrl: string): PolicyResponse | undefined {
+  return readAll()[serverUrl]?.policy;
 }
 
 /** Replace the cached policy. Only ever called with a VALIDATED policy. */

--- a/src/policy/cache.ts
+++ b/src/policy/cache.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { writeFileAtomicSync } from "../atomic-write.js";
 import type { PolicyResponse } from "./types.js";
 
 // The last VALID policy, keyed by remote URL so switching instances does not
@@ -40,7 +41,7 @@ function writeAll(data: PolicyCacheFile): void {
   const file = cachePath();
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-    fs.writeFileSync(file, JSON.stringify(data, null, 2), { mode: 0o600 });
+    writeFileAtomicSync(file, JSON.stringify(data, null, 2), 0o600);
   } catch {
     // A cache that cannot be written degrades to in-session-only behavior, which
     // is a worse experience but never a wrong policy decision.

--- a/src/policy/context.ts
+++ b/src/policy/context.ts
@@ -1,0 +1,78 @@
+import { FEATURE_NAMES, type FeatureName } from "./key.js";
+import { pluginVersion } from "../version.js";
+import type {
+  ConfiguredServers,
+  HostIdentity,
+  NegotiationRequest,
+} from "./types.js";
+
+/**
+ * Host identity from the MCP `initialize` handshake -- clientInfo, declared
+ * capabilities, and the negotiated protocol revision.
+ *
+ * This is the reliable path and needs no host-specific code: no host is known to
+ * expose its own version through an environment variable, and no hook payload carries
+ * one either, so the handshake is the only place this information exists.
+ */
+export function hostIdentityFromHandshake(
+  clientInfo: { name?: string; version?: string } | undefined,
+  capabilities: Record<string, unknown> | undefined,
+  mcpProtocolVersion?: string,
+): HostIdentity {
+  if (!clientInfo?.name) {
+    // Report the revision even when clientInfo is unusable: it is the field most
+    // worth having when diagnosing a host we cannot otherwise identify.
+    return { id: "unknown", mcpProtocolVersion, source: "unknown" };
+  }
+  return {
+    id: clientInfo.name,
+    version: clientInfo.version,
+    mcpProtocolVersion,
+    capabilities,
+    source: "handshake",
+  };
+}
+
+/**
+ * The configured-MCP-server inventory. Not reported yet.
+ *
+ * Reconstructing it from host configuration files was evaluated and rejected: it means
+ * reimplementing host merge semantics -- multiple config scopes, enablement and
+ * approval state, plugin installation state, two different `.mcp.json` schemas, and
+ * enterprise managed settings -- and every failure in that reimplementation is silent,
+ * producing a plausible list with wrong contents rather than an error.
+ *
+ * The accurate source is the host's own CLI (`claude mcp list`, `codex mcp list
+ * --json`), which is deferred because it cannot be called from this path: those
+ * commands health-check every server by spawning it, including this one, so invoking
+ * them during `tools/list` would make the plugin recursively launch itself. It needs a
+ * SessionStart hook that runs once per session and caches the result.
+ *
+ * Until then the field reports `unavailable`, which by contract says nothing about the
+ * user's setup rather than implying an empty list.
+ */
+export function inventory(): ConfiguredServers {
+  return { source: "unavailable" };
+}
+
+/** The features this build implements. Static: it changes only when a release does. */
+export function supportedFeatures(): Record<FeatureName, boolean> {
+  return Object.fromEntries(FEATURE_NAMES.map((f) => [f, true])) as Record<
+    FeatureName,
+    boolean
+  >;
+}
+
+export function buildNegotiationRequest(host: HostIdentity): NegotiationRequest {
+  const { version, source } = pluginVersion();
+  return {
+    plugin: {
+      id: "glean",
+      version,
+      versionSource: source,
+      supportedFeatures: supportedFeatures(),
+    },
+    host,
+    configuredServers: inventory(),
+  };
+}

--- a/src/policy/evaluate.ts
+++ b/src/policy/evaluate.ts
@@ -1,0 +1,166 @@
+import { FEATURE_NAMES, type FeatureName } from "./key.js";
+import type {
+  Decision,
+  PolicyResponse,
+  VersionSource,
+  VersionState,
+} from "./types.js";
+
+// Plain x.y.z comparison. The plugin's own version scheme is plain semver with no
+// pre-release or build metadata (enforced by the release tooling), so a full
+// semver implementation would be dead weight. A version that does not parse is
+// treated as unknown rather than guessed at.
+export function parseVersion(v: string): [number, number, number] | undefined {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+  if (!m) return undefined;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** -1 if a < b, 0 if equal, 1 if a > b; undefined if either is unparseable. */
+export function compareVersions(a: string, b: string): number | undefined {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return undefined;
+  for (let i = 0; i < 3; i++) {
+    const x = pa[i] as number;
+    const y = pb[i] as number;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+function allFeatures(value: boolean): Record<FeatureName, boolean> {
+  return Object.fromEntries(FEATURE_NAMES.map((f) => [f, value])) as Record<
+    FeatureName,
+    boolean
+  >;
+}
+
+export interface EvaluateInput {
+  /** The plugin's own version, and how much that value can be trusted. */
+  pluginVersion: string;
+  versionSource: VersionSource;
+  /** Features this build actually implements. */
+  supportedFeatures: Record<FeatureName, boolean>;
+  /** The policy to apply, or undefined for the no-policy / first-run case. */
+  policy?: PolicyResponse;
+}
+
+/**
+ * Resolve a policy against the local build into an enforceable Decision.
+ *
+ * Two rules drive everything here:
+ *   1. A feature is enabled only if this build supports it AND the remote has not
+ *      disabled it. The remote cannot switch on something that is not built.
+ *   2. No policy means everything supported is enabled and no version rule
+ *      applies -- that is the compatibility path for a remote that does not
+ *      implement negotiation yet.
+ */
+export function evaluate(input: EvaluateInput): Decision {
+  const { pluginVersion, versionSource, supportedFeatures, policy } = input;
+  const reasons: string[] = [];
+
+  if (!policy) {
+    reasons.push(
+      "no policy available: enabling all supported features, applying no version policy",
+    );
+    return {
+      deactivated: false,
+      versionState: "unenforced",
+      features: { ...supportedFeatures },
+      showUpgrade: false,
+      reasons,
+    };
+  }
+
+  // ---- version eligibility ------------------------------------------------
+  // Enforcement is gated on provenance. Deactivating a plugin on a version we
+  // cannot actually vouch for would break working installs for no benefit.
+  let versionState: VersionState = "ok";
+  let deactivated = false;
+
+  if (versionSource === "unknown") {
+    versionState = "unenforced";
+    reasons.push(
+      "version source is unknown: version policy not enforced (never deactivate on an unverifiable version)",
+    );
+  } else {
+    const blocked = policy.plugin?.blockedVersions ?? [];
+    const min = policy.plugin?.minimumSupportedVersion;
+
+    // Minimum first: it is the compatibility floor, and "too old" is a more
+    // actionable message than "specifically blocked".
+    if (min) {
+      const cmp = compareVersions(pluginVersion, min);
+      if (cmp === undefined) {
+        reasons.push(
+          `cannot compare ${pluginVersion} against minimum ${min}: skipping minimum check`,
+        );
+      } else if (cmp < 0) {
+        versionState = "below-minimum";
+        deactivated = true;
+        reasons.push(
+          `version ${pluginVersion} is below the minimum supported ${min}: deactivated`,
+        );
+      }
+    }
+
+    // Exact-match list, not a threshold -- it exists for non-contiguous bad
+    // releases (block 1.2 while 1.1 and 1.3 stay usable).
+    if (!deactivated && blocked.includes(pluginVersion)) {
+      versionState = "blocked";
+      deactivated = true;
+      reasons.push(`version ${pluginVersion} is explicitly blocked: deactivated`);
+    }
+
+    if (!deactivated) {
+      const latest = policy.plugin?.latestVersion;
+      if (latest && compareVersions(pluginVersion, latest) === -1) {
+        versionState = "outdated-supported";
+        reasons.push(
+          `version ${pluginVersion} is older than latest ${latest} but supported`,
+        );
+      }
+    }
+  }
+
+  // ---- feature policy -----------------------------------------------------
+  // A deactivated plugin exposes only setup, so every feature is inert. Reported
+  // as all-false so no caller can accidentally act on a stale enablement.
+  if (deactivated) {
+    return {
+      deactivated: true,
+      versionState,
+      features: allFeatures(false),
+      showUpgrade: true,
+      message: policy.message,
+      reasons,
+    };
+  }
+
+  const features = {} as Record<FeatureName, boolean>;
+  for (const name of FEATURE_NAMES) {
+    const supported = supportedFeatures[name] === true;
+    if (!supported) {
+      features[name] = false;
+      continue;
+    }
+    // An omitted feature is left enabled: the remote naming fewer features than
+    // the plugin supports means it has no opinion, not that it said no.
+    const entry = policy.features?.[name];
+    const enabled = entry?.enabled !== false;
+    features[name] = enabled;
+    if (!enabled) reasons.push(`feature "${name}" disabled by remote policy`);
+  }
+
+  return {
+    deactivated: false,
+    versionState,
+    features,
+    showUpgrade:
+      versionState === "outdated-supported" &&
+      policy.plugin?.upgradeRecommendation?.show === true,
+    message: policy.message,
+    reasons,
+  };
+}

--- a/src/policy/key.ts
+++ b/src/policy/key.ts
@@ -1,0 +1,16 @@
+// The vendor-prefixed `_meta` key carrying the policy exchange. This is an
+// application-level Glean extension, not a core MCP method or capability: the
+// host never needs to understand it, and the plugin both creates and consumes it.
+export const CAPABILITY_POLICY_KEY = "com.glean.mcp/capabilityPolicy";
+
+// The features whose enablement the remote controls. Keep in lockstep with
+// FeatureName below -- the array exists so the plugin can declare support for
+// exactly the features it implements, no more.
+export const FEATURE_NAMES = [
+  "toolPromotion",
+  "metaTools",
+  "hitl",
+  "fileArgs",
+] as const;
+
+export type FeatureName = (typeof FEATURE_NAMES)[number];

--- a/src/policy/negotiate.ts
+++ b/src/policy/negotiate.ts
@@ -1,0 +1,158 @@
+import { CAPABILITY_POLICY_KEY, FEATURE_NAMES } from "./key.js";
+import type {
+  NegotiationOutcome,
+  NegotiationRequest,
+  PolicyResponse,
+} from "./types.js";
+
+/**
+ * Wrap the negotiation payload in the `_meta` envelope carried on every outgoing
+ * request. Verified against MCP SDK 1.12 over StreamableHTTP: `_meta` on
+ * `tools/list` and `tools/call` params reaches the server, and `result._meta`
+ * survives Zod parsing on the way back, with nested objects intact.
+ */
+export function metaFor(request: NegotiationRequest): {
+  _meta: Record<string, unknown>;
+} {
+  return { _meta: { [CAPABILITY_POLICY_KEY]: request } };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Keys this version understands, by object. Anything outside these sets is still
+// ACCEPTED -- forward compatibility requires that a remote may add fields without an
+// older plugin calling the response malformed -- but it is collected and reported so
+// the ignoring becomes observable. Silence is the failure mode worth avoiding: an
+// unrecognized key's type is never checked, so a renamed or misspelled field carrying
+// a bad value is indistinguishable from an absent one.
+const KNOWN_TOP_LEVEL: ReadonlySet<string> = new Set([
+  "plugin",
+  "features",
+  "message",
+]);
+const KNOWN_PLUGIN: ReadonlySet<string> = new Set([
+  "latestVersion",
+  "minimumSupportedVersion",
+  "blockedVersions",
+  "upgradeRecommendation",
+]);
+const KNOWN_UPGRADE: ReadonlySet<string> = new Set([
+  "show",
+  "dailyCap",
+  "weeklyCap",
+  "message",
+]);
+
+function unknownIn(
+  obj: unknown,
+  known: ReadonlySet<string>,
+  prefix: string,
+): string[] {
+  if (!isRecord(obj)) return [];
+  return Object.keys(obj)
+    .filter((k) => !known.has(k))
+    .map((k) => `${prefix}${k}`);
+}
+
+/**
+ * Validate a candidate policy object. Deliberately shallow: it rejects shapes
+ * that would make `evaluate` misbehave and ignores everything else, so a remote
+ * can add fields without old plugins calling the response malformed.
+ *
+ * On success it also returns the keys it did not recognize. Those are still ignored
+ * for evaluation; the caller logs them so a shape mismatch during a rollout is
+ * greppable instead of invisible.
+ */
+export function validatePolicy(
+  value: unknown,
+):
+  | { ok: true; policy: PolicyResponse; unknownKeys: string[] }
+  | { ok: false; reason: string } {
+  if (!isRecord(value)) return { ok: false, reason: "policy is not an object" };
+
+  const plugin = value.plugin;
+  if (plugin !== undefined) {
+    if (!isRecord(plugin)) {
+      return { ok: false, reason: "plugin must be an object" };
+    }
+    for (const key of ["latestVersion", "minimumSupportedVersion"] as const) {
+      const v = plugin[key];
+      if (v !== undefined && typeof v !== "string") {
+        return { ok: false, reason: `plugin.${key} must be a string` };
+      }
+    }
+    const blocked = plugin.blockedVersions;
+    if (
+      blocked !== undefined &&
+      (!Array.isArray(blocked) || blocked.some((b) => typeof b !== "string"))
+    ) {
+      return { ok: false, reason: "plugin.blockedVersions must be string[]" };
+    }
+    const rec = plugin.upgradeRecommendation;
+    if (rec !== undefined && !isRecord(rec)) {
+      return { ok: false, reason: "plugin.upgradeRecommendation must be an object" };
+    }
+  }
+
+  const features = value.features;
+  if (features !== undefined) {
+    if (!isRecord(features)) {
+      return { ok: false, reason: "features must be an object" };
+    }
+    for (const [name, entry] of Object.entries(features)) {
+      if (!isRecord(entry)) {
+        return { ok: false, reason: `features.${name} must be an object` };
+      }
+      if (entry.enabled !== undefined && typeof entry.enabled !== "boolean") {
+        return { ok: false, reason: `features.${name}.enabled must be boolean` };
+      }
+    }
+  }
+
+  if (value.message !== undefined && typeof value.message !== "string") {
+    return { ok: false, reason: "message must be a string" };
+  }
+
+  // Unrecognized feature NAMES are collected too. A policy naming a feature this
+  // build does not implement means the plugin is older than the policy -- worth
+  // seeing, even though `evaluate` correctly ignores it.
+  const unknownKeys = [
+    ...unknownIn(value, KNOWN_TOP_LEVEL, ""),
+    ...unknownIn(value.plugin, KNOWN_PLUGIN, "plugin."),
+    ...unknownIn(
+      isRecord(value.plugin) ? value.plugin.upgradeRecommendation : undefined,
+      KNOWN_UPGRADE,
+      "plugin.upgradeRecommendation.",
+    ),
+    ...unknownIn(value.features, new Set<string>(FEATURE_NAMES), "features."),
+  ];
+
+  return { ok: true, policy: value as PolicyResponse, unknownKeys };
+}
+
+/**
+ * Classify what came back from a successful request.
+ *
+ * The distinction between "succeeded but no policy" and "could not reach the
+ * remote" is the subtlest part of the contract and is NOT decided here -- an
+ * unreachable remote never produces a result to classify, so the caller reports
+ * that case separately. Conflating them silently disables version enforcement,
+ * because no-policy clears version rules while unreachable must keep applying
+ * the last synced ones.
+ */
+export function classifyResult(result: unknown): NegotiationOutcome {
+  const meta = isRecord(result) ? result._meta : undefined;
+  const candidate = isRecord(meta) ? meta[CAPABILITY_POLICY_KEY] : undefined;
+
+  if (candidate === undefined) return { kind: "no-policy" };
+
+  const validated = validatePolicy(candidate);
+  if (!validated.ok) return { kind: "malformed", reason: validated.reason };
+  return {
+    kind: "policy",
+    policy: validated.policy,
+    unknownKeys: validated.unknownKeys,
+  };
+}

--- a/src/policy/protocol-version.ts
+++ b/src/policy/protocol-version.ts
@@ -1,0 +1,105 @@
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Observe the MCP revision the plugin and the host settle on.
+ *
+ * The SDK negotiates this internally -- it compares the host's requested version
+ * against SUPPORTED_PROTOCOL_VERSIONS and answers with either that version or its
+ * own latest -- but exposes no server-side accessor for the outcome. `Server` keeps
+ * only clientInfo and client capabilities. So the value is recovered by watching the
+ * `initialize` exchange on the transport, which is public API: `Transport` is a
+ * plain interface, so wrapping it needs no private-field access and no subclassing.
+ *
+ * The NEGOTIATED value is read from the initialize *response*, not the request. The
+ * request carries what the host proposed, which differs whenever the host asks for a
+ * revision this build does not implement -- exactly the case worth reporting.
+ */
+export class ProtocolVersionObserver {
+  private negotiated: string | undefined;
+  private proposed: string | undefined;
+  private initializeId: string | number | undefined;
+
+  /** The agreed revision, or undefined when it could not be observed. */
+  get version(): string | undefined {
+    return this.negotiated;
+  }
+
+  /** What the host asked for. Retained for diagnostics, not reported as the answer. */
+  get requested(): string | undefined {
+    return this.proposed;
+  }
+
+  /**
+   * Wrap a transport so the initialize exchange is observed as it passes through.
+   * Delegates everything; the only additions are two taps that never throw, since a
+   * failed observation must degrade to "unknown" rather than break the connection.
+   */
+  wrap(inner: Transport): Transport {
+    const observer = this;
+
+    const wrapped: Transport = {
+      start: () => inner.start(),
+      close: () => inner.close(),
+      send: async (message, options) => {
+        observer.observeOutgoing(message);
+        return inner.send(message, options);
+      },
+      get sessionId() {
+        return inner.sessionId;
+      },
+      set onmessage(handler) {
+        inner.onmessage = handler
+          ? (message, extra) => {
+              observer.observeIncoming(message);
+              handler(message, extra);
+            }
+          : undefined;
+      },
+      get onmessage() {
+        return inner.onmessage;
+      },
+      set onclose(handler) {
+        inner.onclose = handler;
+      },
+      get onclose() {
+        return inner.onclose;
+      },
+      set onerror(handler) {
+        inner.onerror = handler;
+      },
+      get onerror() {
+        return inner.onerror;
+      },
+    };
+
+    return wrapped;
+  }
+
+  private observeIncoming(message: JSONRPCMessage): void {
+    try {
+      const m = message as { id?: string | number; method?: string; params?: unknown };
+      if (m.method !== "initialize" || m.id === undefined) return;
+      this.initializeId = m.id;
+      const params = m.params as { protocolVersion?: unknown } | undefined;
+      if (typeof params?.protocolVersion === "string") {
+        this.proposed = params.protocolVersion;
+      }
+    } catch {
+      // Observation is best-effort; the field is omitted rather than guessed.
+    }
+  }
+
+  private observeOutgoing(message: JSONRPCMessage): void {
+    try {
+      const m = message as { id?: string | number; result?: unknown };
+      if (m.id === undefined || m.id !== this.initializeId) return;
+      const result = m.result as { protocolVersion?: unknown } | undefined;
+      if (typeof result?.protocolVersion === "string") {
+        this.negotiated = result.protocolVersion;
+      }
+    } catch {
+      // As above.
+    }
+  }
+}

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -3,7 +3,7 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { hostIdentityFromHandshake, buildNegotiationRequest } from "./context.js";
 import { classifyResult, metaFor } from "./negotiate.js";
 import { evaluate } from "./evaluate.js";
-import { loadCached, savePolicy } from "./cache.js";
+import { clearCache, loadCached, savePolicy } from "./cache.js";
 import { ProtocolVersionObserver } from "./protocol-version.js";
 import type { Decision, NegotiationRequest, PolicyResponse } from "./types.js";
 
@@ -42,6 +42,20 @@ export function initPolicySession(server: Server, log: LogFn): void {
 /** Called whenever the configured server URL is resolved or changed. */
 export function setPolicyServerUrl(url: string | undefined): void {
   cacheKeyUrl = url;
+}
+
+/**
+ * Discard every cached policy, for `setup({reset})`.
+ *
+ * Deliberately global, with no URL argument, to match clearRemoteTools() on the same
+ * path: reset wipes the tools cache for every URL, and a per-URL policy clear here
+ * would leave the two stores disagreeing about what "reset" cleared. The two caches
+ * are separate files, so nothing but this pairing keeps them consistent — a new clear
+ * path has to touch both.
+ */
+export function clearPolicyCache(): void {
+  clearCache();
+  decision = undefined;
 }
 
 /**

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -3,7 +3,7 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { hostIdentityFromHandshake, buildNegotiationRequest } from "./context.js";
 import { classifyResult, metaFor } from "./negotiate.js";
 import { evaluate } from "./evaluate.js";
-import { loadCached, savePolicy } from "./cache.js";
+import { loadCachedPolicy, savePolicy } from "./cache.js";
 import { ProtocolVersionObserver } from "./protocol-version.js";
 import type { Decision, NegotiationRequest, PolicyResponse } from "./types.js";
 
@@ -85,7 +85,7 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
   if (!serverUrl) return;
 
   const outcome = classifyResult(result);
-  const cached = loadCached(serverUrl);
+  const cachedPolicy = loadCachedPolicy(serverUrl);
   let policy: PolicyResponse | undefined;
 
   switch (outcome.kind) {
@@ -102,7 +102,7 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
       break;
     case "malformed":
       logLine("policy.malformed", { label, reason: outcome.reason });
-      policy = cached.policy;
+      policy = cachedPolicy;
       break;
     case "no-policy":
       policy = undefined;

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -1,0 +1,160 @@
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+import { hostIdentityFromHandshake, buildNegotiationRequest } from "./context.js";
+import { classifyResult, metaFor } from "./negotiate.js";
+import { evaluate } from "./evaluate.js";
+import { loadCached, savePolicy } from "./cache.js";
+import { ProtocolVersionObserver } from "./protocol-version.js";
+import type { Decision, NegotiationRequest, PolicyResponse } from "./types.js";
+
+type LogFn = (label: string, detail?: Record<string, unknown>) => void;
+
+/**
+ * Session-scoped state for the capability/policy exchange.
+ *
+ * Kept out of index.ts so the wiring there stays to a few lines, and so the pieces a
+ * later change needs -- the resolved decision, the `_meta` to attach -- have one
+ * obvious home.
+ *
+ * This module reports context and records the resolved policy. It does not enforce
+ * anything: nothing here changes which tools are advertised or which calls succeed.
+ * Enforcement is a separate change, deliberately, so the exchange can be observed in
+ * production before it is allowed to alter behaviour.
+ */
+let mcpServer: Server | undefined;
+let logLine: LogFn = () => {};
+let decision: Decision | undefined;
+let lastRequest: NegotiationRequest | undefined;
+// The remote the policy cache is keyed by. Held here rather than threaded through
+// every call site so that `callRemoteTool` -- the single funnel every remote tool call
+// passes through -- can record policy without knowing about configuration resolution.
+// Keyed by URL so switching Glean instances cannot apply one instance's policy to
+// another.
+let cacheKeyUrl: string | undefined;
+
+export const protocolVersion = new ProtocolVersionObserver();
+
+export function initPolicySession(server: Server, log: LogFn): void {
+  mcpServer = server;
+  logLine = log;
+}
+
+/** Called whenever the configured server URL is resolved or changed. */
+export function setPolicyServerUrl(url: string | undefined): void {
+  cacheKeyUrl = url;
+}
+
+/**
+ * The negotiation payload for the current session, rebuilt per request so a late
+ * `initialize` (the handshake completes after the transport is wired) is reflected
+ * rather than captured as undefined at startup.
+ */
+export function negotiationRequest(): NegotiationRequest {
+  const host = hostIdentityFromHandshake(
+    mcpServer?.getClientVersion(),
+    mcpServer?.getClientCapabilities() as Record<string, unknown> | undefined,
+    protocolVersion.version,
+  );
+  lastRequest = buildNegotiationRequest(host);
+  return lastRequest;
+}
+
+/** The `_meta` envelope to attach to an outgoing remote request. */
+export function negotiationMeta(): { _meta: Record<string, unknown> } {
+  return metaFor(negotiationRequest());
+}
+
+/**
+ * Record the policy carried on a remote response, if any.
+ *
+ * The four outcomes are distinct on purpose:
+ *   policy      - persist it and re-evaluate.
+ *   no-policy   - the remote does not implement negotiation yet. Every supported
+ *                 feature is treated as enabled and no version rule applies. The
+ *                 cache is NOT erased.
+ *   malformed   - keep the last valid policy and treat this round as no-policy, so a
+ *                 bad response can never deactivate a working plugin.
+ *   unreachable - decided by the caller, not here: an unreachable remote produces no
+ *                 result to classify. Conflating it with no-policy would silently
+ *                 drop a previously synced version rule on any network blip.
+ */
+export function recordPolicyFromResult(result: unknown, label: string): void {
+  // No configured remote yet means nothing to key the cache by, and no exchange to
+  // record. Silent no-op rather than an error: this runs on every remote call.
+  const serverUrl = cacheKeyUrl;
+  if (!serverUrl) return;
+
+  const outcome = classifyResult(result);
+  const cached = loadCached(serverUrl);
+  let policy: PolicyResponse | undefined;
+
+  switch (outcome.kind) {
+    case "policy":
+      policy = outcome.policy;
+      savePolicy(serverUrl, outcome.policy);
+      // Unknown keys are accepted and ignored -- a newer remote must be able to add
+      // fields without an older plugin rejecting the response -- but reported, since
+      // an unrecognized key's type is never checked and a renamed field carrying a
+      // bad value would otherwise pass in total silence.
+      if (outcome.unknownKeys.length > 0) {
+        logLine("policy.unknown-keys", { label, keys: outcome.unknownKeys });
+      }
+      break;
+    case "malformed":
+      logLine("policy.malformed", { label, reason: outcome.reason });
+      policy = cached.policy;
+      break;
+    case "no-policy":
+      policy = undefined;
+      break;
+  }
+
+  const request = lastRequest ?? negotiationRequest();
+  const next = evaluate({
+    pluginVersion: request.plugin.version,
+    versionSource: request.plugin.versionSource,
+    supportedFeatures: request.plugin.supportedFeatures,
+    policy,
+  });
+
+  const changed =
+    !decision ||
+    JSON.stringify([decision.deactivated, decision.features]) !==
+      JSON.stringify([next.deactivated, next.features]);
+  decision = next;
+
+  if (changed) {
+    logLine("policy.resolved", {
+      label,
+      outcome: outcome.kind,
+      versionState: next.versionState,
+      deactivated: next.deactivated,
+      features: next.features,
+      reasons: next.reasons,
+    });
+  }
+}
+
+/** The policy currently in force, or undefined before the first exchange. */
+export function currentDecision(): Decision | undefined {
+  return decision;
+}
+
+/** For `setup` output: what was reported, and what came back. */
+export function policySummary(): string[] {
+  const r = lastRequest;
+  const d = decision;
+  const lines = [
+    `Plugin version: ${r?.plugin.version ?? "?"} (source: ${r?.plugin.versionSource ?? "?"})`,
+    `Host: ${r?.host.id ?? "?"} ${r?.host.version ?? ""} (source: ${r?.host.source ?? "?"})`,
+    `MCP revision: ${r?.host.mcpProtocolVersion ?? "not observed"}`,
+    `Server inventory: ${r?.configuredServers.source ?? "?"}`,
+  ];
+  if (d) {
+    lines.push(`Policy: version ${d.versionState}, features ${JSON.stringify(d.features)}`);
+    if (d.message) lines.push(`Notice: ${d.message}`);
+  } else {
+    lines.push("Policy: not yet negotiated");
+  }
+  return lines;
+}

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -3,7 +3,7 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { hostIdentityFromHandshake, buildNegotiationRequest } from "./context.js";
 import { classifyResult, metaFor } from "./negotiate.js";
 import { evaluate } from "./evaluate.js";
-import { clearCache, loadCached, savePolicy } from "./cache.js";
+import { loadCached, savePolicy } from "./cache.js";
 import { ProtocolVersionObserver } from "./protocol-version.js";
 import type { Decision, NegotiationRequest, PolicyResponse } from "./types.js";
 
@@ -42,20 +42,6 @@ export function initPolicySession(server: Server, log: LogFn): void {
 /** Called whenever the configured server URL is resolved or changed. */
 export function setPolicyServerUrl(url: string | undefined): void {
   cacheKeyUrl = url;
-}
-
-/**
- * Discard every cached policy, for `setup({reset})`.
- *
- * Deliberately global, with no URL argument, to match clearRemoteTools() on the same
- * path: reset wipes the tools cache for every URL, and a per-URL policy clear here
- * would leave the two stores disagreeing about what "reset" cleared. The two caches
- * are separate files, so nothing but this pairing keeps them consistent — a new clear
- * path has to touch both.
- */
-export function clearPolicyCache(): void {
-  clearCache();
-  decision = undefined;
 }
 
 /**

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -24,6 +24,9 @@ type LogFn = (label: string, detail?: Record<string, unknown>) => void;
 let mcpServer: Server | undefined;
 let logLine: LogFn = () => {};
 let decision: Decision | undefined;
+// Labels already logged in this process, so each negotiation path reports itself once
+// even when the resolved decision never changes. See recordPolicyFromResult.
+const loggedLabels = new Set<string>();
 let lastRequest: NegotiationRequest | undefined;
 // The remote the policy cache is keyed by. Held here rather than threaded through
 // every call site so that `callRemoteTool` -- the single funnel every remote tool call
@@ -123,7 +126,19 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
       JSON.stringify([next.deactivated, next.features]);
   decision = next;
 
-  if (changed) {
+  // Log on a change, and once per label per process.
+  //
+  // The second condition is what makes the mechanism observable at all. A steady-state
+  // exchange changes nothing -- against a remote with no policy support, every response
+  // resolves to the same decision -- so change-only logging goes silent after the first
+  // tools/list and never says a word about tools/call again. The result is a feature
+  // whose entire job is remote control, with no evidence in the log that it ran on a
+  // given path. Labels are bounded (one per distinct remote method plus tool name), so
+  // this is a handful of lines per process, not per call.
+  const firstForLabel = !loggedLabels.has(label);
+  loggedLabels.add(label);
+
+  if (changed || firstForLabel) {
     logLine("policy.resolved", {
       label,
       outcome: outcome.kind,

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -1,0 +1,132 @@
+import type { FeatureName } from "./key.js";
+
+// ---------------------------------------------------------------- request side
+
+// VersionSource is defined alongside the build constant it describes, in
+// ../version.ts. Imported for local use and re-exported so the payload types read
+// as one unit.
+import type { VersionSource } from "../version.js";
+export type { VersionSource };
+
+// Where host identity came from. `handshake` is the MCP initialize exchange,
+// which is the reliable path and needs no host-specific code.
+export type HostSource = "handshake" | "env" | "unknown";
+
+// The inventory is all-or-nothing on purpose. A partial list is worse than none
+// for policy, because it is indistinguishable from a user who genuinely has
+// fewer servers.
+export type InventorySource = "host-cli" | "unavailable";
+
+export type AuthStatus = "authenticated" | "unauthenticated" | "unknown";
+
+export interface ConfiguredServer {
+  name: string;
+  url?: string;
+  authStatus: AuthStatus;
+}
+
+export interface ConfiguredServers {
+  source: InventorySource;
+  servers?: ConfiguredServer[];
+}
+
+/** The host block of the request, as observed from the MCP handshake. */
+export interface HostIdentity {
+  id: string;
+  version?: string;
+  /**
+   * The MCP revision the plugin and host settled on for this session -- the value
+   * from the initialize RESULT, not what the host proposed. Omitted rather than
+   * guessed when it could not be observed; see protocol-version.ts.
+   */
+  mcpProtocolVersion?: string;
+  capabilities?: Record<string, unknown>;
+  source: HostSource;
+}
+
+export interface NegotiationRequest {
+  // supportedFeatures lives HERE, not at the top level: the features a build
+  // implements are a property of that build, fixed at compile time and changing
+  // only when a new version ships -- exactly like `version` beside it. The
+  // response's `features` map stays top level because it is a per-session policy
+  // decision, not plugin metadata; the two are not peers despite the similar name.
+  plugin: {
+    id: string;
+    version: string;
+    versionSource: VersionSource;
+    supportedFeatures: Record<FeatureName, boolean>;
+  };
+  host: HostIdentity;
+  configuredServers: ConfiguredServers;
+}
+
+// --------------------------------------------------------------- response side
+
+export interface UpgradeRecommendation {
+  show?: boolean;
+  dailyCap?: number;
+  weeklyCap?: number;
+}
+
+// Plugin-scoped rules are grouped under `plugin`; session-scoped policy stays at
+// the top level. Version rules and upgrade guidance describe the installed
+// artifact and change only when a release changes, whereas `features` and
+// `message` are decisions about this session that can differ between two calls
+// from the same build. The grouping is also what removes the `Plugin` prefix these
+// names used to carry to compensate for having no namespace, and it leaves a slot
+// for the deferred host-version rules as a `host` sibling.
+export interface PluginPolicy {
+  latestVersion?: string;
+  minimumSupportedVersion?: string;
+  blockedVersions?: string[];
+  upgradeRecommendation?: UpgradeRecommendation;
+}
+
+export interface PolicyResponse {
+  plugin?: PluginPolicy;
+  features?: Partial<Record<FeatureName, { enabled?: boolean }>>;
+  message?: string;
+}
+
+// ------------------------------------------------------------------- outcomes
+
+// Classification of a single negotiation round-trip. These four are genuinely
+// different and conflating any two of them breaks the contract:
+//
+//   policy       - a valid policy object came back; persist and apply it.
+//   no-policy    - the request SUCCEEDED but carried no policy object. The
+//                  remote does not implement negotiation yet. All supported
+//                  features are enabled and NO version policy applies. Must not
+//                  erase the cache.
+//   malformed    - a policy object came back but failed validation. Keep the
+//                  last valid policy and treat this round as no-policy; garbage
+//                  must never be able to deactivate a working plugin.
+//   unreachable  - the request failed. Fall back to the CACHED policy and
+//                  cached tools list, which is different from no-policy: here a
+//                  previously synced version rule still applies.
+export type NegotiationOutcome =
+  | { kind: "policy"; policy: PolicyResponse; unknownKeys: string[] }
+  | { kind: "no-policy" }
+  | { kind: "malformed"; reason: string }
+  | { kind: "unreachable"; reason: string };
+
+// ------------------------------------------------------------------- decision
+
+export type VersionState =
+  | "ok"
+  | "outdated-supported"
+  | "below-minimum"
+  | "blocked"
+  | "unenforced";
+
+export interface Decision {
+  /** Deactivated plugins advertise ONLY the setup tool. */
+  deactivated: boolean;
+  versionState: VersionState;
+  features: Record<FeatureName, boolean>;
+  /** True when an upgrade recommendation should be surfaced this session. */
+  showUpgrade: boolean;
+  message?: string;
+  /** Human-readable trail of why this decision came out the way it did. */
+  reasons: string[];
+}

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -4,6 +4,7 @@ import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { GleanOAuthClientProvider } from "./auth-provider.js";
 import { pluginVersionString } from "./version.js";
+import { negotiationMeta, recordPolicyFromResult } from "./policy/session.js";
 
 const GLEAN_PLUGIN = "GLEAN_PLUGIN";
 
@@ -210,11 +211,16 @@ export async function callRemoteTool(
   name: string,
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
-  // Pass an explicit timeout so the call isn't capped at the SDK's 60s default.
-  // `undefined` for resultSchema keeps the SDK's CallToolResultSchema default.
-  const result = await client.callTool({ name, arguments: args }, undefined, {
-    timeout: remoteToolTimeoutMs(),
-  });
+  // Every remote tool call funnels through here -- find_skills, run_tool, and the
+  // promoted passthrough tools all use it -- so this is the one place that has to
+  // carry negotiation metadata and read back any policy the remote returns. Doing it
+  // here rather than at each call site means a new caller cannot forget to.
+  const result = await client.callTool(
+    { name, arguments: args, ...negotiationMeta() },
+    undefined,
+    { timeout: remoteToolTimeoutMs() },
+  );
+  recordPolicyFromResult(result, `tools/call(${name})`);
   if (!("content" in result)) {
     return { content: [] };
   }

--- a/src/remote-tools-cache-store.ts
+++ b/src/remote-tools-cache-store.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { writeFileAtomicSync } from "./atomic-write.js";
 
 const CACHE_FILENAME = "remote-tools-cache.json";
 const DIR_MODE = 0o700;
@@ -40,11 +41,7 @@ function writeStore(store: ToolsCacheFile): void {
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
   fs.chmodSync(dir, DIR_MODE);
-  fs.writeFileSync(filePath, JSON.stringify(store, null, 2), {
-    encoding: "utf-8",
-    mode: FILE_MODE,
-  });
-  fs.chmodSync(filePath, FILE_MODE);
+  writeFileAtomicSync(filePath, JSON.stringify(store, null, 2), FILE_MODE);
 }
 
 export function loadRemoteTools(serverUrl: string): Tool[] {

--- a/src/remote-tools-cache-store.ts
+++ b/src/remote-tools-cache-store.ts
@@ -15,19 +15,19 @@ function cacheFile(): string {
   return path.join(resolveCacheDir(), CACHE_FILENAME);
 }
 
-interface CacheEntry {
+interface ToolsCacheEntry {
   tools: Tool[];
   fetchedAt: string;
 }
 
-type Store = Record<string, CacheEntry>;
+type ToolsCacheFile = Record<string, ToolsCacheEntry>;
 
-function readStore(): Store {
+function readStore(): ToolsCacheFile {
   try {
     const raw = fs.readFileSync(cacheFile(), "utf-8");
     const data = JSON.parse(raw);
     if (data && typeof data === "object" && !Array.isArray(data)) {
-      return data as Store;
+      return data as ToolsCacheFile;
     }
     return {};
   } catch {
@@ -35,7 +35,7 @@ function readStore(): Store {
   }
 }
 
-function writeStore(store: Store): void {
+function writeStore(store: ToolsCacheFile): void {
   const filePath = cacheFile();
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });

--- a/src/remote-tools-cache-store.ts
+++ b/src/remote-tools-cache-store.ts
@@ -55,6 +55,15 @@ export function loadRemoteTools(serverUrl: string): Tool[] {
   return entry.tools;
 }
 
+// Persist the remote catalog for a URL. Only ever the RAW allow-listed catalog, never
+// a surface that capability policy has already been applied to.
+//
+// That distinction is what lets this cache and the policy cache (policy/cache.ts) be
+// written and cleared independently: tools/list composes its answer by filtering this
+// catalog through the policy in force, at read time, so a catalog from one moment and a
+// policy from another still yield the surface the current policy dictates. Caching a
+// post-policy surface here would reintroduce exactly the skew that avoids — a stored
+// surface would keep advertising what a newer policy has withdrawn.
 export function saveRemoteTools(serverUrl: string, tools: Tool[]): void {
   if (!serverUrl) return;
   try {

--- a/src/tools/remote-passthrough.ts
+++ b/src/tools/remote-passthrough.ts
@@ -6,6 +6,7 @@ import {
   createRemoteClient,
   type RemoteClientOptions,
 } from "../remote-client.js";
+import { negotiationMeta, recordPolicyFromResult } from "../policy/session.js";
 
 // Remote tools promoted to first-class local tools once setup completes.
 // Anything the remote MCP server exposes that is not in this set is dropped
@@ -59,9 +60,13 @@ export async function fetchAllowedRemoteTools(
   const collected: Tool[] = [];
   let cursor: string | undefined;
   do {
-    const page = await remoteClient.listTools(
-      cursor ? { cursor } : undefined,
-    );
+    // Negotiation metadata rides on tools/list as well as tools/call, so a session
+    // that only ever lists tools still reports its context and still receives policy.
+    const page = await remoteClient.listTools({
+      ...(cursor ? { cursor } : {}),
+      ...negotiationMeta(),
+    });
+    recordPolicyFromResult(page, "tools/list");
     for (const tool of page.tools) {
       if (!REMOTE_TOOLS_ALLOWLIST.has(tool.name)) continue;
       collected.push({

--- a/tests/atomic-write.test.ts
+++ b/tests/atomic-write.test.ts
@@ -40,23 +40,32 @@ describe("writeFileAtomicSync", () => {
     expect(fs.statSync(target).mode & 0o777).toBe(0o600);
   });
 
-  // The file is only ever swapped in whole, so a reader either sees the previous
-  // contents or the new ones. This is what keeps a mid-write kill from turning a
-  // cached policy into an unparseable file that every store reads as "no data".
-  it("never leaves the target parseable-but-partial", () => {
-    writeFileAtomicSync(target, JSON.stringify({ first: true }), 0o600);
-    const before = fs.readFileSync(target, "utf-8");
+  // The point of the temp-and-rename dance: a write that fails must leave the previous
+  // contents readable, since every store treats an unparseable file as "no data" and
+  // would otherwise silently discard a cached policy. Forced by pre-creating the temp
+  // path as a directory, so writing it fails with EISDIR before the target is touched.
+  it("preserves the existing file when the write fails", () => {
+    writeFileAtomicSync(target, JSON.stringify({ keep: true }), 0o600);
 
-    // Simulate the failure mode: the rename target is a directory, so the swap fails
-    // after the temp file was written.
+    const tmpPath = path.join(dir, `.store.json.${process.pid}.tmp`);
+    fs.mkdirSync(tmpPath);
+    expect(() =>
+      writeFileAtomicSync(target, JSON.stringify({ replaced: true }), 0o600),
+    ).toThrow();
+
+    expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({ keep: true });
+  });
+
+  // Separately: when the write succeeds but the swap fails, the temp must not be left
+  // behind — one would accumulate per failure in the user's data directory.
+  it("removes the temp file when the swap fails", () => {
     const blocked = path.join(dir, "blocked.json");
     fs.mkdirSync(blocked);
+
     expect(() =>
       writeFileAtomicSync(blocked, JSON.stringify({ second: true }), 0o600),
     ).toThrow();
 
-    // The unrelated target is untouched, and no debris was left in the directory.
-    expect(fs.readFileSync(target, "utf-8")).toBe(before);
     expect(fs.readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
   });
 

--- a/tests/atomic-write.test.ts
+++ b/tests/atomic-write.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeFileAtomicSync } from "../src/atomic-write.js";
+
+describe("writeFileAtomicSync", () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-write-test-"));
+    target = path.join(dir, "store.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the contents", () => {
+    writeFileAtomicSync(target, '{"a":1}', 0o600);
+    expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({ a: 1 });
+  });
+
+  it("replaces existing contents rather than appending", () => {
+    writeFileAtomicSync(target, '{"a":1}', 0o600);
+    writeFileAtomicSync(target, '{"b":2}', 0o600);
+    expect(JSON.parse(fs.readFileSync(target, "utf-8"))).toEqual({ b: 2 });
+  });
+
+  // A temp file left in the data dir would be picked up by nothing, but it would
+  // accumulate one per crash and confuse anyone inspecting the directory.
+  it("leaves no temp file behind", () => {
+    writeFileAtomicSync(target, '{"a":1}', 0o600);
+    expect(fs.readdirSync(dir)).toEqual(["store.json"]);
+  });
+
+  it("applies the requested mode", () => {
+    writeFileAtomicSync(target, '{"a":1}', 0o600);
+    expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  // The file is only ever swapped in whole, so a reader either sees the previous
+  // contents or the new ones. This is what keeps a mid-write kill from turning a
+  // cached policy into an unparseable file that every store reads as "no data".
+  it("never leaves the target parseable-but-partial", () => {
+    writeFileAtomicSync(target, JSON.stringify({ first: true }), 0o600);
+    const before = fs.readFileSync(target, "utf-8");
+
+    // Simulate the failure mode: the rename target is a directory, so the swap fails
+    // after the temp file was written.
+    const blocked = path.join(dir, "blocked.json");
+    fs.mkdirSync(blocked);
+    expect(() =>
+      writeFileAtomicSync(blocked, JSON.stringify({ second: true }), 0o600),
+    ).toThrow();
+
+    // The unrelated target is untouched, and no debris was left in the directory.
+    expect(fs.readFileSync(target, "utf-8")).toBe(before);
+    expect(fs.readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("surfaces a failure instead of reporting success", () => {
+    expect(() =>
+      writeFileAtomicSync(
+        path.join(dir, "missing-subdir", "store.json"),
+        "{}",
+        0o600,
+      ),
+    ).toThrow();
+  });
+});

--- a/tests/find-skills.test.ts
+++ b/tests/find-skills.test.ts
@@ -49,10 +49,10 @@ describe("handleFindSkills", () => {
     const result = await handleFindSkills(mockClient, tmpDir, {});
 
     expect(mockClient.callTool).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         name: "find_skills",
         arguments: {},
-      },
+      }),
       undefined,
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
@@ -75,10 +75,10 @@ describe("handleFindSkills", () => {
     });
 
     expect(mockClient.callTool).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         name: "find_skills",
         arguments: { queries: ["create a calendar event"] },
-      },
+      }),
       undefined,
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
@@ -92,10 +92,10 @@ describe("handleFindSkills", () => {
     });
 
     expect(mockClient.callTool).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         name: "find_skills",
         arguments: { queries: ["search emails", "create calendar event"] },
-      },
+      }),
       undefined,
       expect.objectContaining({ timeout: expect.any(Number) }),
     );

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { evaluate } from "../src/policy/evaluate.js";
 import { classifyResult, validatePolicy } from "../src/policy/negotiate.js";
 import { CAPABILITY_POLICY_KEY } from "../src/policy/key.js";
-import { loadCached, savePolicy } from "../src/policy/cache.js";
+import { loadCachedPolicy, savePolicy } from "../src/policy/cache.js";
 
 const allSupported = {
   toolPromotion: true,
@@ -254,10 +254,10 @@ describe("policy cache", () => {
     savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
     savePolicy("https://b.glean.com", { features: { hitl: { enabled: true } } });
 
-    expect(loadCached("https://a.glean.com").policy).toEqual({
+    expect(loadCachedPolicy("https://a.glean.com")).toEqual({
       features: { hitl: { enabled: false } },
     });
-    expect(loadCached("https://b.glean.com").policy).toEqual({
+    expect(loadCachedPolicy("https://b.glean.com")).toEqual({
       features: { hitl: { enabled: true } },
     });
   });
@@ -269,7 +269,7 @@ describe("policy cache", () => {
   // future one would reintroduce exactly that.
   it("exposes no way to discard a cached policy", async () => {
     const mod = await import("../src/policy/cache.js");
-    expect(Object.keys(mod).sort()).toEqual(["loadCached", "savePolicy"]);
+    expect(Object.keys(mod).sort()).toEqual(["loadCachedPolicy", "savePolicy"]);
   });
 
   // Design: "A response without a policy object does not update or erase the
@@ -278,22 +278,28 @@ describe("policy cache", () => {
     savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
 
     // A no-policy round writes nothing, so the entry is untouched.
-    expect(loadCached("https://a.glean.com").policy).toEqual({
+    expect(loadCachedPolicy("https://a.glean.com")).toEqual({
       features: { hitl: { enabled: false } },
     });
   });
 
   // tools/list belongs to remote-tools-cache-store.ts. Caching it here too would
   // shadow a live subsystem and let the two disagree about which surface goes with
-  // which policy.
-  it("stores policy only, never a tools list", () => {
+  // which policy. Asserted against the file, since that is where a stray field
+  // would actually appear.
+  it("writes policy only, never a tools list", () => {
     savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
 
-    const entry = loadCached("https://a.glean.com") as Record<string, unknown>;
-    expect(Object.keys(entry).sort()).toEqual(["policy", "updatedAt"]);
+    const onDisk = JSON.parse(
+      fs.readFileSync(path.join(dir, "policy-cache.json"), "utf-8"),
+    );
+    expect(Object.keys(onDisk["https://a.glean.com"]).sort()).toEqual([
+      "policy",
+      "updatedAt",
+    ]);
   });
 
-  it("returns an empty entry for an unknown URL rather than throwing", () => {
-    expect(loadCached("https://never-seen.glean.com")).toEqual({});
+  it("returns undefined for an unknown URL rather than throwing", () => {
+    expect(loadCachedPolicy("https://never-seen.glean.com")).toBeUndefined();
   });
 });

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { evaluate } from "../src/policy/evaluate.js";
+import { classifyResult, validatePolicy } from "../src/policy/negotiate.js";
+import { CAPABILITY_POLICY_KEY } from "../src/policy/key.js";
+
+const allSupported = {
+  toolPromotion: true,
+  metaTools: true,
+  hitl: true,
+  fileArgs: true,
+};
+
+describe("feature gating", () => {
+  it("disables exactly the feature the remote turned off", () => {
+    const d = evaluate({
+      pluginVersion: "1.0.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: { features: { fileArgs: { enabled: false } } },
+    });
+    expect(d.features).toEqual({
+      toolPromotion: true,
+      metaTools: true,
+      hitl: true,
+      fileArgs: false,
+    });
+    expect(d.deactivated).toBe(false);
+  });
+
+  it("cannot enable a feature this build does not support", () => {
+    const d = evaluate({
+      pluginVersion: "1.0.0",
+      versionSource: "build",
+      supportedFeatures: { ...allSupported, hitl: false },
+      policy: { features: { hitl: { enabled: true } } },
+    });
+    expect(d.features.hitl).toBe(false);
+  });
+
+  it("treats an omitted feature as no opinion, not as disabled", () => {
+    const d = evaluate({
+      pluginVersion: "1.0.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: { features: {} },
+    });
+    expect(d.features).toEqual(allSupported);
+  });
+});
+
+describe("version gating", () => {
+  it("deactivates below the minimum supported version", () => {
+    const d = evaluate({
+      pluginVersion: "0.2.43",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: { plugin: { minimumSupportedVersion: "9.0.0" } },
+    });
+    expect(d.deactivated).toBe(true);
+    expect(d.versionState).toBe("below-minimum");
+    // Every feature reads false so no caller can act on a stale enablement.
+    expect(Object.values(d.features).every((v) => v === false)).toBe(true);
+  });
+
+  it("deactivates an explicitly blocked version while neighbours stay usable", () => {
+    const policy = { plugin: { blockedVersions: ["1.2.0"] } };
+    const blocked = evaluate({
+      pluginVersion: "1.2.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy,
+    });
+    const neighbour = evaluate({
+      pluginVersion: "1.3.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy,
+    });
+    expect(blocked.versionState).toBe("blocked");
+    expect(neighbour.deactivated).toBe(false);
+  });
+
+  it("NEVER enforces version policy when the version source is unknown", () => {
+    const d = evaluate({
+      pluginVersion: "0.0.0",
+      versionSource: "unknown",
+      supportedFeatures: allSupported,
+      policy: {
+        plugin: {
+          minimumSupportedVersion: "9.0.0",
+          blockedVersions: ["0.0.0"],
+        },
+      },
+    });
+    expect(d.deactivated).toBe(false);
+    expect(d.versionState).toBe("unenforced");
+  });
+
+  it("shows an upgrade notice only when outdated AND the remote asks", () => {
+    const base = {
+      pluginVersion: "1.0.0",
+      versionSource: "build" as const,
+      supportedFeatures: allSupported,
+    };
+    expect(
+      evaluate({
+        ...base,
+        policy: {
+          plugin: {
+            latestVersion: "2.0.0",
+            upgradeRecommendation: { show: true },
+          },
+        },
+      }).showUpgrade,
+    ).toBe(true);
+    expect(
+      evaluate({
+        ...base,
+        policy: {
+          plugin: {
+            latestVersion: "2.0.0",
+            upgradeRecommendation: { show: false },
+          },
+        },
+      }).showUpgrade,
+    ).toBe(false);
+    expect(
+      evaluate({
+        ...base,
+        policy: {
+          plugin: {
+            latestVersion: "1.0.0",
+            upgradeRecommendation: { show: true },
+          },
+        },
+      }).showUpgrade,
+    ).toBe(false);
+  });
+});
+
+describe("no-policy compatibility path", () => {
+  it("enables everything supported and applies no version rule", () => {
+    const d = evaluate({
+      pluginVersion: "0.0.1",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: undefined,
+    });
+    expect(d.features).toEqual(allSupported);
+    expect(d.deactivated).toBe(false);
+    expect(d.versionState).toBe("unenforced");
+  });
+});
+
+describe("outcome classification", () => {
+  it("reads a valid policy off result._meta", () => {
+    const outcome = classifyResult({
+      tools: [],
+      _meta: {
+        [CAPABILITY_POLICY_KEY]: { features: { hitl: { enabled: false } } },
+      },
+    });
+    expect(outcome.kind).toBe("policy");
+  });
+
+  it("distinguishes a successful response with NO policy object", () => {
+    expect(classifyResult({ tools: [] }).kind).toBe("no-policy");
+    expect(classifyResult({ tools: [], _meta: {} }).kind).toBe("no-policy");
+  });
+
+  it("rejects a malformed policy instead of acting on it", () => {
+    const outcome = classifyResult({
+      _meta: {
+        [CAPABILITY_POLICY_KEY]: {
+          plugin: { latestVersion: 123 },
+          features: "everything-on",
+        },
+      },
+    });
+    expect(outcome.kind).toBe("malformed");
+  });
+
+  it("accepts unknown extra fields so a newer remote is not called malformed", () => {
+    const v = validatePolicy({ somethingNew: { nested: true }, features: {} });
+    expect(v.ok).toBe(true);
+  });
+});
+
+// Leniency is required for forward compatibility, but silent leniency hides a
+// renamed or misspelled field: an unrecognized key's type is never checked, so a bad
+// value in one is indistinguishable from its absence. The keys are therefore still
+// ignored for evaluation AND reported, so the ignoring is greppable.
+describe("unknown-key reporting", () => {
+  it("still accepts the policy, and names what it ignored", () => {
+    const v = validatePolicy({
+      somethingNew: true,
+      plugin: { latestVersion: "1.0.0", futureRule: 1 },
+      features: { toolPromotion: { enabled: true }, notAFeature: {} },
+    });
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.unknownKeys.sort()).toEqual([
+      "features.notAFeature",
+      "plugin.futureRule",
+      "somethingNew",
+    ]);
+  });
+
+  it("reports the exact case the response rename created", () => {
+    // A key that WAS valid before the response was nested. It is accepted, because
+    // rejecting unrecognized keys would break forward compatibility -- but its bad
+    // value would otherwise pass in total silence, which is what the report fixes.
+    const v = validatePolicy({ latestPluginVersion: 123 });
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.unknownKeys).toEqual(["latestPluginVersion"]);
+  });
+
+  it("reports nothing when the policy uses only known keys", () => {
+    const v = validatePolicy({
+      plugin: {
+        latestVersion: "1.0.0",
+        minimumSupportedVersion: "0.1.0",
+        blockedVersions: [],
+        upgradeRecommendation: { show: true, dailyCap: 1, weeklyCap: 3, message: "x" },
+      },
+      features: { hitl: { enabled: false } },
+      message: "x",
+    });
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.unknownKeys).toEqual([]);
+  });
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { evaluate } from "../src/policy/evaluate.js";
 import { classifyResult, validatePolicy } from "../src/policy/negotiate.js";
 import { CAPABILITY_POLICY_KEY } from "../src/policy/key.js";
-import { clearCache, loadCached, savePolicy } from "../src/policy/cache.js";
+import { loadCached, savePolicy } from "../src/policy/cache.js";
 
 const allSupported = {
   toolPromotion: true,
@@ -262,17 +262,25 @@ describe("policy cache", () => {
     });
   });
 
-  // Reset must clear every URL, matching clearRemoteTools() on the same path. A
-  // per-URL clear here would leave the two cache files disagreeing about what
-  // "reset" cleared — the pairing is what keeps two separate stores consistent.
-  it("clears every URL when called with no argument", () => {
+  // Reset clears the server URL, credentials and tools cache, but NOT this. A cached
+  // policy can carry a deactivation or a version block, so a user-invokable way to
+  // discard it would be a way to shed one — and the remote may be unreachable
+  // afterwards, with nothing to re-fetch from. Hence no clear function at all; a
+  // future one would reintroduce exactly that.
+  it("exposes no way to discard a cached policy", async () => {
+    const mod = await import("../src/policy/cache.js");
+    expect(Object.keys(mod).sort()).toEqual(["loadCached", "savePolicy"]);
+  });
+
+  // Design: "A response without a policy object does not update or erase the
+  // corresponding cache entry."
+  it("keeps the cached policy when a later response carries none", () => {
     savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
-    savePolicy("https://b.glean.com", { features: { hitl: { enabled: false } } });
 
-    clearCache();
-
-    expect(loadCached("https://a.glean.com").policy).toBeUndefined();
-    expect(loadCached("https://b.glean.com").policy).toBeUndefined();
+    // A no-policy round writes nothing, so the entry is untouched.
+    expect(loadCached("https://a.glean.com").policy).toEqual({
+      features: { hitl: { enabled: false } },
+    });
   });
 
   // tools/list belongs to remote-tools-cache-store.ts. Caching it here too would

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { evaluate } from "../src/policy/evaluate.js";
 import { classifyResult, validatePolicy } from "../src/policy/negotiate.js";
 import { CAPABILITY_POLICY_KEY } from "../src/policy/key.js";
+import { clearCache, loadCached, savePolicy } from "../src/policy/cache.js";
 
 const allSupported = {
   toolPromotion: true,
@@ -230,5 +234,58 @@ describe("unknown-key reporting", () => {
     expect(v.ok).toBe(true);
     if (!v.ok) return;
     expect(v.unknownKeys).toEqual([]);
+  });
+});
+
+describe("policy cache", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-cache-test-"));
+    vi.stubEnv("PLUGIN_DATA_DIR", dir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("keys by remote URL so switching instances cannot cross-contaminate", () => {
+    savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
+    savePolicy("https://b.glean.com", { features: { hitl: { enabled: true } } });
+
+    expect(loadCached("https://a.glean.com").policy).toEqual({
+      features: { hitl: { enabled: false } },
+    });
+    expect(loadCached("https://b.glean.com").policy).toEqual({
+      features: { hitl: { enabled: true } },
+    });
+  });
+
+  // Reset must clear every URL, matching clearRemoteTools() on the same path. A
+  // per-URL clear here would leave the two cache files disagreeing about what
+  // "reset" cleared — the pairing is what keeps two separate stores consistent.
+  it("clears every URL when called with no argument", () => {
+    savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
+    savePolicy("https://b.glean.com", { features: { hitl: { enabled: false } } });
+
+    clearCache();
+
+    expect(loadCached("https://a.glean.com").policy).toBeUndefined();
+    expect(loadCached("https://b.glean.com").policy).toBeUndefined();
+  });
+
+  // tools/list belongs to remote-tools-cache-store.ts. Caching it here too would
+  // shadow a live subsystem and let the two disagree about which surface goes with
+  // which policy.
+  it("stores policy only, never a tools list", () => {
+    savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
+
+    const entry = loadCached("https://a.glean.com") as Record<string, unknown>;
+    expect(Object.keys(entry).sort()).toEqual(["policy", "updatedAt"]);
+  });
+
+  it("returns an empty entry for an unknown URL rather than throwing", () => {
+    expect(loadCached("https://never-seen.glean.com")).toEqual({});
   });
 });

--- a/tests/remote-client.test.ts
+++ b/tests/remote-client.test.ts
@@ -115,10 +115,16 @@ describe("callRemoteTool", () => {
     const result = await callRemoteTool(fakeClient, "some_tool", { a: 1 });
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].params).toEqual({
+    // Every outgoing tools/call now carries the negotiation payload under the
+    // vendor-prefixed `_meta` key, so assert the call's own fields explicitly and
+    // check the envelope separately rather than pinning the whole object.
+    expect(calls[0].params).toMatchObject({
       name: "some_tool",
       arguments: { a: 1 },
     });
+    expect(
+      (calls[0].params as { _meta?: Record<string, unknown> })._meta,
+    ).toHaveProperty("com.glean.mcp/capabilityPolicy");
     expect(calls[0].options).toEqual({ timeout: 12345 });
     expect(result.content).toEqual([{ type: "text", text: "ok" }]);
   });


### PR DESCRIPTION
## What

Adds capability & policy negotiation to the plugin: it reports its context to the remote in a `_meta` vendor extension, and records whatever policy comes back.

**It enforces nothing.** No tool is dropped, no call is refused, `file_args` stays in the schema, HITL is untouched. A policy saying `deactivated` would be computed, logged, cached — and ignored. Nothing outside `src/policy/` reads the resolved decision.

That is *not* the same as a no-op. Five effects are observable:

| Effect | Where |
|---|---|
| New `_meta` on every remote request (`tools/list`, `tools/call`) | `remote-client.ts`, `remote-passthrough.ts` |
| Writes a new file, `~/.glean/policy-cache.json` | `policy/cache.ts` |
| New log lines: `policy.resolved`, `policy.malformed`, `policy.unknown-keys` | `policy/session.ts` |
| Wraps the stdio transport to observe the negotiated MCP revision | `index.ts` |
| `setup` output gains a policy summary | `index.ts` |

Plus, via #49: `serverInfo`/`clientInfo` version changes from a hardcoded `"1.0.0"` to the real build constant.

**Stacked on #49** — base is `mohit/plugin-version-constant`. Review #49 first.

## Verified against production

Installed to `~/.cursor/plugins/local/glean` and exercised in Cursor against `scio-prod-be.glean.com`. Every path that carries `_meta` was confirmed accepted by the real gateway:

```
policy.resolved {"label":"tools/list","outcome":"no-policy",...}
policy.resolved {"label":"tools/call(find_skills)","outcome":"no-policy",...}
policy.resolved {"label":"tools/call(run_tool)","outcome":"no-policy",...}
policy.resolved {"label":"tools/call(search)","outcome":"no-policy",...}
```

`tools/call(search)` is the promoted-passthrough path, `run_tool` exercised the full find_skills → skill → downstream flow. The `setup` output confirmed each field's provenance:

```
Plugin version: 0.2.45 (source: build)
Host: cursor-vscode 1.0.0 (source: handshake)
MCP revision: 2025-11-25
Server inventory: unavailable
Policy: version unenforced, features {toolPromotion,metaTools,hitl,fileArgs all true}
```

So: the build constant survives into a real install (#49's premise), host identity comes from the peer's `clientInfo` rather than our own `serverInfo`, the transport shim observes the negotiated revision, and the deferred inventory reports `unavailable` rather than implying an empty list.

`policy-cache.json` was **never created**, which is correct — only a *valid* policy writes it, and production returns none. `no-policy` stayed distinct from unreachable throughout.

## What testing changed

Three commits exist only because the live test exposed the problem:

- **Negotiation was effectively unobservable.** Against a remote with no policy support every response resolves to the same decision, so change-only logging went silent after the first exchange and never reported `tools/call` again. Confirming the mechanism ran meant reading code, not logs. Now logs on `changed || first-time-for-this-label` — bounded to under ten lines per process.
- **No pid in the log.** Two identical `tools/list` lines a second apart took a `pgrep` and three discarded theories to attribute. Every line now carries `[pid]`; the interesting state (in-force decision, fallback session id, log dedup) is all per-process, so lines that cannot be attributed to a process cannot explain it.
- **Cursor reuses one process across chat sessions** — verified by invoking `setup` in a third session and seeing the same pid serve it. Multiple concurrent processes are therefore not routine, which downgrades (but does not remove) the concern that two processes could hold different in-force decisions once enforcement lands.

## Cache design

The policy cache and the pre-existing `remote-tools-cache-store.ts` are separate and operate independently:

- **The policy cache stores policy only.** The lifted module originally carried a `toolsList` half that duplicated the tools store — dead code shadowing a live subsystem.
- **Only the raw catalog is cached, never a policy-resolved surface.** `tools/list` composes its answer by filtering the catalog through the policy in force, at read time, so a catalog and a policy cached at different moments still yield the surface the current policy dictates. Recorded on `saveRemoteTools`, since that is where an optimisation would break it.
- **A cached policy is never discarded locally** — there is no clear function, and `setup({reset})` deliberately leaves it. It can carry a deactivation or version block, so any local discard is a way to shed one, and afterwards the remote may be unreachable with nothing to re-sync from. Re-keying covers instance switches: entries are keyed by remote URL.
- **Writes are atomic** (temp file + rename). `writeFileSync` truncates then writes, and the cache reads a parse failure as "no data" — so a process killed mid-write silently discarded every entry. Hosts do reap these processes, so that was a live path around the never-discard rule.

## Testing

`219 passed`. Includes the atomic-write helper, whose preservation test is verified by mutation: replacing `writeFileAtomicSync` with a plain `writeFileSync` fails exactly that test and no other.
