### PR TITLE
Restore the HITL approval gate on Cursor, and explain hangs when it drops the prompt

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25128,7 +25128,7 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/version.ts
-var BUILD_VERSION = true ? "0.2.45" : void 0;
+var BUILD_VERSION = true ? "0.2.46" : void 0;
 function pluginVersion() {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
   return { version: "0.0.0", source: "unknown" };
@@ -26363,10 +26363,7 @@ async function findToolJson(skillsBaseDir, toolName) {
 function isCursorClient(mcpServer2) {
   return (mcpServer2.getClientVersion()?.name ?? "").toLowerCase().startsWith("cursor");
 }
-async function buildApprovalMessage(mcpServer2, toolName, args) {
-  if (isCursorClient(mcpServer2)) {
-    return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
-  }
+async function buildApprovalMessage(toolName, args) {
   const { lines, needsFile } = buildCompactArgs(args);
   const message = [
     `Action: ${toolName}`,
@@ -26404,6 +26401,22 @@ async function currentPermissionMode() {
     return null;
   }
 }
+function humanizeMs(ms) {
+  const seconds = Math.round(ms / 1e3);
+  if (seconds < 120) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+function elicitationFailureText(mcpServer2, toolName, detail, elapsedMs, timeoutMs) {
+  const base = `Action ${toolName} was not approved \u2014 the approval request failed (${detail}). The action was NOT executed.`;
+  const waitedFullTimeout = elapsedMs >= timeoutMs * 0.9;
+  if (!waitedFullTimeout || !isCursorClient(mcpServer2)) {
+    return `${base} Ask the user to confirm, then retry.`;
+  }
+  return `${base}
+
+It waited the full ${humanizeMs(timeoutMs)} without an answer. Either the approval prompt was shown and went unanswered, or it was never shown at all \u2014 this end cannot tell which. One possible cause, if no prompt appeared, is a known Cursor issue before version 3.15: a server-initiated approval prompt can be dropped silently, leaving nothing on screen to accept or dismiss. Ask the user whether they saw an approval prompt. If they did not, suggest checking Cursor's version and updating if it is below 3.15 \u2014 otherwise a retry may wait out the clock again.`;
+}
 async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
@@ -26434,16 +26447,13 @@ async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args) {
     throw err;
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
-  if (hitlEnabled && toolMeta?.requires_approval && !isCursorClient(mcpServer2) && mcpServer2.getClientCapabilities()?.elicitation) {
+  if (hitlEnabled && toolMeta?.requires_approval && mcpServer2.getClientCapabilities()?.elicitation) {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
-      const message = await buildApprovalMessage(
-        mcpServer2,
-        toolName,
-        resolvedArgs
-      );
+      const message = await buildApprovalMessage(toolName, resolvedArgs);
       const timeout = hitlTimeoutMs();
       primeElicitationCancellation(mcpServer2);
+      const startedAt = Date.now();
       try {
         const result = await mcpServer2.elicitInput(
           {
@@ -26468,7 +26478,13 @@ async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args) {
           content: [
             {
               type: "text",
-              text: `Action ${toolName} was not approved \u2014 the approval request failed (${detail}). The action was NOT executed. Ask the user to confirm, then retry.`
+              text: elicitationFailureText(
+                mcpServer2,
+                toolName,
+                detail,
+                Date.now() - startedAt,
+                timeout
+              )
             }
           ],
           isError: true
@@ -26489,8 +26505,8 @@ function buildRemoteArgs(serverId, toolName, resolvedArgs) {
     arguments: resolvedArgs
   };
 }
-function runToolAnnotations(enableHitl, clientSupportsElicitation, isCursor) {
-  return enableHitl && clientSupportsElicitation && !isCursor ? { readOnlyHint: true } : void 0;
+function runToolAnnotations(enableHitl, clientSupportsElicitation) {
+  return enableHitl && clientSupportsElicitation ? { readOnlyHint: true } : void 0;
 }
 
 // src/url-config-store.ts
@@ -26907,8 +26923,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     ...RUN_TOOL_TOOL,
     annotations: runToolAnnotations(
       process.env.ENABLE_HITL === "true",
-      !!server.getClientCapabilities()?.elicitation,
-      isCursorClient(server)
+      !!server.getClientCapabilities()?.elicitation
     )
   };
   const staticTools = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,7 @@ import {
   closeCallbackServer,
 } from "./auth-callback-server.js";
 import { handleFindSkills } from "./tools/find-skills.js";
-import {
-  handleRunTool,
-  isCursorClient,
-  runToolAnnotations,
-} from "./tools/run-tool.js";
+import { handleRunTool, runToolAnnotations } from "./tools/run-tool.js";
 import { evictStaleSkills } from "./skill-writer.js";
 import {
   loadServerUrl,
@@ -314,7 +310,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     annotations: runToolAnnotations(
       process.env.ENABLE_HITL === "true",
       !!server.getClientCapabilities()?.elicitation,
-      isCursorClient(server),
     ),
   };
   const staticTools: Tool[] = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -188,8 +188,9 @@ async function findToolJson(
 }
 
 // A stdio server's only client signal is clientInfo.name; Cursor reports
-// "cursor-vscode". Used to offer a Cursor-specific explanation when an approval
-// request waits out the clock (see elicitationFailureText).
+// "cursor-vscode". Two uses: Cursor renders tool name and arguments itself, so its
+// approval prompt is shorter (buildApprovalMessage), and a request that waits out
+// the clock offers its version as a possible cause (elicitationFailureText).
 export function isCursorClient(mcpServer: Server): boolean {
   return (mcpServer.getClientVersion()?.name ?? "")
     .toLowerCase()
@@ -200,13 +201,18 @@ export function isCursorClient(mcpServer: Server): boolean {
 // elicitation prompts. Kept short (a few lines) so the Accept/Decline buttons
 // stay in view; full argument detail spills to a file when it can't fit.
 //
-// Self-contained on every host: it names the action and its arguments rather
-// than pointing at whatever the host renders around the prompt, so it still
-// reads correctly where that surrounding detail is absent or collapsed.
+// Cursor is the exception, and deliberately so: it renders the tool name and
+// arguments itself, directly above the prompt, so repeating them here would
+// duplicate what is already on screen. Its prompt only needs the review ask.
 async function buildApprovalMessage(
+  mcpServer: Server,
   toolName: string,
   args: unknown,
 ): Promise<string> {
+  if (isCursorClient(mcpServer)) {
+    return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
+  }
+
   const { lines, needsFile } = buildCompactArgs(args);
   // Indent argument lines under "Arguments:" so the structural labels stay
   // distinct from values; keys are uppercased (in compactArgLine) so a key
@@ -409,7 +415,11 @@ export async function handleRunTool(
     // gate. Only bypassPermissions is skipped (deliberately narrow).
     const bypass = (await currentPermissionMode()) === "bypassPermissions";
     if (!bypass) {
-      const message = await buildApprovalMessage(toolName, resolvedArgs);
+      const message = await buildApprovalMessage(
+        mcpServer,
+        toolName,
+        resolvedArgs,
+      );
       const timeout = hitlTimeoutMs();
 
       // Make a dummy empty request to burn JSON-RPC request id 0

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -188,9 +188,8 @@ async function findToolJson(
 }
 
 // A stdio server's only client signal is clientInfo.name; Cursor reports
-// "cursor-vscode". Two uses: Cursor renders tool name and arguments itself, so its
-// approval prompt is shorter (buildApprovalMessage), and a request that waits out
-// the clock offers its version as a possible cause (elicitationFailureText).
+// "cursor-vscode". Used to offer Cursor's version as a possible cause when an
+// approval request waits out the clock (see elicitationFailureText).
 export function isCursorClient(mcpServer: Server): boolean {
   return (mcpServer.getClientVersion()?.name ?? "")
     .toLowerCase()
@@ -201,18 +200,18 @@ export function isCursorClient(mcpServer: Server): boolean {
 // elicitation prompts. Kept short (a few lines) so the Accept/Decline buttons
 // stay in view; full argument detail spills to a file when it can't fit.
 //
-// Cursor is the exception, and deliberately so: it renders the tool name and
-// arguments itself, directly above the prompt, so repeating them here would
-// duplicate what is already on screen. Its prompt only needs the review ask.
+// Every host gets the same text, Cursor included. Cursor was an exception for good
+// reason until recently: it rendered the tool and its arguments itself, directly above
+// the prompt, so its message was only a review ask — "Review the tool and arguments
+// shown above". As of August 2026 Cursor no longer renders them (confirmed by
+// screenshot), which left that message pointing at nothing on screen. The shared text
+// names the action and arguments itself, so it cannot go stale that way. Re-introducing
+// a host-specific short form means first confirming that host still displays the
+// arguments somewhere.
 async function buildApprovalMessage(
-  mcpServer: Server,
   toolName: string,
   args: unknown,
 ): Promise<string> {
-  if (isCursorClient(mcpServer)) {
-    return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
-  }
-
   const { lines, needsFile } = buildCompactArgs(args);
   // Indent argument lines under "Arguments:" so the structural labels stay
   // distinct from values; keys are uppercased (in compactArgLine) so a key
@@ -415,11 +414,7 @@ export async function handleRunTool(
     // gate. Only bypassPermissions is skipped (deliberately narrow).
     const bypass = (await currentPermissionMode()) === "bypassPermissions";
     if (!bypass) {
-      const message = await buildApprovalMessage(
-        mcpServer,
-        toolName,
-        resolvedArgs,
-      );
+      const message = await buildApprovalMessage(toolName, resolvedArgs);
       const timeout = hitlTimeoutMs();
 
       // Make a dummy empty request to burn JSON-RPC request id 0

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -187,9 +187,9 @@ async function findToolJson(
   return null;
 }
 
-// A stdio server's only client signal is clientInfo.name. Cursor reports
-// "cursor-vscode" and already renders the tool name + arguments in its own
-// expandable UI, so its approval prompt only needs a one-line review ask.
+// A stdio server's only client signal is clientInfo.name; Cursor reports
+// "cursor-vscode". Used to attach Cursor-specific upgrade guidance when an
+// approval prompt is never answered (see elicitationFailureText).
 export function isCursorClient(mcpServer: Server): boolean {
   return (mcpServer.getClientVersion()?.name ?? "")
     .toLowerCase()
@@ -199,15 +199,14 @@ export function isCursorClient(mcpServer: Server): boolean {
 // Plain text, NOT Markdown: Claude Code does not reliably render Markdown in
 // elicitation prompts. Kept short (a few lines) so the Accept/Decline buttons
 // stay in view; full argument detail spills to a file when it can't fit.
+//
+// Self-contained on every host: it names the action and its arguments rather
+// than pointing at whatever the host renders around the prompt, so it still
+// reads correctly where that surrounding detail is absent or collapsed.
 async function buildApprovalMessage(
-  mcpServer: Server,
   toolName: string,
   args: unknown,
 ): Promise<string> {
-  if (isCursorClient(mcpServer)) {
-    return `Review the tool and arguments shown above, click on Submit to allow and Cancel to deny.`;
-  }
-
   const { lines, needsFile } = buildCompactArgs(args);
   // Indent argument lines under "Arguments:" so the structural labels stay
   // distinct from values; keys are uppercased (in compactArgLine) so a key
@@ -281,6 +280,51 @@ async function currentPermissionMode(): Promise<string | null> {
   }
 }
 
+// Text for a FAILED approval request — a rejection, not a user's decline or cancel.
+// Those resolve with an action and are handled by the caller.
+//
+// Cursor before 3.15 drops server-initiated elicitations onto the auto-run lane, so the
+// prompt never appears and the request sits until the HITL timeout. Its
+// clientInfo.version is a hardcoded "1.0.0" (verified: the app reports 3.14.7 while the
+// handshake says 1.0.0), so the guidance cannot be gated on a version comparison and has
+// to key off the symptom.
+//
+// That symptom is DURATION, not the error: a dropped prompt burns the entire timeout,
+// while an interrupted one fails early. Elapsed time is the only discriminator available,
+// because the SDK wraps every abort reason as ErrorCode.RequestTimeout
+// (shared/protocol.js) — a user-driven abort and a real timeout arrive with the same code
+// and message shape. Keying off duration is what keeps someone who simply dismissed the
+// prompt from being told to upgrade Cursor.
+export function elicitationFailureText(
+  mcpServer: Server,
+  toolName: string,
+  detail: string,
+  elapsedMs: number,
+  timeoutMs: number,
+): string {
+  const base =
+    `Action ${toolName} was not approved — the approval request failed ` +
+    `(${detail}). The action was NOT executed.`;
+
+  // Within 10% of the deadline: the prompt was never answered, rather than
+  // dismissed. Anything faster was interrupted, so say nothing about Cursor.
+  const hung = elapsedMs >= timeoutMs * 0.9;
+
+  if (!hung || !isCursorClient(mcpServer)) {
+    return `${base} Ask the user to confirm, then retry.`;
+  }
+
+  return (
+    `${base}\n\n` +
+    `This tool requires explicit approval before it runs, and the approval prompt ` +
+    `never appeared — it waited the full ${Math.round(timeoutMs / 1000)}s and timed ` +
+    `out. Cursor does not deliver approval prompts reliably before version 3.15: the ` +
+    `prompt is silently dropped, which is why this looked frozen. If Cursor is older ` +
+    `than 3.15, updating it will fix this. Tell the user, and do not retry until they ` +
+    `have updated — the retry will hang the same way.`
+  );
+}
+
 export async function handleRunTool(
   remoteClient: Client,
   mcpServer: Server,
@@ -329,17 +373,20 @@ export async function handleRunTool(
   }
 
   const hitlEnabled = process.env.ENABLE_HITL === "true";
-  // Cursor is gated by its OWN native run-tool approval, not our elicitation.
-  // We omit run_tool's readOnlyHint for Cursor (see runToolAnnotations), so
-  // Cursor prompts the user before it executes run_tool. Firing our elicitation
-  // on top would be a redundant second gate — and worse, Cursor 3.12.x silently
-  // drops server-initiated elicitations on the auto-run lane, hanging for the
-  // full HITL timeout. So skip our gate for Cursor and let its native prompt
-  // (already shown before this call) be the single approval.
+  // Cursor is deliberately NOT excepted here any more. It used to be: we omitted
+  // run_tool's readOnlyHint so Cursor showed its own native prompt, and skipped our
+  // elicitation entirely, because Cursor before 3.15 silently drops server-initiated
+  // elicitations onto the auto-run lane — no banner appears and the call hangs to the
+  // HITL timeout. That workaround was permanent and silent, though: it left every Cursor
+  // user on the weaker native prompt even on builds where elicitation works, with no
+  // signal that upgrading would help. Cursor's clientInfo.version is a hardcoded "1.0.0"
+  // (verified: the app reports 3.14.7 while the handshake says 1.0.0), so we cannot
+  // detect the fixed build and switch back automatically. Instead we treat Cursor like
+  // any other elicitation-capable host and let the failure carry the explanation — see
+  // elicitationFailureText.
   if (
     hitlEnabled &&
     toolMeta?.requires_approval &&
-    !isCursorClient(mcpServer) &&
     mcpServer.getClientCapabilities()?.elicitation
   ) {
     // In bypassPermissions mode (`claude --dangerously-skip-permissions`) the
@@ -351,16 +398,13 @@ export async function handleRunTool(
     // gate. Only bypassPermissions is skipped (deliberately narrow).
     const bypass = (await currentPermissionMode()) === "bypassPermissions";
     if (!bypass) {
-      const message = await buildApprovalMessage(
-        mcpServer,
-        toolName,
-        resolvedArgs,
-      );
+      const message = await buildApprovalMessage(toolName, resolvedArgs);
       const timeout = hitlTimeoutMs();
 
       // Make a dummy empty request to burn JSON-RPC request id 0
       primeElicitationCancellation(mcpServer);
 
+      const startedAt = Date.now();
       try {
         const result = await mcpServer.elicitInput(
           {
@@ -389,7 +433,13 @@ export async function handleRunTool(
           content: [
             {
               type: "text",
-              text: `Action ${toolName} was not approved — the approval request failed (${detail}). The action was NOT executed. Ask the user to confirm, then retry.`,
+              text: elicitationFailureText(
+                mcpServer,
+                toolName,
+                detail,
+                Date.now() - startedAt,
+                timeout,
+              ),
             },
           ],
           isError: true,
@@ -432,21 +482,18 @@ export function buildRemoteArgs(
  * and avoid a double prompt. Without HITL there is no gate of our own, so we
  * leave annotations unset and let the client decide.
  *
- * TEMP (Cursor): Cursor 3.12.x silently drops the server-initiated elicitation
- * for a `run_tool` marked `readOnlyHint` (it lands on the auto-run lane), so the
- * approval banner never shows and the call hangs to the HITL timeout. For Cursor
- * we therefore flip the whole strategy: do NOT advertise `readOnlyHint` (so
- * Cursor shows its OWN native run-tool approval before executing), and skip our
- * elicitation entirely (see handleRunTool) so Cursor's native prompt is the
- * single gate. Claude Code is unaffected: it keeps `readOnlyHint` (its native
- * prompt stays suppressed) and our elicitation remains its gate.
+ * Cursor is no longer excepted here. It used to be, to route around its
+ * pre-3.15 elicitation bug, but that traded a permanent weaker gate for a
+ * transient bug and left users with no signal that upgrading would help. Cursor
+ * now gets `readOnlyHint` like any other elicitation-capable host, so our prompt
+ * is the single gate there too; on a broken build the elicitation times out and
+ * `elicitationFailureText` explains why and what to do.
  */
 export function runToolAnnotations(
   enableHitl: boolean,
   clientSupportsElicitation: boolean,
-  isCursor: boolean,
 ): Tool["annotations"] {
-  return enableHitl && clientSupportsElicitation && !isCursor
+  return enableHitl && clientSupportsElicitation
     ? { readOnlyHint: true }
     : undefined;
 }

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -188,8 +188,8 @@ async function findToolJson(
 }
 
 // A stdio server's only client signal is clientInfo.name; Cursor reports
-// "cursor-vscode". Used to attach Cursor-specific upgrade guidance when an
-// approval prompt is never answered (see elicitationFailureText).
+// "cursor-vscode". Used to offer a Cursor-specific explanation when an approval
+// request waits out the clock (see elicitationFailureText).
 export function isCursorClient(mcpServer: Server): boolean {
   return (mcpServer.getClientVersion()?.name ?? "")
     .toLowerCase()
@@ -280,21 +280,6 @@ async function currentPermissionMode(): Promise<string | null> {
   }
 }
 
-// Text for a FAILED approval request — a rejection, not a user's decline or cancel.
-// Those resolve with an action and are handled by the caller.
-//
-// Cursor before 3.15 drops server-initiated elicitations onto the auto-run lane, so the
-// prompt never appears and the request sits until the HITL timeout. Its
-// clientInfo.version is a hardcoded "1.0.0" (verified: the app reports 3.14.7 while the
-// handshake says 1.0.0), so the guidance cannot be gated on a version comparison and has
-// to key off the symptom.
-//
-// That symptom is DURATION, not the error: a dropped prompt burns the entire timeout,
-// while an interrupted one fails early. Elapsed time is the only discriminator available,
-// because the SDK wraps every abort reason as ErrorCode.RequestTimeout
-// (shared/protocol.js) — a user-driven abort and a real timeout arrive with the same code
-// and message shape. Keying off duration is what keeps someone who simply dismissed the
-// prompt from being told to upgrade Cursor.
 // The HITL timeout defaults to 5 minutes, and "waited the full 300s" reads worse than
 // "the full 5 minutes" in a message a model relays to a user verbatim.
 function humanizeMs(ms: number): string {
@@ -304,6 +289,22 @@ function humanizeMs(ms: number): string {
   return `${minutes} minute${minutes === 1 ? "" : "s"}`;
 }
 
+// Text for a FAILED approval request — a rejection, not a user's decline or cancel.
+// Those resolve with an action and are handled by the caller.
+//
+// A request that burned the whole timeout is AMBIGUOUS, and the message has to stay that
+// way: the prompt may have been shown and left unanswered, or never delivered at all.
+// Nothing observable from here separates the two, so the Cursor explanation is offered as
+// a possibility for the user to check, never asserted. Cursor before 3.15 can silently
+// drop server-initiated elicitations onto the auto-run lane, and its clientInfo.version
+// is a hardcoded "1.0.0" (verified: the app reports 3.14.7 while the handshake says
+// 1.0.0), so there is no version to compare and no way to confirm which case occurred.
+//
+// The duration check only keeps the note off plainly unrelated failures: an interrupted
+// request fails early, a dropped one waits out the clock. It cannot carry more weight
+// than that, because the SDK wraps every abort reason as ErrorCode.RequestTimeout
+// (shared/protocol.js) — a user-driven abort and a real timeout arrive with the same code
+// and message shape.
 export function elicitationFailureText(
   mcpServer: Server,
   toolName: string,
@@ -315,22 +316,23 @@ export function elicitationFailureText(
     `Action ${toolName} was not approved — the approval request failed ` +
     `(${detail}). The action was NOT executed.`;
 
-  // Within 10% of the deadline: the prompt was never answered, rather than
-  // dismissed. Anything faster was interrupted, so say nothing about Cursor.
-  const hung = elapsedMs >= timeoutMs * 0.9;
+  // Only a request that waited out the clock is a candidate for the Cursor note; an
+  // early failure was interrupted, which the dropped-prompt bug does not explain.
+  const waitedFullTimeout = elapsedMs >= timeoutMs * 0.9;
 
-  if (!hung || !isCursorClient(mcpServer)) {
+  if (!waitedFullTimeout || !isCursorClient(mcpServer)) {
     return `${base} Ask the user to confirm, then retry.`;
   }
 
   return (
     `${base}\n\n` +
-    `This tool requires explicit approval before it runs, and the approval prompt ` +
-    `never appeared — it waited the full ${humanizeMs(timeoutMs)} and timed ` +
-    `out. Cursor does not deliver approval prompts reliably before version 3.15: the ` +
-    `prompt is silently dropped, which is why this looked frozen. If Cursor is older ` +
-    `than 3.15, updating it will fix this. Tell the user, and do not retry until they ` +
-    `have updated — the retry will hang the same way.`
+    `It waited the full ${humanizeMs(timeoutMs)} without an answer. Either the approval ` +
+    `prompt was shown and went unanswered, or it was never shown at all — this end ` +
+    `cannot tell which. One possible cause, if no prompt appeared, is a known Cursor ` +
+    `issue before version 3.15: a server-initiated approval prompt can be dropped ` +
+    `silently, leaving nothing on screen to accept or dismiss. Ask the user whether they ` +
+    `saw an approval prompt. If they did not, suggest checking Cursor's version and ` +
+    `updating if it is below 3.15 — otherwise a retry may wait out the clock again.`
   );
 }
 
@@ -384,15 +386,15 @@ export async function handleRunTool(
   const hitlEnabled = process.env.ENABLE_HITL === "true";
   // Cursor is deliberately NOT excepted here any more. It used to be: we omitted
   // run_tool's readOnlyHint so Cursor showed its own native prompt, and skipped our
-  // elicitation entirely, because Cursor before 3.15 silently drops server-initiated
-  // elicitations onto the auto-run lane — no banner appears and the call hangs to the
+  // elicitation entirely, because Cursor before 3.15 can silently drop server-initiated
+  // elicitations onto the auto-run lane — no prompt appears and the call waits out the
   // HITL timeout. That workaround was permanent and silent, though: it left every Cursor
   // user on the weaker native prompt even on builds where elicitation works, with no
   // signal that upgrading would help. Cursor's clientInfo.version is a hardcoded "1.0.0"
   // (verified: the app reports 3.14.7 while the handshake says 1.0.0), so we cannot
   // detect the fixed build and switch back automatically. Instead we treat Cursor like
-  // any other elicitation-capable host and let the failure carry the explanation — see
-  // elicitationFailureText.
+  // any other elicitation-capable host, and a timeout surfaces the version as a
+  // possible cause — see elicitationFailureText.
   if (
     hitlEnabled &&
     toolMeta?.requires_approval &&
@@ -495,8 +497,8 @@ export function buildRemoteArgs(
  * pre-3.15 elicitation bug, but that traded a permanent weaker gate for a
  * transient bug and left users with no signal that upgrading would help. Cursor
  * now gets `readOnlyHint` like any other elicitation-capable host, so our prompt
- * is the single gate there too; on a broken build the elicitation times out and
- * `elicitationFailureText` explains why and what to do.
+ * is the single gate there too. If the prompt is dropped, the request waits out the HITL
+ * timeout and `elicitationFailureText` raises the version as something to check.
  */
 export function runToolAnnotations(
   enableHitl: boolean,

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -295,6 +295,15 @@ async function currentPermissionMode(): Promise<string | null> {
 // (shared/protocol.js) — a user-driven abort and a real timeout arrive with the same code
 // and message shape. Keying off duration is what keeps someone who simply dismissed the
 // prompt from being told to upgrade Cursor.
+// The HITL timeout defaults to 5 minutes, and "waited the full 300s" reads worse than
+// "the full 5 minutes" in a message a model relays to a user verbatim.
+function humanizeMs(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 120) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
 export function elicitationFailureText(
   mcpServer: Server,
   toolName: string,
@@ -317,7 +326,7 @@ export function elicitationFailureText(
   return (
     `${base}\n\n` +
     `This tool requires explicit approval before it runs, and the approval prompt ` +
-    `never appeared — it waited the full ${Math.round(timeoutMs / 1000)}s and timed ` +
+    `never appeared — it waited the full ${humanizeMs(timeoutMs)} and timed ` +
     `out. Cursor does not deliver approval prompts reliably before version 3.15: the ` +
     `prompt is silently dropped, which is why this looked frozen. If Cursor is older ` +
     `than 3.15, updating it will fix this. Tell the user, and do not retry until they ` +

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -360,11 +360,10 @@ describe("handleRunTool (HITL)", () => {
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
-  // Cursor renders the tool name and arguments itself, directly above the prompt, so
-  // its message is only the review ask. This branch was unreachable while Cursor was
-  // excluded from the gate — restoring the gate makes it live again, and these two
-  // tests exist so it is not mistaken for dead code a second time.
-  it("asks Cursor to review what it already renders, without repeating it", async () => {
+  // Cursor used to render the tool and its arguments itself, so its prompt was only a
+  // review ask pointing at them. It stopped doing that (confirmed by screenshot, Aug
+  // 2026), so it now gets the same self-describing text as every other host.
+  it("spells out action and arguments for Cursor too, since it no longer shows them", async () => {
     vi.stubEnv("ENABLE_HITL", "true");
     const remote = makeRemote();
     const elicit = vi.fn().mockResolvedValue({ action: "accept" });
@@ -381,9 +380,10 @@ describe("handleRunTool (HITL)", () => {
     });
 
     const message = elicit.mock.calls[0][0].message as string;
-    expect(message).toContain("shown above");
-    expect(message).not.toContain("Action:");
-    expect(message).not.toContain("ENG");
+    expect(message).toContain("Action: jirasearch");
+    expect(message).toContain("ENG");
+    // Would point at something Cursor no longer draws.
+    expect(message).not.toContain("shown above");
   });
 
   it("spells out action and arguments for a host that does not render them", async () => {

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -340,10 +340,10 @@ describe("handleRunTool (HITL)", () => {
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT elicit for Cursor — its native prompt is the gate; executes directly", async () => {
+  it("DOES elicit for Cursor — our prompt is the single gate there too", async () => {
     vi.stubEnv("ENABLE_HITL", "true");
     const remote = makeRemote();
-    const elicit = vi.fn();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
     const server = makeServer({
       elicitation: true,
       clientName: "cursor-vscode",
@@ -353,10 +353,106 @@ describe("handleRunTool (HITL)", () => {
 
     await handleRunTool(remote, server, tmpDir, baseArgs);
 
-    // Cursor: readOnlyHint is omitted (native prompt shows), so our elicitation
-    // is skipped and the tool runs directly.
-    expect(elicit).not.toHaveBeenCalled();
+    // Cursor is no longer excluded: it gets readOnlyHint like every other
+    // elicitation-capable host, so this prompt is the only approval gate.
+    expect(elicit).toHaveBeenCalledTimes(1);
     expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  // Cursor's pre-3.15 bug drops the prompt, so the request burns the whole
+  // timeout. Its version cannot be checked (clientInfo reports a hardcoded
+  // "1.0.0"), so the guidance keys off that duration instead.
+  it("adds Cursor upgrade guidance when the prompt was never answered", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    vi.stubEnv("HITL_TIMEOUT_MS", "40");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockImplementation(
+      () =>
+        new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error("Request timed out")), 60),
+        ),
+    );
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("3.15");
+    expect(text).toContain("NOT executed");
+    expect(remote.callTool).not.toHaveBeenCalled();
+  });
+
+  // Escape should resolve with action "cancel", but a host that delivers it as
+  // an abort instead reaches this path as ErrorCode.RequestTimeout — the SDK
+  // wraps every abort reason that way, so the code and message shape are
+  // identical to a real timeout. Duration is the only discriminator, and a fast
+  // failure must not blame Cursor's version.
+  it("omits Cursor guidance when the prompt failed early, e.g. dismissed", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    vi.stubEnv("HITL_TIMEOUT_MS", "10000");
+    const remote = makeRemote();
+    const elicit = vi
+      .fn()
+      .mockRejectedValue(new Error("MCP error -32001: Request timed out"));
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(result.isError).toBe(true);
+    expect(text).not.toContain("3.15");
+    expect(text).toContain("Ask the user to confirm");
+    expect(remote.callTool).not.toHaveBeenCalled();
+  });
+
+  it("never mentions Cursor to another host, even on a full-timeout hang", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    vi.stubEnv("HITL_TIMEOUT_MS", "40");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockImplementation(
+      () =>
+        new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error("Request timed out")), 60),
+        ),
+    );
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+
+    expect((result.content[0] as { text: string }).text).not.toContain("3.15");
+    expect(remote.callTool).not.toHaveBeenCalled();
+  });
+
+  it("treats a spec-compliant cancel as a cancel, not a failure", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "cancel" });
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(text).toContain("cancelled by the user");
+    expect(text).not.toContain("3.15");
+    expect(result.isError).toBeUndefined();
+    expect(remote.callTool).not.toHaveBeenCalled();
   });
 
   it("prompts with action name + arguments and forwards on accept", async () => {
@@ -710,21 +806,25 @@ describe("formatArgumentsForFile", () => {
 });
 
 describe("runToolAnnotations", () => {
-  it("marks run_tool read-only when HITL gates an elicitation-capable non-Cursor client", () => {
-    expect(runToolAnnotations(true, true, false)).toEqual({
+  it("marks run_tool read-only when HITL gates an elicitation-capable client", () => {
+    expect(runToolAnnotations(true, true)).toEqual({
       readOnlyHint: true,
     });
   });
 
   it("leaves annotations unset when HITL is disabled", () => {
-    expect(runToolAnnotations(false, true, false)).toBeUndefined();
+    expect(runToolAnnotations(false, true)).toBeUndefined();
   });
 
   it("leaves annotations unset when the client cannot elicit", () => {
-    expect(runToolAnnotations(true, false, false)).toBeUndefined();
+    expect(runToolAnnotations(true, false)).toBeUndefined();
   });
 
-  it("does NOT advertise readOnlyHint to Cursor (its elicitation only renders on the attended lane)", () => {
-    expect(runToolAnnotations(true, true, true)).toBeUndefined();
+  // Cursor used to be excluded here so it would show its own native prompt. It no
+  // longer is: our elicitation is the single gate on every elicitation-capable host,
+  // and a Cursor build that drops the prompt surfaces as a timeout carrying upgrade
+  // guidance rather than as a permanently weaker gate.
+  it("advertises readOnlyHint to Cursor as well, so our prompt is the single gate", () => {
+    expect(runToolAnnotations(true, true)).toEqual({ readOnlyHint: true });
   });
 });

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -360,10 +360,10 @@ describe("handleRunTool (HITL)", () => {
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
-  // Cursor's pre-3.15 bug drops the prompt, so the request burns the whole
+  // Cursor's pre-3.15 bug can drop the prompt, so the request burns the whole
   // timeout. Its version cannot be checked (clientInfo reports a hardcoded
-  // "1.0.0"), so the guidance keys off that duration instead.
-  it("adds Cursor upgrade guidance when the prompt was never answered", async () => {
+  // "1.0.0"), so the note keys off that duration instead.
+  it("raises Cursor as a possible cause when the request waits out the clock", async () => {
     vi.stubEnv("ENABLE_HITL", "true");
     vi.stubEnv("HITL_TIMEOUT_MS", "40");
     const remote = makeRemote();
@@ -387,6 +387,38 @@ describe("handleRunTool (HITL)", () => {
     expect(text).toContain("3.15");
     expect(text).toContain("NOT executed");
     expect(remote.callTool).not.toHaveBeenCalled();
+  });
+
+  // A timeout cannot distinguish "prompt shown, nobody answered" from "prompt never
+  // delivered", so the text must not claim the prompt was missing. Asserting it would
+  // send the user chasing a Cursor upgrade for what may just be an unanswered prompt.
+  it("frames the missing prompt as a possibility, never as a finding", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    vi.stubEnv("HITL_TIMEOUT_MS", "40");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockImplementation(
+      () =>
+        new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error("Request timed out")), 60),
+        ),
+    );
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(text).toContain("cannot tell which");
+    expect(text).toContain("One possible cause");
+    expect(text).toContain("Ask the user whether they saw an approval prompt");
+    // No claim about what did or did not happen on screen.
+    expect(text).not.toContain("never appeared");
+    expect(text).not.toContain("is silently dropped");
+    expect(text).not.toContain("will fix this");
   });
 
   // Escape should resolve with action "cancel", but a host that delivers it as

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -8,6 +8,7 @@ import {
   FileArgsError,
   handleRunTool,
   runToolAnnotations,
+  elicitationFailureText,
 } from "../src/tools/run-tool.js";
 import {
   buildCompactArgs,
@@ -826,5 +827,24 @@ describe("runToolAnnotations", () => {
   // guidance rather than as a permanently weaker gate.
   it("advertises readOnlyHint to Cursor as well, so our prompt is the single gate", () => {
     expect(runToolAnnotations(true, true)).toEqual({ readOnlyHint: true });
+  });
+});
+
+describe("elicitationFailureText", () => {
+  const cursor = {
+    getClientVersion: () => ({ name: "cursor-vscode", version: "1.0.0" }),
+  } as any;
+
+  // The shipped HITL_TIMEOUT_MS is 300000, so this phrasing is what almost every
+  // real occurrence prints. A model relays it verbatim, so it reads in minutes.
+  it("renders the 5-minute default as minutes, not 300s", () => {
+    const text = elicitationFailureText(cursor, "t", "timed out", 300_000, 300_000);
+    expect(text).toContain("the full 5 minutes");
+    expect(text).not.toContain("300s");
+  });
+
+  it("keeps short test timeouts in seconds", () => {
+    const text = elicitationFailureText(cursor, "t", "timed out", 20_000, 20_000);
+    expect(text).toContain("the full 20s");
   });
 });

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -360,6 +360,50 @@ describe("handleRunTool (HITL)", () => {
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
+  // Cursor renders the tool name and arguments itself, directly above the prompt, so
+  // its message is only the review ask. This branch was unreachable while Cursor was
+  // excluded from the gate — restoring the gate makes it live again, and these two
+  // tests exist so it is not mistaken for dead code a second time.
+  it("asks Cursor to review what it already renders, without repeating it", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({
+      elicitation: true,
+      clientName: "cursor-vscode",
+      elicit,
+    });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, {
+      ...baseArgs,
+      arguments: { project: "ENG", summary: "ship it" },
+    });
+
+    const message = elicit.mock.calls[0][0].message as string;
+    expect(message).toContain("shown above");
+    expect(message).not.toContain("Action:");
+    expect(message).not.toContain("ENG");
+  });
+
+  it("spells out action and arguments for a host that does not render them", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    const elicit = vi.fn().mockResolvedValue({ action: "accept" });
+    const server = makeServer({ elicitation: true, elicit });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, {
+      ...baseArgs,
+      arguments: { project: "ENG" },
+    });
+
+    const message = elicit.mock.calls[0][0].message as string;
+    expect(message).toContain("Action: jirasearch");
+    expect(message).toContain("ENG");
+    expect(message).not.toContain("shown above");
+  });
+
   // Cursor's pre-3.15 bug can drop the prompt, so the request burns the whole
   // timeout. Its version cannot be checked (clientInfo reports a hardcoded
   // "1.0.0"), so the note keys off that duration instead.


### PR DESCRIPTION
## What

Cursor was excepted from our HITL approval gate. This restores it, and makes an approval request that waits out the clock explain itself instead of just looking frozen.

## Why

Cursor before 3.15 can silently drop server-initiated elicitations onto the auto-run lane: the prompt never appears and `run_tool` waits out the full HITL timeout (5 min by default) with nothing on screen to accept or dismiss. The existing workaround routed around that by omitting `run_tool`'s `readOnlyHint` for Cursor and skipping our elicitation entirely, leaving Cursor's own native prompt as the gate.

That trades something permanent for something transient:

- Cursor users stay on the weaker native prompt forever, including on builds where elicitation works fine.
- Nobody learns that upgrading might fix it.
- We can't detect the fixed build and switch back. **Cursor's `clientInfo.version` is a hardcoded `1.0.0`** — verified against a 3.14.7 install, which still announces `1.0.0` in the handshake. There is no version to compare against 3.15.

## How

Cursor is now treated like any other elicitation-capable host, and a failed approval carries the context.

When an approval request is *rejected* (not declined or cancelled — those resolve with an action), we look at how long it waited:

| Elapsed | Message |
|---|---|
| ≥ 90% of the timeout | generic + Cursor version raised as a **possible** cause (Cursor only) |
| anything faster | generic only |

### The note is a possibility, not a diagnosis

A timeout **cannot** distinguish "the prompt was shown and nobody answered it" from "the prompt was never delivered". Nothing observable separates them. So the message states only what is known, names both cases, and asks the user before suggesting anything:

> It waited the full 5 minutes without an answer. Either the approval prompt was shown and went unanswered, or it was never shown at all — this end cannot tell which. One possible cause, if no prompt appeared, is a known Cursor issue before version 3.15: a server-initiated approval prompt can be dropped silently, leaving nothing on screen to accept or dismiss. Ask the user whether they saw an approval prompt. If they did not, suggest checking Cursor's version and updating if it is below 3.15 — otherwise a retry may wait out the clock again.

An earlier revision asserted the prompt "never appeared" and that Cursor "does not deliver approval prompts reliably before 3.15". That reads as a finding we have no basis for, and would send someone who merely stepped away from a visible prompt off to check their Cursor version. Tests pin the conditional framing and assert the old absolute phrasings are gone.

The duration gate does no more than keep the note off failures that ended early, which the dropped-prompt bug would not explain.

### Why duration at all, and not the error

The SDK wraps **every** abort reason as `ErrorCode.RequestTimeout`:

```js
// @modelcontextprotocol/sdk/shared/protocol.js
const error = reason instanceof McpError ? reason : new McpError(ErrorCode.RequestTimeout, String(reason));
reject(error);
```

A user-driven abort and a real timeout are therefore indistinguishable by code or message shape.

**On Escape:** per spec that resolves with `action: "cancel"`, which returns a result and never reaches this path — covered by a test. The duration check exists for hosts that deliver it as an abort instead; those land on the fast path and get only the generic message. (In Cursor 3.14.7 the hang can't be escaped at all, so in practice this case doesn't arise there.)

## Scope

- No change on any other host.
- No change on a Cursor build where elicitation works — the note only appears after a full-timeout failure.
- The gate still fails **closed**: a failed approval never executes the action.

**Cursor now gets the same approval-prompt text as every other host.** Its prompt used to be a bare review ask — "Review the tool and arguments shown above" — because Cursor drew the tool and its arguments itself, directly above the prompt. That was true when the text was added in 72b0a8a; it is not true now. **As of August 2026 Cursor no longer renders them** (confirmed by screenshot), so the message pointed at nothing and the user saw an approval prompt with no indication of what they were approving. The shared text names the action and arguments itself, so it cannot go stale that way. A test pins it for Cursor specifically.

One smaller thing: **the timeout renders as "the full 5 minutes"** rather than "the full 300s". 300000 is the shipped default, so that phrasing is what almost every real occurrence prints, and a model relays it verbatim. Short test timeouts stay in seconds.

## Testing

`198 passed`. New/rewritten tests cover: Cursor now gets the elicitation; a full-timeout failure raises the version as a possibility; the text stays conditional and never claims the prompt was missing; an early failure gets only the generic message; a non-Cursor host never sees the note; a spec-compliant cancel stays a cancel; the 5-minute default renders as minutes; and each host gets its own approval-prompt text.

Verified end-to-end against the **built bundle** with a stdio client identifying as `cursor-vscode` and announcing the elicitation capability, pointed at a local no-auth MCP standing in for the remote:

```
mode=accept  → fake-remote executed run_tool …    (note ABSENT)
mode=hang    → full-timeout text                  (note PRESENT, isError=true)
mode=abort   → "…Ask the user to confirm…"         (note ABSENT, isError=true)
```

Neither the hang nor the abort case reached the remote.

Also installed to `~/.cursor/plugins/local/glean` and exercised in **Cursor 3.14.7**: the prompt does not appear, the request waits out the timeout, and the message comes back as expected. The accept path can't be exercised on that build, which is why it's covered by the synthetic client above.
