### PR TITLE
Enforce the negotiated capability policy

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25562,7 +25562,10 @@ function recordPolicyFromResult(result, label) {
       policy = cachedPolicy;
       break;
     case "no-policy":
-      policy = void 0;
+      policy = cachedPolicy;
+      if (cachedPolicy) {
+        logLine("policy.absent-kept-cache", { label });
+      }
       break;
   }
   const request = lastRequest ?? negotiationRequest();

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25142,7 +25142,6 @@ var CAPABILITY_POLICY_KEY = "com.glean.mcp/capabilityPolicy";
 var FEATURE_NAMES = [
   "toolPromotion",
   "metaTools",
-  "hitl",
   "fileArgs"
 ];
 

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25128,7 +25128,7 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/version.ts
-var BUILD_VERSION = true ? "0.2.46" : void 0;
+var BUILD_VERSION = true ? "0.2.47" : void 0;
 function pluginVersion() {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
   return { version: "0.0.0", source: "unknown" };
@@ -25520,6 +25520,7 @@ var loggedLabels = /* @__PURE__ */ new Set();
 var lastRequest;
 var cacheKeyUrl;
 var protocolVersion = new ProtocolVersionObserver();
+var TOOLS_LIST_LABEL = "tools/list";
 function initPolicySession(server2, log) {
   mcpServer = server2;
   logLine = log;
@@ -25568,7 +25569,8 @@ function recordPolicyFromResult(result, label) {
     supportedFeatures: request.plugin.supportedFeatures,
     policy
   });
-  const changed = !decision || JSON.stringify([decision.deactivated, decision.features]) !== JSON.stringify([next.deactivated, next.features]);
+  const previous = decision;
+  const changed = !previous || surfaceKey(previous) !== surfaceKey(next);
   decision = next;
   const firstForLabel = !loggedLabels.has(label);
   loggedLabels.add(label);
@@ -25582,6 +25584,18 @@ function recordPolicyFromResult(result, label) {
       reasons: next.reasons
     });
   }
+  if (changed && previous && label !== TOOLS_LIST_LABEL) {
+    logLine("policy.surface-changed", {
+      label,
+      from: { deactivated: previous.deactivated, features: previous.features },
+      to: { deactivated: next.deactivated, features: next.features }
+    });
+    mcpServer?.sendToolListChanged().catch(() => {
+    });
+  }
+}
+function surfaceKey(d) {
+  return JSON.stringify([d.deactivated, d.features]);
 }
 function policySummary() {
   const r = lastRequest;
@@ -26650,7 +26664,7 @@ async function fetchAllowedRemoteTools(remoteClient) {
       ...cursor ? { cursor } : {},
       ...negotiationMeta()
     });
-    recordPolicyFromResult(page, "tools/list");
+    recordPolicyFromResult(page, TOOLS_LIST_LABEL);
     for (const tool of page.tools) {
       if (!REMOTE_TOOLS_ALLOWLIST.has(tool.name)) continue;
       collected.push({

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25555,6 +25555,7 @@ function recordPolicyFromResult(result, label) {
       if (outcome.unknownKeys.length > 0) {
         logLine("policy.unknown-keys", { label, keys: outcome.unknownKeys });
       }
+      reportUnenforcedCaps(outcome.policy);
       break;
     case "malformed":
       logLine("policy.malformed", { label, reason: outcome.reason });
@@ -25598,6 +25599,16 @@ function recordPolicyFromResult(result, label) {
 }
 function surfaceKey(d) {
   return JSON.stringify([d.deactivated, d.features]);
+}
+var capsReported = false;
+function reportUnenforcedCaps(policy) {
+  if (capsReported) return;
+  const rec = policy.plugin?.upgradeRecommendation;
+  const dailyCap = rec?.dailyCap;
+  const weeklyCap = rec?.weeklyCap;
+  if (dailyCap === void 0 && weeklyCap === void 0) return;
+  capsReported = true;
+  logLine("policy.caps-not-enforced", { dailyCap, weeklyCap });
 }
 function decisionInForce() {
   if (decision) return decision;

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25351,6 +25351,7 @@ function evaluate(input) {
       features: allFeatures(false),
       showUpgrade: true,
       message: policy.message,
+      upgradeMessage: policy.plugin?.upgradeRecommendation?.message,
       reasons
     };
   }
@@ -25372,6 +25373,7 @@ function evaluate(input) {
     features,
     showUpgrade: versionState === "outdated-supported" && policy.plugin?.upgradeRecommendation?.show === true,
     message: policy.message,
+    upgradeMessage: policy.plugin?.upgradeRecommendation?.message,
     reasons
   };
 }
@@ -25597,6 +25599,37 @@ function recordPolicyFromResult(result, label) {
 function surfaceKey(d) {
   return JSON.stringify([d.deactivated, d.features]);
 }
+function decisionInForce() {
+  if (decision) return decision;
+  try {
+    const policy = cacheKeyUrl ? loadCachedPolicy(cacheKeyUrl) : void 0;
+    const request = lastRequest ?? negotiationRequest();
+    decision = evaluate({
+      pluginVersion: request.plugin.version,
+      versionSource: request.plugin.versionSource,
+      supportedFeatures: request.plugin.supportedFeatures,
+      policy
+    });
+    if (policy) {
+      logLine("policy.seeded-from-cache", {
+        versionState: decision.versionState,
+        deactivated: decision.deactivated,
+        features: decision.features
+      });
+    }
+    return decision;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logLine("policy.seed-failed", { msg });
+    decision = evaluate({
+      pluginVersion: "0.0.0",
+      versionSource: "unknown",
+      supportedFeatures: supportedFeatures(),
+      policy: void 0
+    });
+    return decision;
+  }
+}
 function policySummary() {
   const r = lastRequest;
   const d = decision;
@@ -25608,6 +25641,15 @@ function policySummary() {
   ];
   if (d) {
     lines.push(`Policy: version ${d.versionState}, features ${JSON.stringify(d.features)}`);
+    if (d.deactivated) {
+      lines.push(
+        `Deactivated: only \`setup\` is available. ${d.upgradeMessage ?? "Upgrade the Glean plugin to restore functionality."}`
+      );
+    } else if (d.showUpgrade) {
+      lines.push(
+        `Upgrade available: ${d.upgradeMessage ?? "a newer version of the Glean plugin is available."}`
+      );
+    }
     if (d.message) lines.push(`Notice: ${d.message}`);
   } else {
     lines.push("Policy: not yet negotiated");
@@ -26160,6 +26202,79 @@ import fs6 from "node:fs/promises";
 import os3 from "node:os";
 import path6 from "node:path";
 
+// src/policy/enforce.ts
+var SETUP_TOOL_NAME = "setup";
+var META_TOOL_NAMES = /* @__PURE__ */ new Set([
+  "find_skills",
+  "run_tool"
+]);
+function withoutFileArgs(tool) {
+  const schema = tool.inputSchema;
+  if (!schema?.properties || !("file_args" in schema.properties)) return tool;
+  const { file_args: _dropped, ...rest } = schema.properties;
+  return {
+    ...tool,
+    inputSchema: { ...schema, properties: rest }
+  };
+}
+function advertisedTools(input) {
+  const { decision: decision2, setupTool, findSkillsTool, runTool, promoted } = input;
+  if (decision2.deactivated) {
+    return {
+      tools: [setupTool],
+      withheld: [
+        findSkillsTool.name,
+        runTool.name,
+        ...promoted.map((t) => t.name)
+      ]
+    };
+  }
+  const tools = [];
+  const withheld = [];
+  if (decision2.features.metaTools) {
+    tools.push(
+      findSkillsTool,
+      decision2.features.fileArgs ? runTool : withoutFileArgs(runTool)
+    );
+  } else {
+    withheld.push(findSkillsTool.name, runTool.name);
+  }
+  tools.push(setupTool);
+  if (decision2.features.toolPromotion) {
+    tools.push(...promoted);
+  } else {
+    withheld.push(...promoted.map((t) => t.name));
+  }
+  return { tools, withheld };
+}
+function refuse(text) {
+  return { content: [{ type: "text", text }], isError: true };
+}
+function policyRefusal(input) {
+  const { name, decision: decision2, promoted } = input;
+  if (name === SETUP_TOOL_NAME) return void 0;
+  if (decision2.deactivated) {
+    const remedy = decision2.upgradeMessage ?? "Upgrade the Glean plugin, then call `setup` to confirm the connection.";
+    return refuse(
+      `[POLICY_DEACTIVATED]
+
+This version of the Glean plugin is not supported by your Glean instance, so only \`setup\` is available and ${name} will not run. Do not retry. ${remedy}`
+    );
+  }
+  if (META_TOOL_NAMES.has(name) && !decision2.features.metaTools) {
+    return refuse(
+      `${name} is disabled for your Glean instance by remote policy and will not run. Do not retry \u2014 this is not a transient failure. Call \`setup\` to see the policy currently in force.`
+    );
+  }
+  if (promoted.has(name) && !decision2.features.toolPromotion) {
+    return refuse(
+      `${name} is not available: Glean tool promotion is disabled for your instance by remote policy, so this call will not run. Do not retry. Call \`setup\` to see the policy currently in force.`
+    );
+  }
+  return void 0;
+}
+var FILE_ARGS_DISABLED_TEXT = "`file_args` is disabled for your Glean instance by remote policy, so no file was read and the tool was not executed. Retry `run_tool` with the values inline in `arguments` instead.";
+
 // src/tools/approval-args.ts
 import fs5 from "node:fs/promises";
 import path5 from "node:path";
@@ -26430,7 +26545,7 @@ function elicitationFailureText(mcpServer2, toolName, detail, elapsedMs, timeout
 
 It waited the full ${humanizeMs(timeoutMs)} without an answer. Either the approval prompt was shown and went unanswered, or it was never shown at all \u2014 this end cannot tell which. One possible cause, if no prompt appeared, is a known Cursor issue before version 3.15: a server-initiated approval prompt can be dropped silently, leaving nothing on screen to accept or dismiss. Ask the user whether they saw an approval prompt. If they did not, suggest checking Cursor's version and updating if it is below 3.15 \u2014 otherwise a retry may wait out the clock again.`;
 }
-async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args) {
+async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args, policy) {
   const serverId = args.server_id;
   const toolName = args.tool_name;
   if (typeof serverId !== "string" || typeof toolName !== "string") {
@@ -26442,6 +26557,12 @@ async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args) {
     };
   }
   const toolMeta = await findToolJson(skillsBaseDir, toolName);
+  if (!policy.fileArgs && args.file_args !== void 0) {
+    return {
+      content: [{ type: "text", text: FILE_ARGS_DISABLED_TEXT }],
+      isError: true
+    };
+  }
   const baseArgs = args.arguments != null && typeof args.arguments === "object" ? args.arguments : {};
   let resolvedArgs;
   try {
@@ -26932,22 +27053,34 @@ var SETUP_TOOL = {
   }
 };
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const runTool = {
-    ...RUN_TOOL_TOOL,
-    annotations: runToolAnnotations(
-      process.env.ENABLE_HITL === "true",
-      !!server.getClientCapabilities()?.elicitation
-    )
-  };
-  const staticTools = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];
   const serve = (state, dynamic) => {
+    const decision2 = decisionInForce();
+    const runTool = {
+      ...RUN_TOOL_TOOL,
+      annotations: runToolAnnotations(
+        process.env.ENABLE_HITL === "true",
+        !!server.getClientCapabilities()?.elicitation
+      )
+    };
+    const { tools, withheld } = advertisedTools({
+      decision: decision2,
+      setupTool: SETUP_TOOL,
+      findSkillsTool: FIND_SKILLS_TOOL,
+      runTool,
+      promoted: dynamic
+    });
+    const fromCatalog = new Set(dynamic.map((t) => t.name));
     logLine2("tools-list.served", {
-      static: staticTools.length,
-      dynamic: dynamic.length,
+      static: tools.filter((t) => !fromCatalog.has(t.name)).length,
+      dynamic: tools.filter((t) => fromCatalog.has(t.name)).length,
       names: dynamic.map((t) => t.name),
+      withheld,
+      deactivated: decision2.deactivated,
+      versionState: decision2.versionState,
+      features: decision2.features,
       state
     });
-    return { tools: [...staticTools, ...dynamic] };
+    return { tools };
   };
   const serverUrl = resolveServerUrl();
   if (!serverUrl) {
@@ -27112,6 +27245,11 @@ async function advanceSetup() {
     cachedRemoteTools = remoteTools;
     saveRemoteTools(serverUrl, remoteTools);
     const toolNames = remoteTools.map((t) => t.name).join(", ") || "(none)";
+    const decision2 = decisionInForce();
+    const closing = decision2.deactivated ? `This plugin version is not supported by your Glean instance, so only \`setup\` is available. Upgrade the Glean plugin to restore the rest.` : `You can now use ` + [
+      ...decision2.features.metaTools ? ["find_skills", "run_tool"] : [],
+      ...decision2.features.toolPromotion && remoteTools.length > 0 ? ["any of the listed remote tools"] : []
+    ].join(", ") + `.`;
     return {
       content: [
         {
@@ -27122,7 +27260,7 @@ Authenticated: yes
 Remote tools: ${toolNames}
 ${policySummary().join("\n")}
 
-You can now use find_skills, run_tool, and any of the listed remote tools.`
+` + closing
         }
       ]
     };
@@ -27147,6 +27285,21 @@ Try calling setup again to retry, or setup({reset:true}) to start over.`
 }
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args = {} } = request.params;
+  const decision2 = decisionInForce();
+  const refusal = policyRefusal({
+    name,
+    decision: decision2,
+    promoted: REMOTE_TOOLS_ALLOWLIST
+  });
+  if (refusal) {
+    logLine2("policy.refused", {
+      tool: name,
+      deactivated: decision2.deactivated,
+      versionState: decision2.versionState,
+      features: decision2.features
+    });
+    return refusal;
+  }
   if (REMOTE_TOOLS_ALLOWLIST.has(name)) {
     const serverUrl = resolveServerUrl();
     if (!serverUrl) {
@@ -27268,7 +27421,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
       try {
         const skillsBaseDir = resolveSkillsBaseDir();
-        return await handleRunTool(remoteClient, server, skillsBaseDir, args);
+        return await handleRunTool(remoteClient, server, skillsBaseDir, args, {
+          fileArgs: decision2.features.fileArgs
+        });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`run_tool: execution failed: ${msg}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,13 @@ import { resolveSessionId } from "./session-id.js";
 import { resolveServerUrlFromEmail } from "./config-search.js";
 import { pluginVersionString } from "./version.js";
 import {
+  decisionInForce,
   initPolicySession,
   policySummary,
   protocolVersion,
   setPolicyServerUrl,
 } from "./policy/session.js";
+import { advertisedTools, policyRefusal } from "./policy/enforce.js";
 
 function readEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -138,8 +140,10 @@ const server = new Server(
   { capabilities: { tools: { listChanged: true } } },
 );
 
-// Capability/policy negotiation. This reports the plugin's context to the remote and
-// records whatever policy comes back; it does not yet change what the plugin does.
+// Capability/policy negotiation. Reports the plugin's context to the remote, records the
+// policy that comes back, and — since this build enforces it — gates what `tools/list`
+// advertises and what `tools/call` will run. The gates themselves are pure functions in
+// ./policy/enforce.ts; the two handlers below only read the decision and apply them.
 initPolicySession(server, logLine);
 setPolicyServerUrl(resolveServerUrl());
 
@@ -305,30 +309,48 @@ const SETUP_TOOL: Tool = {
 };
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  const runTool: Tool = {
-    ...RUN_TOOL_TOOL,
-    annotations: runToolAnnotations(
-      process.env.ENABLE_HITL === "true",
-      !!server.getClientCapabilities()?.elicitation,
-    ),
-  };
-  const staticTools: Tool[] = [FIND_SKILLS_TOOL, runTool, SETUP_TOOL];
-
   // One structured line on every return path, so "why don't my tools appear?"
-  // is answerable from the log alone: `static` is constant, `names` lists the
-  // dynamic tools we actually surfaced (freshly fetched or served from cache),
-  // and `state` names the path we took. The allow-list only ever drops tools
-  // outside our fixed set, so a missing allow-listed name (e.g. `chat`) means
-  // the backend never returned it. Only tool *names*, counts and the state
-  // tag are logged — never argument values, which can carry PII/secrets.
+  // is answerable from the log alone: `names` lists the dynamic tools we actually
+  // surfaced (freshly fetched or served from cache), `withheld` names what policy
+  // removed, and `state` names the path we took. The allow-list only ever drops
+  // tools outside our fixed set, so a missing allow-listed name (e.g. `chat`)
+  // that policy did not withhold means the backend never returned it. Only tool
+  // *names*, counts and the state tag are logged — never argument values, which
+  // can carry PII/secrets.
+  //
+  // The decision is read HERE rather than at the top of the handler: on the `fetched`
+  // path the policy is recorded during the fetch `await`, so reading it earlier would
+  // apply a one-request-stale decision to a freshly fetched catalog.
   const serve = (state: string, dynamic: Tool[]): { tools: Tool[] } => {
+    const decision = decisionInForce();
+    const runTool: Tool = {
+      ...RUN_TOOL_TOOL,
+      annotations: runToolAnnotations(
+        process.env.ENABLE_HITL === "true",
+        !!server.getClientCapabilities()?.elicitation,
+      ),
+    };
+    const { tools, withheld } = advertisedTools({
+      decision,
+      setupTool: SETUP_TOOL,
+      findSkillsTool: FIND_SKILLS_TOOL,
+      runTool,
+      promoted: dynamic,
+    });
+    // `static` used to be a constant 3. It varies now, so derive it rather than assume:
+    // anything advertised that did not come from the remote catalog.
+    const fromCatalog = new Set(dynamic.map((t) => t.name));
     logLine("tools-list.served", {
-      static: staticTools.length,
-      dynamic: dynamic.length,
+      static: tools.filter((t) => !fromCatalog.has(t.name)).length,
+      dynamic: tools.filter((t) => fromCatalog.has(t.name)).length,
       names: dynamic.map((t) => t.name),
+      withheld,
+      deactivated: decision.deactivated,
+      versionState: decision.versionState,
+      features: decision.features,
       state,
     });
-    return { tools: [...staticTools, ...dynamic] };
+    return { tools };
   };
 
   // Pre-auth gate: tokens() is sync. When unauthenticated (or unconfigured)
@@ -542,6 +564,21 @@ async function advanceSetup(): Promise<CallToolResult> {
     cachedRemoteTools = remoteTools;
     saveRemoteTools(serverUrl, remoteTools);
     const toolNames = remoteTools.map((t) => t.name).join(", ") || "(none)";
+    // Derived from the decision rather than asserted. Naming find_skills and run_tool
+    // unconditionally would be wrong the moment policy withholds them, and actively
+    // misleading when the plugin is deactivated and only `setup` works.
+    const decision = decisionInForce();
+    const closing = decision.deactivated
+      ? `This plugin version is not supported by your Glean instance, so only ` +
+        `\`setup\` is available. Upgrade the Glean plugin to restore the rest.`
+      : `You can now use ` +
+        [
+          ...(decision.features.metaTools ? ["find_skills", "run_tool"] : []),
+          ...(decision.features.toolPromotion && remoteTools.length > 0
+            ? ["any of the listed remote tools"]
+            : []),
+        ].join(", ") +
+        `.`;
     return {
       content: [
         {
@@ -555,8 +592,7 @@ async function advanceSetup(): Promise<CallToolResult> {
             // missing version constant, or an unobserved MCP revision, visible per
             // install rather than only in logs.
             `${policySummary().join("\n")}\n\n` +
-            `You can now use find_skills, run_tool, and any of the listed ` +
-            `remote tools.`,
+            closing,
         },
       ],
     };
@@ -583,6 +619,30 @@ async function advanceSetup(): Promise<CallToolResult> {
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args = {} } = request.params;
+
+  // The gate. Advertisement is advisory: a host may re-fetch its tool list late or never,
+  // and a model can call a tool still in its context from an earlier list, so a tool
+  // withdrawn from tools/list stays reachable until it is refused here too.
+  //
+  // Placed above the allow-list branch because that is the only point covering all three
+  // lanes — promoted passthrough, find_skills, and run_tool each have their own entry
+  // below. `setup` is exempt inside policyRefusal, before the deactivation check, since it
+  // is the path by which a deactivation gets lifted.
+  const decision = decisionInForce();
+  const refusal = policyRefusal({
+    name,
+    decision,
+    promoted: REMOTE_TOOLS_ALLOWLIST,
+  });
+  if (refusal) {
+    logLine("policy.refused", {
+      tool: name,
+      deactivated: decision.deactivated,
+      versionState: decision.versionState,
+      features: decision.features,
+    });
+    return refusal;
+  }
 
   // Allow-listed remote tools (chat/search/read_document) — only valid once
   // setup has provided a server URL. Auth is handled by dispatchRemoteTool
@@ -727,7 +787,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
       try {
         const skillsBaseDir = resolveSkillsBaseDir();
-        return await handleRunTool(remoteClient, server, skillsBaseDir, args);
+        return await handleRunTool(remoteClient, server, skillsBaseDir, args, {
+          fileArgs: decision.features.fileArgs,
+        });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`run_tool: execution failed: ${msg}`);

--- a/src/policy/enforce.ts
+++ b/src/policy/enforce.ts
@@ -1,0 +1,152 @@
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Decision } from "./types.js";
+
+// The tool that policy can never withdraw. A deactivated plugin advertises only this,
+// because it is how a user restores the connection that would lift the deactivation.
+export const SETUP_TOOL_NAME = "setup";
+
+// Gated together by `metaTools`, and gated as a pair on purpose: a surface with
+// find_skills but no run_tool can discover work it cannot perform.
+export const META_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "find_skills",
+  "run_tool",
+]);
+
+/**
+ * `run_tool` with `file_args` removed from its advertised schema, so a disabled
+ * fileArgs feature is genuinely inert rather than present-and-rejected.
+ *
+ * Returns a NEW tool at every level it changes. The caller clones RUN_TOOL_TOOL with a
+ * shallow spread, so `inputSchema.properties` is shared with that module-level const --
+ * deleting from it would drop `file_args` for the life of the process and survive a
+ * later policy flip back to enabled.
+ */
+export function withoutFileArgs(tool: Tool): Tool {
+  const schema = tool.inputSchema as { properties?: Record<string, unknown> };
+  if (!schema?.properties || !("file_args" in schema.properties)) return tool;
+  const { file_args: _dropped, ...rest } = schema.properties;
+  return {
+    ...tool,
+    inputSchema: { ...schema, properties: rest } as Tool["inputSchema"],
+  };
+}
+
+export interface Advertisement {
+  tools: Tool[];
+  /** Names policy withheld, for the served log line. */
+  withheld: string[];
+}
+
+/**
+ * The tool surface policy allows, composed from the decision and the tools on offer.
+ *
+ * Order is preserved from the pre-policy implementation so that the no-policy case --
+ * every install today -- produces a byte-identical list.
+ */
+export function advertisedTools(input: {
+  decision: Decision;
+  setupTool: Tool;
+  findSkillsTool: Tool;
+  runTool: Tool;
+  promoted: Tool[];
+}): Advertisement {
+  const { decision, setupTool, findSkillsTool, runTool, promoted } = input;
+
+  if (decision.deactivated) {
+    return {
+      tools: [setupTool],
+      withheld: [
+        findSkillsTool.name,
+        runTool.name,
+        ...promoted.map((t) => t.name),
+      ],
+    };
+  }
+
+  const tools: Tool[] = [];
+  const withheld: string[] = [];
+
+  if (decision.features.metaTools) {
+    tools.push(
+      findSkillsTool,
+      decision.features.fileArgs ? runTool : withoutFileArgs(runTool),
+    );
+  } else {
+    withheld.push(findSkillsTool.name, runTool.name);
+  }
+
+  tools.push(setupTool);
+
+  if (decision.features.toolPromotion) {
+    tools.push(...promoted);
+  } else {
+    withheld.push(...promoted.map((t) => t.name));
+  }
+
+  return { tools, withheld };
+}
+
+function refuse(text: string): CallToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+/**
+ * The refusal policy requires for a call, or undefined when the call may proceed.
+ *
+ * Advertisement is not the gate; this is. A host may re-fetch its tool list late or
+ * never, and a model can call a tool still sitting in its context from an earlier list,
+ * so a feature withdrawn from `tools/list` stays reachable until it is also refused
+ * here. `toolPromotion` is the clearest case: a promoted tool would otherwise keep
+ * working indefinitely after being withdrawn.
+ *
+ * Covers only the gates that make a tool uncallable. `fileArgs` is argument-level and
+ * belongs next to the code that reads the files; `hitl` changes how run_tool executes,
+ * never whether it runs, and is not declared by this build at all.
+ */
+export function policyRefusal(input: {
+  name: string;
+  decision: Decision;
+  promoted: ReadonlySet<string>;
+}): CallToolResult | undefined {
+  const { name, decision, promoted } = input;
+
+  // Before every other check: setup is the recovery path, so it stays callable in
+  // states where nothing else is -- including deactivation.
+  if (name === SETUP_TOOL_NAME) return undefined;
+
+  // Ahead of the feature checks deliberately. `evaluate` reports every feature as false
+  // when deactivated, so testing features first would answer "metaTools is disabled"
+  // for a plugin whose actual problem, and only remedy, is its version.
+  if (decision.deactivated) {
+    return refuse(
+      `[POLICY_DEACTIVATED]\n\nThis version of the Glean plugin is not supported by ` +
+        `your Glean instance, so only \`setup\` is available and ${name} will not run. ` +
+        `Do not retry. Upgrade the Glean plugin, then call \`setup\` to confirm the ` +
+        `connection.`,
+    );
+  }
+
+  if (META_TOOL_NAMES.has(name) && !decision.features.metaTools) {
+    return refuse(
+      `${name} is disabled for your Glean instance by remote policy and will not run. ` +
+        `Do not retry — this is not a transient failure. Call \`setup\` to see the ` +
+        `policy currently in force.`,
+    );
+  }
+
+  if (promoted.has(name) && !decision.features.toolPromotion) {
+    return refuse(
+      `${name} is not available: Glean tool promotion is disabled for your instance by ` +
+        `remote policy, so this call will not run. Do not retry. Call \`setup\` to see ` +
+        `the policy currently in force.`,
+    );
+  }
+
+  return undefined;
+}
+
+/** Refusal for a `run_tool` call that passes `file_args` while the feature is disabled. */
+export const FILE_ARGS_DISABLED_TEXT =
+  "`file_args` is disabled for your Glean instance by remote policy, so no file was " +
+  "read and the tool was not executed. Retry `run_tool` with the values inline in " +
+  "`arguments` instead.";

--- a/src/policy/enforce.ts
+++ b/src/policy/enforce.ts
@@ -118,11 +118,16 @@ export function policyRefusal(input: {
   // when deactivated, so testing features first would answer "metaTools is disabled"
   // for a plugin whose actual problem, and only remedy, is its version.
   if (decision.deactivated) {
+    // The remote's own upgrade text when it supplied one -- the design assigns
+    // upgradeRecommendation.message this job as well as the soft recommendation, since
+    // the remedy is an upgrade either way, and it may carry instructions we do not know.
+    const remedy =
+      decision.upgradeMessage ??
+      "Upgrade the Glean plugin, then call `setup` to confirm the connection.";
     return refuse(
       `[POLICY_DEACTIVATED]\n\nThis version of the Glean plugin is not supported by ` +
         `your Glean instance, so only \`setup\` is available and ${name} will not run. ` +
-        `Do not retry. Upgrade the Glean plugin, then call \`setup\` to confirm the ` +
-        `connection.`,
+        `Do not retry. ${remedy}`,
     );
   }
 

--- a/src/policy/evaluate.ts
+++ b/src/policy/evaluate.ts
@@ -134,6 +134,7 @@ export function evaluate(input: EvaluateInput): Decision {
       features: allFeatures(false),
       showUpgrade: true,
       message: policy.message,
+      upgradeMessage: policy.plugin?.upgradeRecommendation?.message,
       reasons,
     };
   }
@@ -161,6 +162,7 @@ export function evaluate(input: EvaluateInput): Decision {
       versionState === "outdated-supported" &&
       policy.plugin?.upgradeRecommendation?.show === true,
     message: policy.message,
+    upgradeMessage: policy.plugin?.upgradeRecommendation?.message,
     reasons,
   };
 }

--- a/src/policy/key.ts
+++ b/src/policy/key.ts
@@ -6,10 +6,21 @@ export const CAPABILITY_POLICY_KEY = "com.glean.mcp/capabilityPolicy";
 // The features whose enablement the remote controls. Keep in lockstep with
 // FeatureName below -- the array exists so the plugin can declare support for
 // exactly the features it implements, no more.
+//
+// `hitl` is deliberately absent, though the design contract defines it. Disabling local
+// HITL only makes sense once approval moves to the remote, and the remote is stateless:
+// it has no back-channel to send `elicitation/create` on, so remote-side approval waits
+// on MCP 2026-07-28 landing there. Until then a remote-disabled HITL would leave no gate
+// at all -- and under Claude Code it would be worse than having no policy, because the
+// plugin's PreToolUse hook auto-approves run_tool on the premise that the local prompt
+// IS the gate. A remote that needs to stop such a plugin deactivates the version.
+//
+// Declaring it here is what would make the remote believe it is controllable, so the
+// honest signal is to leave it out until a build can honour it. A remote that sends
+// `features.hitl` anyway takes the unknown-key path: accepted, logged, ignored.
 export const FEATURE_NAMES = [
   "toolPromotion",
   "metaTools",
-  "hitl",
   "fileArgs",
 ] as const;
 

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -248,6 +248,22 @@ export function policySummary(): string[] {
   ];
   if (d) {
     lines.push(`Policy: version ${d.versionState}, features ${JSON.stringify(d.features)}`);
+    // The recommendation is only shown here. It is computed on every exchange, so
+    // without a surface it would be a value the remote sets and nobody ever sees.
+    // dailyCap/weeklyCap are not implemented yet, so this appears on every setup call.
+    if (d.deactivated) {
+      lines.push(
+        `Deactivated: only \`setup\` is available. ${
+          d.upgradeMessage ?? "Upgrade the Glean plugin to restore functionality."
+        }`,
+      );
+    } else if (d.showUpgrade) {
+      lines.push(
+        `Upgrade available: ${
+          d.upgradeMessage ?? "a newer version of the Glean plugin is available."
+        }`,
+      );
+    }
     if (d.message) lines.push(`Notice: ${d.message}`);
   } else {
     lines.push("Policy: not yet negotiated");

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -107,6 +107,7 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
       if (outcome.unknownKeys.length > 0) {
         logLine("policy.unknown-keys", { label, keys: outcome.unknownKeys });
       }
+      reportUnenforcedCaps(outcome.policy);
       break;
     case "malformed":
       logLine("policy.malformed", { label, reason: outcome.reason });
@@ -186,6 +187,30 @@ function surfaceKey(d: Decision): string {
   return JSON.stringify([d.deactivated, d.features]);
 }
 
+// Whether this process has already said the caps are inert.
+let capsReported = false;
+
+/**
+ * Say once that display caps are accepted but not honoured.
+ *
+ * `dailyCap`/`weeklyCap` are deliberately tolerated rather than rejected: the design has
+ * the remote send them for forward compatibility, and only `show` needs honouring in v0.
+ * But a remote that sets `dailyCap: 1` and then sees the recommendation on every `setup`
+ * has no way to learn why, and "read the plugin source" is not an answer. Frequency
+ * capping also has nothing to cap yet — `setup` is the only surface and it is
+ * user-initiated, so rate-limiting the answer to a question the user just asked would be
+ * wrong. Once per process, and only when a remote actually sets one.
+ */
+function reportUnenforcedCaps(policy: PolicyResponse): void {
+  if (capsReported) return;
+  const rec = policy.plugin?.upgradeRecommendation;
+  const dailyCap = rec?.dailyCap;
+  const weeklyCap = rec?.weeklyCap;
+  if (dailyCap === undefined && weeklyCap === undefined) return;
+  capsReported = true;
+  logLine("policy.caps-not-enforced", { dailyCap, weeklyCap });
+}
+
 /**
  * The decision now in force, seeded from the cached policy on first read.
  *
@@ -250,7 +275,9 @@ export function policySummary(): string[] {
     lines.push(`Policy: version ${d.versionState}, features ${JSON.stringify(d.features)}`);
     // The recommendation is only shown here. It is computed on every exchange, so
     // without a surface it would be a value the remote sets and nobody ever sees.
-    // dailyCap/weeklyCap are not implemented yet, so this appears on every setup call.
+    // Shown on every setup call: dailyCap/weeklyCap are accepted but not enforced
+    // (see reportUnenforcedCaps), and capping a user-initiated answer would be wrong
+    // anyway.
     if (d.deactivated) {
       lines.push(
         `Deactivated: only \`setup\` is available. ${

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -77,14 +77,29 @@ export function negotiationMeta(): { _meta: Record<string, unknown> } {
  *
  * The four outcomes are distinct on purpose:
  *   policy      - persist it and re-evaluate.
- *   no-policy   - the remote does not implement negotiation yet. Every supported
- *                 feature is treated as enabled and no version rule applies. The
- *                 cache is NOT erased.
+ *   no-policy   - no policy on THIS response. What that means depends on whether this
+ *                 remote has ever sent one; see below. The cache is never erased.
  *   malformed   - keep the last valid policy and treat this round as no-policy, so a
  *                 bad response can never deactivate a working plugin.
  *   unreachable - decided by the caller, not here: an unreachable remote produces no
  *                 result to classify. Conflating it with no-policy would silently
  *                 drop a previously synced version rule on any network blip.
+ *
+ * On no-policy, a cached policy is RETAINED rather than cleared. The compatibility path
+ * -- every supported feature enabled, no version rule -- is for a remote that does not
+ * implement negotiation, and the cached policy is the evidence of whether this one does.
+ * A remote that has already sent a policy is not disowning it by omitting it later.
+ *
+ * Reading omission as revocation looks harmless until a remote attaches policy to
+ * tools/list but not to tools/call -- a plausible split, since a list is answered once
+ * while calls are the hot path. Then every call would clear the policy, every following
+ * list would restore it, and each clear would emit tools/list_changed, so the host would
+ * re-fetch on every tool call and the advertised surface would visibly flicker.
+ *
+ * The cost is that a remote can no longer lift a restriction by going silent: it must
+ * send an explicit `enabled: true`. For a control plane that is the better default --
+ * clearing-by-silence is exactly what makes the flicker possible -- and it makes this
+ * agree with the unreachable path, which already retains the cached policy.
  */
 export function recordPolicyFromResult(result: unknown, label: string): void {
   // No configured remote yet means nothing to key the cache by, and no exchange to
@@ -114,7 +129,12 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
       policy = cachedPolicy;
       break;
     case "no-policy":
-      policy = undefined;
+      // Silence, not revocation. Undefined only when this remote has never sent a
+      // policy, which is the compatibility path's actual condition.
+      policy = cachedPolicy;
+      if (cachedPolicy) {
+        logLine("policy.absent-kept-cache", { label });
+      }
       break;
   }
 

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -1,6 +1,6 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 
-import { hostIdentityFromHandshake, buildNegotiationRequest } from "./context.js";
+import { hostIdentityFromHandshake, buildNegotiationRequest, supportedFeatures } from "./context.js";
 import { classifyResult, metaFor } from "./negotiate.js";
 import { evaluate } from "./evaluate.js";
 import { loadCachedPolicy, savePolicy } from "./cache.js";
@@ -16,10 +16,10 @@ type LogFn = (label: string, detail?: Record<string, unknown>) => void;
  * later change needs -- the resolved decision, the `_meta` to attach -- have one
  * obvious home.
  *
- * This module reports context and records the resolved policy. It does not enforce
- * anything: nothing here changes which tools are advertised or which calls succeed.
- * Enforcement is a separate change, deliberately, so the exchange can be observed in
- * production before it is allowed to alter behaviour.
+ * This module owns the decision's lifecycle: it reports context, records the policy a
+ * response carried, and resolves the decision now in force. It does not itself withhold
+ * or refuse anything -- the gates are pure functions in ./enforce.ts, applied by the
+ * handlers in index.ts.
  */
 let mcpServer: Server | undefined;
 let logLine: LogFn = () => {};
@@ -36,6 +36,11 @@ let lastRequest: NegotiationRequest | undefined;
 let cacheKeyUrl: string | undefined;
 
 export const protocolVersion = new ProtocolVersionObserver();
+
+// The label recordPolicyFromResult receives for a tools/list exchange. Exported so the
+// caller and the notification guard cannot drift apart on a string literal — the guard
+// depends on distinguishing that path from tools/call.
+export const TOOLS_LIST_LABEL = "tools/list";
 
 export function initPolicySession(server: Server, log: LogFn): void {
   mcpServer = server;
@@ -120,10 +125,9 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
     policy,
   });
 
+  const previous = decision;
   const changed =
-    !decision ||
-    JSON.stringify([decision.deactivated, decision.features]) !==
-      JSON.stringify([next.deactivated, next.features]);
+    !previous || surfaceKey(previous) !== surfaceKey(next);
   decision = next;
 
   // Log on a change, and once per label per process.
@@ -148,11 +152,88 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
       reasons: next.reasons,
     });
   }
+
+  // Tell the host to re-fetch, but only from the tools/call path and only once a
+  // previous decision existed.
+  //
+  // Not from tools/list: there the response IS the update -- the host has just asked and
+  // is about to receive the freshly filtered surface, so a notification would only make
+  // it ask again for what it already holds, and notify -> tools/list -> resolve ->
+  // notify would be a cycle. A policy arriving on a tools/call response is the case that
+  // needs this, because the surface changed and the host has no reason to re-fetch.
+  //
+  // Not on the first decision either: `!previous` counts as changed, so without that
+  // guard every process's first gated call would notify, costing a host tools/list and a
+  // remote round-trip for every user in a world where no policy exists. The stale-list
+  // window on a first call is closed by the refusal, which is the real gate anyway.
+  if (changed && previous && label !== TOOLS_LIST_LABEL) {
+    logLine("policy.surface-changed", {
+      label,
+      from: { deactivated: previous.deactivated, features: previous.features },
+      to: { deactivated: next.deactivated, features: next.features },
+    });
+    mcpServer?.sendToolListChanged().catch(() => {
+      // Transport not connected, or the host does not support the notification.
+      // Harmless: the next tools/list is correct, and calls are refused regardless.
+    });
+  }
 }
 
-/** The policy currently in force, or undefined before the first exchange. */
-export function currentDecision(): Decision | undefined {
-  return decision;
+// The fields that determine what the agent can reach. Reasons and messages churn between
+// otherwise-equivalent responses without changing the surface, and every spurious
+// notification costs a host tools/list and therefore a remote round-trip.
+function surfaceKey(d: Decision): string {
+  return JSON.stringify([d.deactivated, d.features]);
+}
+
+/**
+ * The decision now in force, seeded from the cached policy on first read.
+ *
+ * A fresh process has no decision until a remote exchange happens, and `tools/list` does
+ * not always reach the remote -- the unconfigured, unauthenticated and connect-error
+ * paths all return before any negotiation. Treating that as "no policy, everything on"
+ * would mean a cached deactivation, or a cached `metaTools: false`, was silently undone
+ * by every process start, which is exactly what the design forbids.
+ *
+ * So the first read evaluates the cached policy and memoizes the result. The cache is
+ * touched once per process, never per gated call: `_meta` rides every remote request, so
+ * a process that talks to the remote refreshes its own decision constantly and needs no
+ * re-read. With no configured URL there is nothing to key by, which yields the
+ * all-supported decision.
+ *
+ * Never throws. A failure here would break every tool call, and for a feature that is
+ * inert for every install today, failing open is the only defensible direction.
+ */
+export function decisionInForce(): Decision {
+  if (decision) return decision;
+  try {
+    const policy = cacheKeyUrl ? loadCachedPolicy(cacheKeyUrl) : undefined;
+    const request = lastRequest ?? negotiationRequest();
+    decision = evaluate({
+      pluginVersion: request.plugin.version,
+      versionSource: request.plugin.versionSource,
+      supportedFeatures: request.plugin.supportedFeatures,
+      policy,
+    });
+    if (policy) {
+      logLine("policy.seeded-from-cache", {
+        versionState: decision.versionState,
+        deactivated: decision.deactivated,
+        features: decision.features,
+      });
+    }
+    return decision;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logLine("policy.seed-failed", { msg });
+    decision = evaluate({
+      pluginVersion: "0.0.0",
+      versionSource: "unknown",
+      supportedFeatures: supportedFeatures(),
+      policy: undefined,
+    });
+    return decision;
+  }
 }
 
 /** For `setup` output: what was reported, and what came back. */

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -66,6 +66,15 @@ export interface UpgradeRecommendation {
   show?: boolean;
   dailyCap?: number;
   weeklyCap?: number;
+  /**
+   * Text shown with a recommendation, and also the text used when version policy
+   * deactivates the plugin -- the remedy is an upgrade either way.
+   *
+   * The remote owns the wording, including whether to name a version. Nothing here
+   * interpolates `latestVersion` into it: a plugin that composed its own sentence would
+   * be second-guessing a message the remote wrote for its own users.
+   */
+  message?: string;
 }
 
 // Plugin-scoped rules are grouped under `plugin`; session-scoped policy stays at
@@ -127,6 +136,12 @@ export interface Decision {
   /** True when an upgrade recommendation should be surfaced this session. */
   showUpgrade: boolean;
   message?: string;
+  /**
+   * The remote's upgrade text, carried separately from `message` because they answer
+   * different questions: `message` is about this session, this is about the installed
+   * artifact. Used for the recommendation and for the deactivation refusal.
+   */
+  upgradeMessage?: string;
   /** Human-readable trail of why this decision came out the way it did. */
   reasons: string[];
 }

--- a/src/tools/remote-passthrough.ts
+++ b/src/tools/remote-passthrough.ts
@@ -6,7 +6,11 @@ import {
   createRemoteClient,
   type RemoteClientOptions,
 } from "../remote-client.js";
-import { negotiationMeta, recordPolicyFromResult } from "../policy/session.js";
+import {
+  TOOLS_LIST_LABEL,
+  negotiationMeta,
+  recordPolicyFromResult,
+} from "../policy/session.js";
 
 // Remote tools promoted to first-class local tools once setup completes.
 // Anything the remote MCP server exposes that is not in this set is dropped
@@ -66,7 +70,7 @@ export async function fetchAllowedRemoteTools(
       ...(cursor ? { cursor } : {}),
       ...negotiationMeta(),
     });
-    recordPolicyFromResult(page, "tools/list");
+    recordPolicyFromResult(page, TOOLS_LIST_LABEL);
     for (const tool of page.tools) {
       if (!REMOTE_TOOLS_ALLOWLIST.has(tool.name)) continue;
       collected.push({

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { callRemoteTool } from "../remote-client.js";
+import { FILE_ARGS_DISABLED_TEXT } from "../policy/enforce.js";
 import { buildCompactArgs, writeApprovalArgsFile } from "./approval-args.js";
 import { resolveSessionId } from "../session-id.js";
 
@@ -341,11 +342,22 @@ export function elicitationFailureText(
   );
 }
 
+/**
+ * The policy-controlled features this handler implements.
+ *
+ * Required rather than optional: an omitted argument would silently mean "enabled", and
+ * the typechecker is the only thing that can stop a new call site forgetting it.
+ */
+export interface RunToolPolicy {
+  fileArgs: boolean;
+}
+
 export async function handleRunTool(
   remoteClient: Client,
   mcpServer: Server,
   skillsBaseDir: string,
   args: Record<string, unknown>,
+  policy: RunToolPolicy,
 ): Promise<CallToolResult> {
   const serverId = args.server_id;
   const toolName = args.tool_name;
@@ -363,6 +375,21 @@ export async function handleRunTool(
   // file_args JSON-parsing (object/array params) and its requires_approval
   // drives the HITL gate. Both paths must see it regardless of ENABLE_HITL.
   const toolMeta = await findToolJson(skillsBaseDir, toolName);
+
+  // Refuse before resolveFileArgs, not alongside it. That function reads model-supplied
+  // absolute paths off the user's disk, so a disabled feature has to mean the read does
+  // not happen -- "advertised without file_args but still reading files" would make the
+  // feature inert in name only.
+  //
+  // Refusing rather than ignoring the argument: silently dropping input the model
+  // supplied invites it to retry the same call, so the text says to inline the values.
+  // A call that passes no file_args is unaffected.
+  if (!policy.fileArgs && args.file_args !== undefined) {
+    return {
+      content: [{ type: "text", text: FILE_ARGS_DISABLED_TEXT }],
+      isError: true,
+    };
+  }
 
   // Resolve file_args up front so the approval prompt shows the COMPLETE input
   // (file-sourced values included, not just the inline `arguments`), and so an

--- a/tests/policy-enforce.test.ts
+++ b/tests/policy-enforce.test.ts
@@ -156,6 +156,54 @@ describe("deactivated", () => {
   });
 });
 
+// upgradeRecommendation.message does double duty per the design: the soft recommendation
+// AND the deactivation remedy, since an upgrade is the fix either way. Before this it was
+// accepted by the validator and then dropped, so a remote could write user-facing text
+// into the designated field and see nothing.
+describe("the remote's upgrade text", () => {
+  it("is used as the remedy in a deactivation refusal", () => {
+    const d = decision({
+      deactivated: true,
+      versionState: "below-minimum",
+      features: { toolPromotion: false, metaTools: false, fileArgs: false },
+      upgradeMessage: "Run `/plugin update glean-vnext` and restart Claude Code.",
+    });
+
+    const text = (refusal("find_skills", d)!.content[0] as { text: string }).text;
+    expect(text).toContain("Run `/plugin update glean-vnext`");
+  });
+
+  it("falls back to generic wording when the remote supplied none", () => {
+    const d = decision({
+      deactivated: true,
+      versionState: "blocked",
+      features: { toolPromotion: false, metaTools: false, fileArgs: false },
+    });
+
+    const text = (refusal("run_tool", d)!.content[0] as { text: string }).text;
+    expect(text).toContain("Upgrade the Glean plugin");
+  });
+
+  // A soft recommendation must not withdraw anything -- it is advice, not a gate.
+  it("changes nothing about the surface or the refusals", () => {
+    const d = decision({
+      versionState: "outdated-supported",
+      showUpgrade: true,
+      upgradeMessage: "1.4.0 is out.",
+    });
+
+    expect(names(d)).toEqual([
+      "find_skills",
+      "run_tool",
+      "setup",
+      "search",
+      "chat",
+    ]);
+    expect(refusal("search", d)).toBeUndefined();
+    expect(refusal("run_tool", d)).toBeUndefined();
+  });
+});
+
 describe("metaTools disabled", () => {
   const d = decision({ features: { ...allSupported, metaTools: false } });
 

--- a/tests/policy-enforce.test.ts
+++ b/tests/policy-enforce.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import {
+  advertisedTools,
+  policyRefusal,
+  withoutFileArgs,
+} from "../src/policy/enforce.js";
+import { evaluate } from "../src/policy/evaluate.js";
+import type { Decision } from "../src/policy/types.js";
+
+const allSupported = { toolPromotion: true, metaTools: true, fileArgs: true };
+
+// Version rules cannot be exercised through evaluate() under vitest -- the build constant
+// is absent, so versionSource is "unknown" and version policy is never enforced. The
+// gates are therefore driven from a Decision directly, which is the reason enforce.ts is
+// a pure module in the first place.
+function decision(over: Partial<Decision> = {}): Decision {
+  return {
+    deactivated: false,
+    versionState: "unenforced",
+    features: { ...allSupported },
+    showUpgrade: false,
+    reasons: [],
+    ...over,
+  };
+}
+
+const setupTool: Tool = {
+  name: "setup",
+  inputSchema: { type: "object", properties: {} },
+};
+const findSkillsTool: Tool = {
+  name: "find_skills",
+  inputSchema: { type: "object", properties: { queries: { type: "array" } } },
+};
+
+function makeRunTool(): Tool {
+  return {
+    name: "run_tool",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        server_id: { type: "string" },
+        tool_name: { type: "string" },
+        arguments: { type: "object" },
+        file_args: { type: "object" },
+      },
+      required: ["server_id", "tool_name"],
+    },
+  };
+}
+
+const promoted: Tool[] = [
+  { name: "search", inputSchema: { type: "object", properties: {} } },
+  { name: "chat", inputSchema: { type: "object", properties: {} } },
+];
+const promotedNames: ReadonlySet<string> = new Set(["search", "chat"]);
+
+function advertise(d: Decision) {
+  return advertisedTools({
+    decision: d,
+    setupTool,
+    findSkillsTool,
+    runTool: makeRunTool(),
+    promoted,
+  });
+}
+
+function names(d: Decision): string[] {
+  return advertise(d).tools.map((t) => t.name);
+}
+
+function refusal(name: string, d: Decision) {
+  return policyRefusal({ name, decision: d, promoted: promotedNames });
+}
+
+function fileArgsAdvertised(d: Decision): boolean {
+  const tool = advertise(d).tools.find((t) => t.name === "run_tool");
+  const props = (tool?.inputSchema as { properties?: Record<string, unknown> })
+    ?.properties;
+  return !!props && "file_args" in props;
+}
+
+// The regression that matters most: production returns no policy, so every install today
+// resolves to this decision. The surface must be exactly what shipped before enforcement.
+describe("no policy", () => {
+  it("advertises the pre-policy surface, in the pre-policy order", () => {
+    const d = evaluate({
+      pluginVersion: "0.0.0",
+      versionSource: "unknown",
+      supportedFeatures: allSupported,
+      policy: undefined,
+    });
+    expect(names(d)).toEqual([
+      "find_skills",
+      "run_tool",
+      "setup",
+      "search",
+      "chat",
+    ]);
+    expect(advertise(d).withheld).toEqual([]);
+    expect(fileArgsAdvertised(d)).toBe(true);
+  });
+
+  it("refuses nothing", () => {
+    const d = evaluate({
+      pluginVersion: "0.0.0",
+      versionSource: "unknown",
+      supportedFeatures: allSupported,
+      policy: undefined,
+    });
+    for (const name of ["setup", "find_skills", "run_tool", "search", "chat"]) {
+      expect(refusal(name, d)).toBeUndefined();
+    }
+  });
+});
+
+describe("deactivated", () => {
+  const d = decision({
+    deactivated: true,
+    versionState: "blocked",
+    // evaluate() reports every feature false when deactivated; the gates must not read
+    // that as "the features were individually disabled".
+    features: { toolPromotion: false, metaTools: false, fileArgs: false },
+  });
+
+  it("advertises setup and nothing else", () => {
+    expect(names(d)).toEqual(["setup"]);
+    expect(advertise(d).withheld.sort()).toEqual([
+      "chat",
+      "find_skills",
+      "run_tool",
+      "search",
+    ]);
+  });
+
+  it("keeps setup callable -- it is the recovery path", () => {
+    expect(refusal("setup", d)).toBeUndefined();
+  });
+
+  it("refuses everything else", () => {
+    for (const name of ["find_skills", "run_tool", "search", "chat"]) {
+      expect(refusal(name, d)?.isError).toBe(true);
+    }
+  });
+
+  // The ordering guard: a deactivated plugin's problem is its version, and the only
+  // remedy is an upgrade. Answering "metaTools is disabled" would send the model and the
+  // user after the wrong thing.
+  it("blames the version, not the features", () => {
+    const text = (refusal("find_skills", d)!.content[0] as { text: string }).text;
+    expect(text).toContain("[POLICY_DEACTIVATED]");
+    expect(text).toContain("Upgrade the Glean plugin");
+    expect(text).not.toContain("metaTools");
+  });
+});
+
+describe("metaTools disabled", () => {
+  const d = decision({ features: { ...allSupported, metaTools: false } });
+
+  it("withdraws both meta tools but keeps setup and promoted tools", () => {
+    expect(names(d)).toEqual(["setup", "search", "chat"]);
+    expect(advertise(d).withheld).toEqual(["find_skills", "run_tool"]);
+  });
+
+  it("refuses both by name, and nothing else", () => {
+    expect(refusal("find_skills", d)?.isError).toBe(true);
+    expect(refusal("run_tool", d)?.isError).toBe(true);
+    expect(refusal("search", d)).toBeUndefined();
+    expect(refusal("setup", d)).toBeUndefined();
+  });
+});
+
+describe("toolPromotion disabled", () => {
+  const d = decision({ features: { ...allSupported, toolPromotion: false } });
+
+  it("promotes none, and keeps the meta tools", () => {
+    expect(names(d)).toEqual(["find_skills", "run_tool", "setup"]);
+    expect(advertise(d).withheld).toEqual(["search", "chat"]);
+  });
+
+  // This is the case that motivated call-time enforcement at all: a host holding a stale
+  // list still shows `search` to the model, and without the refusal the call would be
+  // forwarded happily.
+  it("refuses every promoted name even though none are advertised", () => {
+    expect(refusal("search", d)?.isError).toBe(true);
+    expect(refusal("chat", d)?.isError).toBe(true);
+  });
+
+  it("does not refuse a name outside the promoted set", () => {
+    // Left to the handler's existing "Unknown tool" branch.
+    expect(refusal("something_else", d)).toBeUndefined();
+  });
+});
+
+describe("fileArgs disabled", () => {
+  const d = decision({ features: { ...allSupported, fileArgs: false } });
+
+  it("keeps run_tool but drops file_args from its schema", () => {
+    expect(names(d)).toEqual([
+      "find_skills",
+      "run_tool",
+      "setup",
+      "search",
+      "chat",
+    ]);
+    expect(fileArgsAdvertised(d)).toBe(false);
+  });
+
+  it("leaves the rest of the schema intact", () => {
+    const tool = advertise(d).tools.find((t) => t.name === "run_tool")!;
+    const schema = tool.inputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(Object.keys(schema.properties).sort()).toEqual([
+      "arguments",
+      "server_id",
+      "tool_name",
+    ]);
+    expect(schema.required).toEqual(["server_id", "tool_name"]);
+    expect(tool.annotations).toEqual({ readOnlyHint: true });
+  });
+
+  // run_tool itself stays callable -- only a call that passes file_args is rejected, and
+  // that check lives beside the code that reads the files.
+  it("does not refuse run_tool at the funnel", () => {
+    expect(refusal("run_tool", d)).toBeUndefined();
+  });
+});
+
+// The shared-schema hazard: index.ts clones RUN_TOOL_TOOL with a shallow spread, so
+// inputSchema.properties is the module const's own object. A delete would drop file_args
+// for the life of the process and survive a policy flip back to enabled.
+describe("withoutFileArgs", () => {
+  it("does not mutate the tool it is given", () => {
+    const base = makeRunTool();
+    withoutFileArgs(base);
+    const props = (base.inputSchema as { properties: Record<string, unknown> })
+      .properties;
+    expect("file_args" in props).toBe(true);
+  });
+
+  it("survives a flip back to enabled on the same base tool", () => {
+    const base = makeRunTool();
+    const off = advertisedTools({
+      decision: decision({ features: { ...allSupported, fileArgs: false } }),
+      setupTool,
+      findSkillsTool,
+      runTool: base,
+      promoted,
+    });
+    const on = advertisedTools({
+      decision: decision(),
+      setupTool,
+      findSkillsTool,
+      runTool: base,
+      promoted,
+    });
+    const propsOf = (a: typeof off) => {
+      const t = a.tools.find((x) => x.name === "run_tool")!;
+      return (t.inputSchema as { properties: Record<string, unknown> }).properties;
+    };
+    expect("file_args" in propsOf(off)).toBe(false);
+    expect("file_args" in propsOf(on)).toBe(true);
+  });
+
+  it("is a no-op for a tool that never had file_args", () => {
+    expect(withoutFileArgs(findSkillsTool)).toBe(findSkillsTool);
+  });
+});

--- a/tests/policy-session.test.ts
+++ b/tests/policy-session.test.ts
@@ -150,6 +150,43 @@ describe("decisionInForce", () => {
     expect(session.decisionInForce().features.metaTools).toBe(true);
   });
 
+  // Two levels of omission, deliberately different:
+  //
+  //   a feature omitted INSIDE a policy  -> no opinion, so enabled
+  //   the policy object omitted entirely -> silence, so the cache stands
+  //
+  // The first depends on savePolicy REPLACING the cached entry rather than merging into
+  // it, so every policy is evaluated as a complete statement of intent. Turning that into
+  // a merge would make restrictions sticky and leave a remote unable to lift one at all.
+  it("lets a later policy lift a restriction by omitting the feature", async () => {
+    const { session } = await freshSession(dir);
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    session.recordPolicyFromResult(
+      resultWith({ features: { metaTools: { enabled: false } } }),
+      "tools/list",
+    );
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+
+    // Names only toolPromotion; says nothing at all about metaTools.
+    session.recordPolicyFromResult(
+      resultWith({ features: { toolPromotion: { enabled: false } } }),
+      "tools/list",
+    );
+
+    const f = session.decisionInForce().features;
+    expect(f.metaTools).toBe(true);
+    expect(f.toolPromotion).toBe(false);
+
+    // And the same must hold once the CACHE is what answers, not the incoming policy.
+    // evaluate() runs on the response's policy, so the two assertions above pass even if
+    // savePolicy merged rather than replaced — the merge would only surface here, or on a
+    // later process start. This is the assertion that actually pins replace-not-merge.
+    session.recordPolicyFromResult({ content: [] }, "tools/call(search)");
+    expect(session.decisionInForce().features.metaTools).toBe(true);
+  });
+
   it("takes the compatibility path when no policy was ever received", async () => {
     const { session } = await freshSession(dir);
     session.initPolicySession(fakeServer() as never, () => {});

--- a/tests/policy-session.test.ts
+++ b/tests/policy-session.test.ts
@@ -280,3 +280,68 @@ describe("policySummary", () => {
     expect(summary).not.toContain("Deactivated:");
   });
 });
+
+// dailyCap/weeklyCap are tolerated rather than rejected -- the design has the remote send
+// them for forward compatibility and only `show` needs honouring in v0. Tolerating them
+// silently is the problem: a remote setting dailyCap: 1 and seeing the recommendation on
+// every setup has no way to learn why. So it is stated once, in the log.
+describe("unenforced display caps", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-caps-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  async function record(policy: unknown) {
+    const { session } = await freshSession(dir);
+    const labels: string[] = [];
+    session.initPolicySession(fakeServer() as never, (l) => labels.push(l));
+    session.setPolicyServerUrl(URL_A);
+    session.recordPolicyFromResult(resultWith(policy), "tools/call(search)");
+    return { session, labels };
+  }
+
+  it("says so when the remote sets a cap", async () => {
+    const { labels } = await record({
+      plugin: { upgradeRecommendation: { show: true, dailyCap: 1 } },
+    });
+    expect(labels).toContain("policy.caps-not-enforced");
+  });
+
+  it("still accepts the policy rather than calling it malformed", async () => {
+    const { labels } = await record({
+      plugin: { upgradeRecommendation: { show: true, weeklyCap: 3 } },
+    });
+    // Tolerated, not rejected: no malformed, and not reported as an unknown key either.
+    expect(labels).not.toContain("policy.malformed");
+    expect(labels).not.toContain("policy.unknown-keys");
+  });
+
+  it("says nothing when the remote sets no cap", async () => {
+    const { labels } = await record({
+      plugin: { upgradeRecommendation: { show: true } },
+    });
+    expect(labels).not.toContain("policy.caps-not-enforced");
+  });
+
+  // Policy rides every remote response, so an unconditional log here would be one line
+  // per tool call for the life of the process.
+  it("says it once per process, not once per exchange", async () => {
+    const { session, labels } = await record({
+      plugin: { upgradeRecommendation: { show: true, dailyCap: 1 } },
+    });
+
+    session.recordPolicyFromResult(
+      resultWith({ plugin: { upgradeRecommendation: { show: true, dailyCap: 1 } } }),
+      "tools/call(chat)",
+    );
+
+    expect(labels.filter((l) => l === "policy.caps-not-enforced")).toHaveLength(1);
+  });
+});
+

--- a/tests/policy-session.test.ts
+++ b/tests/policy-session.test.ts
@@ -117,10 +117,10 @@ describe("decisionInForce", () => {
     expect(labels).not.toContain("policy.seeded-from-cache");
   });
 
-  // A live response replaces a seeded decision. The no-policy case in particular must
-  // clear a cached restriction rather than keep it, which is what separates "the remote
-  // answered and has no policy" from "the remote was unreachable".
-  it("lets a live no-policy response supersede a cached restriction", async () => {
+  // A response carrying no policy is silence, not revocation. The compatibility path --
+  // everything enabled, no version rule -- is for a remote that does not implement
+  // negotiation at all, and the cached policy is the evidence of whether this one does.
+  it("keeps a cached restriction when a later response carries no policy", async () => {
     const { session, cache } = await freshSession(dir);
     cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
     session.initPolicySession(fakeServer() as never, () => {});
@@ -130,7 +130,62 @@ describe("decisionInForce", () => {
 
     session.recordPolicyFromResult({ tools: [] }, "tools/list");
 
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+  });
+
+  // ...and the remote can still lift it, by saying so rather than by going quiet.
+  it("lets an explicit re-enable lift a cached restriction", async () => {
+    const { session, cache } = await freshSession(dir);
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+
+    session.recordPolicyFromResult(
+      resultWith({ features: { metaTools: { enabled: true } } }),
+      "tools/list",
+    );
+
     expect(session.decisionInForce().features.metaTools).toBe(true);
+  });
+
+  it("takes the compatibility path when no policy was ever received", async () => {
+    const { session } = await freshSession(dir);
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    session.recordPolicyFromResult({ tools: [] }, "tools/list");
+
+    const d = session.decisionInForce();
+    expect(d.features.metaTools).toBe(true);
+    expect(d.versionState).toBe("unenforced");
+  });
+
+  // The regression this replaced a wrong assumption for: a remote that attaches policy to
+  // tools/list but not to tools/call is a plausible split, since a list is answered once
+  // while calls are the hot path. Reading omission as revocation made every call clear the
+  // policy and every following list restore it -- and each clear changed the surface, so
+  // the host re-fetched on every tool call and the advertised list visibly flickered.
+  it("does not flip-flop when the remote only attaches policy to tools/list", async () => {
+    const { session } = await freshSession(dir);
+    const server = fakeServer();
+    session.initPolicySession(server as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    const policy = { features: { metaTools: { enabled: false } } };
+    const seen: boolean[] = [];
+
+    for (const label of ["tools/list", "tools/call(search)", "tools/list", "tools/call(chat)"]) {
+      session.recordPolicyFromResult(
+        label === "tools/list" ? resultWith(policy) : { content: [] },
+        label,
+      );
+      seen.push(session.decisionInForce().features.metaTools);
+    }
+
+    expect(seen).toEqual([false, false, false, false]);
+    expect(server.sendToolListChanged).not.toHaveBeenCalled();
   });
 
   it("keeps the cached policy on disk when a response carries none", async () => {

--- a/tests/policy-session.test.ts
+++ b/tests/policy-session.test.ts
@@ -230,3 +230,53 @@ describe("tools/list_changed notification", () => {
     expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
   });
 });
+
+// The recommendation is computed on every exchange but has exactly one surface: the setup
+// tool's output. Without these, `showUpgrade` and the remote's upgrade text are values the
+// remote sets and no user ever sees -- which is what they were before this change.
+describe("policySummary", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-summary-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  async function summaryAfter(policy: unknown) {
+    const { session } = await freshSession(dir);
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+    session.recordPolicyFromResult(resultWith(policy), "tools/call(search)");
+    return session.policySummary().join("\n");
+  }
+
+  // Deliberately not asserting the upgrade or deactivation lines here. Both require
+  // versionState to be version-derived, and the build constant is absent under vitest, so
+  // pluginVersion() is {0.0.0, unknown} and no version rule ever fires through this
+  // module. Their inputs are covered where they ARE reachable: evaluate() carrying
+  // upgradeMessage (policy.test.ts) and the deactivation refusal consuming it
+  // (policy-enforce.test.ts). The remaining uncovered hop is this function's string
+  // assembly for those two branches.
+  it("reports the negotiated context and the resolved policy", async () => {
+    const summary = await summaryAfter({ features: { metaTools: { enabled: false } } });
+    expect(summary).toContain("Plugin version: 0.0.0 (source: unknown)");
+    expect(summary).toContain("Host: claude-code");
+    expect(summary).toContain("version unenforced");
+    expect(summary).toContain('"metaTools":false');
+  });
+
+  it("shows a session message as a notice", async () => {
+    const summary = await summaryAfter({ message: "Maintenance window at 2am UTC." });
+    expect(summary).toContain("Notice: Maintenance window at 2am UTC.");
+  });
+
+  it("says nothing about upgrades when the remote does not ask", async () => {
+    const summary = await summaryAfter({ features: { metaTools: { enabled: true } } });
+    expect(summary).not.toContain("Upgrade available");
+    expect(summary).not.toContain("Deactivated:");
+  });
+});

--- a/tests/policy-session.test.ts
+++ b/tests/policy-session.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CAPABILITY_POLICY_KEY } from "../src/policy/key.js";
+
+// session.ts holds module state, so every test gets a fresh module graph and its own
+// PLUGIN_DATA_DIR. cachePath() reads the env per call, so stubbing it is enough to
+// isolate the cache file.
+async function freshSession(dir: string) {
+  vi.resetModules();
+  vi.stubEnv("PLUGIN_DATA_DIR", dir);
+  const session = await import("../src/policy/session.js");
+  const cache = await import("../src/policy/cache.js");
+  return { session, cache };
+}
+
+const URL_A = "https://a-be.glean.com/mcp/gateway/proxy";
+
+interface FakeServer {
+  getClientVersion: () => { name: string; version: string };
+  getClientCapabilities: () => Record<string, unknown>;
+  sendToolListChanged: ReturnType<typeof vi.fn>;
+}
+
+function fakeServer(): FakeServer {
+  return {
+    getClientVersion: () => ({ name: "claude-code", version: "1.2.3" }),
+    getClientCapabilities: () => ({ elicitation: {} }),
+    sendToolListChanged: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function resultWith(policy: unknown) {
+  return { tools: [], _meta: { [CAPABILITY_POLICY_KEY]: policy } };
+}
+
+describe("decisionInForce", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-session-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("enables everything supported when there is no configured remote", async () => {
+    const { session } = await freshSession(dir);
+    session.initPolicySession(fakeServer() as never, () => {});
+
+    const d = session.decisionInForce();
+
+    expect(d.deactivated).toBe(false);
+    expect(d.versionState).toBe("unenforced");
+    expect(Object.values(d.features).every((v) => v === true)).toBe(true);
+  });
+
+  it("enables everything supported when the URL has no cached policy", async () => {
+    const { session } = await freshSession(dir);
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    expect(session.decisionInForce().features.metaTools).toBe(true);
+  });
+
+  // The fresh-process regression the design calls out by name: a cached metaTools:false,
+  // or a cached deactivation, must not be undone just because this process has not talked
+  // to the remote yet. tools/list returns before negotiating on three of its five paths.
+  it("applies a cached policy before any exchange happens", async () => {
+    const { session, cache } = await freshSession(dir);
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
+
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+  });
+
+  it("reads the cache once per process, not per call", async () => {
+    const { session, cache } = await freshSession(dir);
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+
+    // Rewrite the file behind its back. A memoized decision ignores it; a per-call read
+    // would pick it up.
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: true } } });
+
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+  });
+
+  it("logs that the decision came from cache, so the seam is visible", async () => {
+    const { session, cache } = await freshSession(dir);
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
+    const labels: string[] = [];
+    session.initPolicySession(fakeServer() as never, (l) => labels.push(l));
+    session.setPolicyServerUrl(URL_A);
+
+    session.decisionInForce();
+
+    expect(labels).toContain("policy.seeded-from-cache");
+  });
+
+  it("does not claim a cache seed when there was no cached policy", async () => {
+    const { session } = await freshSession(dir);
+    const labels: string[] = [];
+    session.initPolicySession(fakeServer() as never, (l) => labels.push(l));
+    session.setPolicyServerUrl(URL_A);
+
+    session.decisionInForce();
+
+    expect(labels).not.toContain("policy.seeded-from-cache");
+  });
+
+  // A live response replaces a seeded decision. The no-policy case in particular must
+  // clear a cached restriction rather than keep it, which is what separates "the remote
+  // answered and has no policy" from "the remote was unreachable".
+  it("lets a live no-policy response supersede a cached restriction", async () => {
+    const { session, cache } = await freshSession(dir);
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    expect(session.decisionInForce().features.metaTools).toBe(false);
+
+    session.recordPolicyFromResult({ tools: [] }, "tools/list");
+
+    expect(session.decisionInForce().features.metaTools).toBe(true);
+  });
+
+  it("keeps the cached policy on disk when a response carries none", async () => {
+    const { session, cache } = await freshSession(dir);
+    cache.savePolicy(URL_A, { features: { metaTools: { enabled: false } } });
+    session.initPolicySession(fakeServer() as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    session.recordPolicyFromResult({ tools: [] }, "tools/list");
+
+    expect(cache.loadCachedPolicy(URL_A)).toEqual({
+      features: { metaTools: { enabled: false } },
+    });
+  });
+});
+
+describe("tools/list_changed notification", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-notify-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  async function armed() {
+    const { session } = await freshSession(dir);
+    const server = fakeServer();
+    session.initPolicySession(server as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+    // Establish a first decision, which must not itself notify.
+    session.recordPolicyFromResult({ tools: [] }, "tools/call(search)");
+    return { session, server };
+  }
+
+  it("does not notify on the first decision of a process", async () => {
+    const { session } = await freshSession(dir);
+    const server = fakeServer();
+    session.initPolicySession(server as never, () => {});
+    session.setPolicyServerUrl(URL_A);
+
+    session.recordPolicyFromResult(
+      resultWith({ features: { metaTools: { enabled: false } } }),
+      "tools/call(run_tool)",
+    );
+
+    expect(server.sendToolListChanged).not.toHaveBeenCalled();
+  });
+
+  it("notifies when a tools/call response changes the reachable surface", async () => {
+    const { session, server } = await armed();
+
+    session.recordPolicyFromResult(
+      resultWith({ features: { metaTools: { enabled: false } } }),
+      "tools/call(search)",
+    );
+
+    expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
+  });
+
+  // The response to a tools/list IS the update -- the host asked and is about to receive
+  // the filtered surface. Notifying would make it ask again, and notify -> list ->
+  // resolve -> notify is a cycle.
+  it("never notifies from the tools/list path, even on a change", async () => {
+    const { session, server } = await armed();
+
+    session.recordPolicyFromResult(
+      resultWith({ features: { metaTools: { enabled: false } } }),
+      "tools/list",
+    );
+
+    expect(server.sendToolListChanged).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when only advisory fields differ", async () => {
+    const { session, server } = await armed();
+
+    // Same features and deactivated flag; only the message changes.
+    session.recordPolicyFromResult(
+      resultWith({ message: "a wholly different notice" }),
+      "tools/call(search)",
+    );
+
+    expect(server.sendToolListChanged).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when the same policy arrives twice", async () => {
+    const { session, server } = await armed();
+    const policy = { features: { metaTools: { enabled: false } } };
+
+    session.recordPolicyFromResult(resultWith(policy), "tools/call(search)");
+    session.recordPolicyFromResult(resultWith(policy), "tools/call(search)");
+
+    expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -10,7 +10,6 @@ import { loadCachedPolicy, savePolicy } from "../src/policy/cache.js";
 const allSupported = {
   toolPromotion: true,
   metaTools: true,
-  hitl: true,
   fileArgs: true,
 };
 
@@ -25,7 +24,6 @@ describe("feature gating", () => {
     expect(d.features).toEqual({
       toolPromotion: true,
       metaTools: true,
-      hitl: true,
       fileArgs: false,
     });
     expect(d.deactivated).toBe(false);
@@ -35,10 +33,10 @@ describe("feature gating", () => {
     const d = evaluate({
       pluginVersion: "1.0.0",
       versionSource: "build",
-      supportedFeatures: { ...allSupported, hitl: false },
-      policy: { features: { hitl: { enabled: true } } },
+      supportedFeatures: { ...allSupported, fileArgs: false },
+      policy: { features: { fileArgs: { enabled: true } } },
     });
-    expect(d.features.hitl).toBe(false);
+    expect(d.features.fileArgs).toBe(false);
   });
 
   it("treats an omitted feature as no opinion, not as disabled", () => {
@@ -161,7 +159,7 @@ describe("outcome classification", () => {
     const outcome = classifyResult({
       tools: [],
       _meta: {
-        [CAPABILITY_POLICY_KEY]: { features: { hitl: { enabled: false } } },
+        [CAPABILITY_POLICY_KEY]: { features: { metaTools: { enabled: false } } },
       },
     });
     expect(outcome.kind).toBe("policy");
@@ -228,12 +226,24 @@ describe("unknown-key reporting", () => {
         blockedVersions: [],
         upgradeRecommendation: { show: true, dailyCap: 1, weeklyCap: 3, message: "x" },
       },
-      features: { hitl: { enabled: false } },
+      features: { metaTools: { enabled: false } },
       message: "x",
     });
     expect(v.ok).toBe(true);
     if (!v.ok) return;
     expect(v.unknownKeys).toEqual([]);
+  });
+
+  // hitl is defined by the design contract but deliberately not declared by this build,
+  // because the stateless remote cannot take approval over yet. It therefore travels the
+  // same path as any feature a policy names ahead of the plugin: accepted so a newer
+  // remote is not called malformed, reported so the ignoring is greppable, and inert.
+  // If a later build declares hitl, this test is the one that should start failing.
+  it("treats hitl as an unknown feature, since this build does not declare it", () => {
+    const v = validatePolicy({ features: { hitl: { enabled: false } } });
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.unknownKeys).toEqual(["features.hitl"]);
   });
 });
 
@@ -251,14 +261,14 @@ describe("policy cache", () => {
   });
 
   it("keys by remote URL so switching instances cannot cross-contaminate", () => {
-    savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
-    savePolicy("https://b.glean.com", { features: { hitl: { enabled: true } } });
+    savePolicy("https://a.glean.com", { features: { metaTools: { enabled: false } } });
+    savePolicy("https://b.glean.com", { features: { metaTools: { enabled: true } } });
 
     expect(loadCachedPolicy("https://a.glean.com")).toEqual({
-      features: { hitl: { enabled: false } },
+      features: { metaTools: { enabled: false } },
     });
     expect(loadCachedPolicy("https://b.glean.com")).toEqual({
-      features: { hitl: { enabled: true } },
+      features: { metaTools: { enabled: true } },
     });
   });
 
@@ -275,11 +285,11 @@ describe("policy cache", () => {
   // Design: "A response without a policy object does not update or erase the
   // corresponding cache entry."
   it("keeps the cached policy when a later response carries none", () => {
-    savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
+    savePolicy("https://a.glean.com", { features: { metaTools: { enabled: false } } });
 
     // A no-policy round writes nothing, so the entry is untouched.
     expect(loadCachedPolicy("https://a.glean.com")).toEqual({
-      features: { hitl: { enabled: false } },
+      features: { metaTools: { enabled: false } },
     });
   });
 
@@ -288,7 +298,7 @@ describe("policy cache", () => {
   // which policy. Asserted against the file, since that is where a stray field
   // would actually appear.
   it("writes policy only, never a tools list", () => {
-    savePolicy("https://a.glean.com", { features: { hitl: { enabled: false } } });
+    savePolicy("https://a.glean.com", { features: { metaTools: { enabled: false } } });
 
     const onDisk = JSON.parse(
       fs.readFileSync(path.join(dir, "policy-cache.json"), "utf-8"),

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -140,6 +140,77 @@ describe("version gating", () => {
   });
 });
 
+// The remote's upgrade text has one job in two places: the soft recommendation and the
+// remedy in a deactivation refusal. It was accepted by validatePolicy and then dropped
+// before reaching the Decision, so a remote could write user-facing text into the field
+// the design designates for it and have it vanish.
+describe("upgrade text", () => {
+  it("is carried out with a soft recommendation", () => {
+    const d = evaluate({
+      pluginVersion: "1.0.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: {
+        plugin: {
+          latestVersion: "2.0.0",
+          upgradeRecommendation: { show: true, message: "2.0.0 adds Codex support." },
+        },
+      },
+    });
+    expect(d.showUpgrade).toBe(true);
+    expect(d.upgradeMessage).toBe("2.0.0 adds Codex support.");
+  });
+
+  it("is carried out when version policy deactivates the plugin", () => {
+    const d = evaluate({
+      pluginVersion: "0.1.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: {
+        plugin: {
+          minimumSupportedVersion: "1.0.0",
+          upgradeRecommendation: { message: "Upgrade to 1.x; 0.x is end of life." },
+        },
+      },
+    });
+    expect(d.deactivated).toBe(true);
+    expect(d.upgradeMessage).toBe("Upgrade to 1.x; 0.x is end of life.");
+  });
+
+  // Distinct fields answering distinct questions: `message` is about this session,
+  // `upgradeMessage` about the installed artifact. Conflating them would mean a
+  // maintenance notice could be shown as upgrade instructions.
+  it("stays separate from the session message", () => {
+    const d = evaluate({
+      pluginVersion: "1.0.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: {
+        message: "Maintenance window at 2am UTC.",
+        plugin: {
+          latestVersion: "2.0.0",
+          upgradeRecommendation: { show: true, message: "2.0.0 is out." },
+        },
+      },
+    });
+    expect(d.message).toBe("Maintenance window at 2am UTC.");
+    expect(d.upgradeMessage).toBe("2.0.0 is out.");
+  });
+
+  it("is absent when the remote sends no upgrade text", () => {
+    const d = evaluate({
+      pluginVersion: "1.0.0",
+      versionSource: "build",
+      supportedFeatures: allSupported,
+      policy: {
+        plugin: { latestVersion: "2.0.0", upgradeRecommendation: { show: true } },
+      },
+    });
+    expect(d.showUpgrade).toBe(true);
+    expect(d.upgradeMessage).toBeUndefined();
+  });
+});
+
 describe("no-policy compatibility path", () => {
   it("enables everything supported and applies no version rule", () => {
     const d = evaluate({

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -14,6 +14,12 @@ import {
   buildCompactArgs,
   formatArgumentsForFile,
 } from "../src/tools/approval-args.js";
+import type { RunToolPolicy } from "../src/tools/run-tool.js";
+
+// The decision every install resolves to today, since production returns no policy.
+// Passed explicitly at each call site rather than defaulted, so a case that means to
+// exercise a disabled feature has to say so.
+const ALL_ON: RunToolPolicy = { fileArgs: true };
 
 describe("resolveFileArgs", () => {
   let tmpDir: string;
@@ -323,7 +329,7 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: false });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(server.elicitInput).not.toHaveBeenCalled();
     expect(remote.callTool).toHaveBeenCalledTimes(1);
@@ -335,7 +341,7 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(server.elicitInput).not.toHaveBeenCalled();
     expect(remote.callTool).toHaveBeenCalledTimes(1);
@@ -352,7 +358,7 @@ describe("handleRunTool (HITL)", () => {
     });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     // Cursor is no longer excluded: it gets readOnlyHint like every other
     // elicitation-capable host, so this prompt is the only approval gate.
@@ -377,7 +383,7 @@ describe("handleRunTool (HITL)", () => {
     await handleRunTool(remote, server, tmpDir, {
       ...baseArgs,
       arguments: { project: "ENG", summary: "ship it" },
-    });
+    }, ALL_ON);
 
     const message = elicit.mock.calls[0][0].message as string;
     expect(message).toContain("Action: jirasearch");
@@ -396,7 +402,7 @@ describe("handleRunTool (HITL)", () => {
     await handleRunTool(remote, server, tmpDir, {
       ...baseArgs,
       arguments: { project: "ENG" },
-    });
+    }, ALL_ON);
 
     const message = elicit.mock.calls[0][0].message as string;
     expect(message).toContain("Action: jirasearch");
@@ -424,7 +430,7 @@ describe("handleRunTool (HITL)", () => {
     });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
     const text = (result.content[0] as { text: string }).text;
 
     expect(result.isError).toBe(true);
@@ -453,7 +459,7 @@ describe("handleRunTool (HITL)", () => {
     });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
     const text = (result.content[0] as { text: string }).text;
 
     expect(text).toContain("cannot tell which");
@@ -484,7 +490,7 @@ describe("handleRunTool (HITL)", () => {
     });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
     const text = (result.content[0] as { text: string }).text;
 
     expect(result.isError).toBe(true);
@@ -506,10 +512,70 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true, elicit });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect((result.content[0] as { text: string }).text).not.toContain("3.15");
     expect(remote.callTool).not.toHaveBeenCalled();
+  });
+
+  // fileArgs disabled by remote policy. The refusal lives here rather than at the call
+  // funnel because resolveFileArgs reads model-supplied absolute paths off the user's
+  // disk: an inert feature has to mean the read does not happen.
+  it("rejects file_args when policy disables the feature", async () => {
+    vi.stubEnv("ENABLE_HITL", "false");
+    const remote = makeRemote();
+    const server = makeServer({ elicitation: false });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
+
+    const result = await handleRunTool(
+      remote,
+      server,
+      tmpDir,
+      { ...baseArgs, file_args: { body: "/tmp/whatever.md" } },
+      { fileArgs: false },
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain(
+      "`file_args` is disabled",
+    );
+    expect(remote.callTool).not.toHaveBeenCalled();
+  });
+
+  // Proves the refusal short-circuits BEFORE any disk access: the path does not exist,
+  // so a guard placed after resolveFileArgs would surface a "cannot read" FileArgsError
+  // instead. That difference is the whole point of where the check sits.
+  it("rejects without touching the filesystem", async () => {
+    vi.stubEnv("ENABLE_HITL", "false");
+    const remote = makeRemote();
+    const server = makeServer({ elicitation: false });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
+
+    const result = await handleRunTool(
+      remote,
+      server,
+      tmpDir,
+      { ...baseArgs, file_args: { body: path.join(tmpDir, "does-not-exist.md") } },
+      { fileArgs: false },
+    );
+
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("`file_args` is disabled");
+    expect(text).not.toContain("cannot read");
+  });
+
+  it("runs normally when policy disables file_args but the call passes none", async () => {
+    vi.stubEnv("ENABLE_HITL", "false");
+    const remote = makeRemote();
+    const server = makeServer({ elicitation: false });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
+
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, {
+      fileArgs: false,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
   it("treats a spec-compliant cancel as a cancel, not a failure", async () => {
@@ -523,7 +589,7 @@ describe("handleRunTool (HITL)", () => {
     });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
     const text = (result.content[0] as { text: string }).text;
 
     expect(text).toContain("cancelled by the user");
@@ -542,7 +608,7 @@ describe("handleRunTool (HITL)", () => {
       description: "Search Jira issues",
     });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     const [params, options] = elicit.mock.calls[0];
     expect(params.message).toContain("Action: jirasearch");
@@ -565,8 +631,8 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true, elicit, request });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     // Ping fired exactly once for this server, and it is a ping.
     expect(request).toHaveBeenCalledTimes(1);
@@ -582,7 +648,7 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true, request });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: false });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(request).not.toHaveBeenCalled();
   });
@@ -595,7 +661,7 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true, elicit });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(elicit.mock.calls[0][1].timeout).toBe(5000);
   });
@@ -610,7 +676,7 @@ describe("handleRunTool (HITL)", () => {
       const elicit = vi.fn().mockResolvedValue({ action: "accept" });
       const server = makeServer({ elicitation: true, elicit });
 
-      await handleRunTool(remote, server, tmpDir, baseArgs);
+      await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
       expect(elicit.mock.calls[0][1].timeout).toBe(300_000);
     }
@@ -623,7 +689,7 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true, elicit });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(remote.callTool).not.toHaveBeenCalled();
     expect((result.content[0] as { text: string }).text).toContain("declined");
@@ -636,7 +702,7 @@ describe("handleRunTool (HITL)", () => {
     const server = makeServer({ elicitation: true, elicit });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
-    const result = await handleRunTool(remote, server, tmpDir, baseArgs);
+    const result = await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(remote.callTool).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
@@ -657,7 +723,7 @@ describe("handleRunTool (HITL)", () => {
       server_id: "s",
       tool_name: "create_doc",
       arguments: { title: "Report", body: bigBody },
-    });
+    }, ALL_ON);
 
     const message = elicit.mock.calls[0][0].message as string;
     expect(message).toContain("Action: create_doc");
@@ -690,7 +756,7 @@ describe("handleRunTool (HITL)", () => {
       tool_name: "create_doc",
       arguments: { title: "Doc" },
       file_args: { body: bodyFile },
-    });
+    }, ALL_ON);
 
     const message = elicit.mock.calls[0][0].message as string;
     expect(message).toContain("TITLE: Doc");
@@ -714,7 +780,7 @@ describe("handleRunTool (HITL)", () => {
       tool_name: "save_agent",
       arguments: {},
       file_args: { spec: specFile },
-    });
+    }, ALL_ON);
 
     const call = remote.callTool.mock.calls[0][0];
     expect(call.name).toBe("run_tool");
@@ -736,7 +802,7 @@ describe("handleRunTool (HITL)", () => {
       tool_name: "create_doc",
       arguments: {},
       file_args: { body: "/no/such/abs/path.md" },
-    });
+    }, ALL_ON);
 
     expect(result.isError).toBe(true);
     expect(elicit).not.toHaveBeenCalled(); // no prompt for unreadable input
@@ -753,7 +819,7 @@ describe("handleRunTool (HITL)", () => {
     const elicit = vi.fn().mockResolvedValue({ action: "accept" });
     const server = makeServer({ elicitation: true, elicit });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(elicit).not.toHaveBeenCalled();
     expect(remote.callTool).toHaveBeenCalledTimes(1);
@@ -769,7 +835,7 @@ describe("handleRunTool (HITL)", () => {
     const elicit = vi.fn().mockResolvedValue({ action: "accept" });
     const server = makeServer({ elicitation: true, elicit });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(elicit).toHaveBeenCalledTimes(1);
     expect(remote.callTool).toHaveBeenCalledTimes(1);
@@ -785,7 +851,7 @@ describe("handleRunTool (HITL)", () => {
     const elicit = vi.fn().mockResolvedValue({ action: "accept" });
     const server = makeServer({ elicitation: true, elicit });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(elicit).toHaveBeenCalledTimes(1);
   });
@@ -801,7 +867,7 @@ describe("handleRunTool (HITL)", () => {
     const elicit = vi.fn().mockResolvedValue({ action: "accept" });
     const server = makeServer({ elicitation: true, elicit });
 
-    await handleRunTool(remote, server, tmpDir, baseArgs);
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
     expect(elicit).toHaveBeenCalledTimes(1); // gate preserved for THIS session
   });


### PR DESCRIPTION
## What

Makes the negotiated policy actually gate behaviour. #49/#50 got the plugin as far as reporting context, recording the policy, and computing a `Decision` — which nothing read: `currentDecision()` was exported and imported by nobody. A remote could express a policy and the plugin would faithfully log and cache it while ignoring it.

| Policy | Advertisement | Call time |
|---|---|---|
| `deactivated` (below minimum, or exact-match blocked) | `setup` only | refuse all but `setup` |
| `metaTools: false` | drop `find_skills` + `run_tool` | refuse both by name |
| `toolPromotion: false` | promote none of the allow-list | refuse any allow-listed name |
| `fileArgs: false` | splice `file_args` out of the schema | reject a call that still passes it |

**Production returns no policy today, so the intended effect for every existing user is that nothing changes.** That's the main risk, and it's pinned by a deep-equal test on the advertised list plus an end-to-end run (below).

## Advertisement is not the gate

Withdrawing a tool from `tools/list` is advisory: a host may re-fetch late or never, and a model can call a tool still sitting in its context from an earlier list. So every gated tool is *also* refused at call time. `toolPromotion` is the clearest case — a promoted tool would otherwise keep working indefinitely after being withdrawn.

The refusal sits at the very top of the call handler, above the `REMOTE_TOOLS_ALLOWLIST` branch, because that's the only point covering all three lanes (promoted passthrough, `find_skills`, `run_tool` each have their own entry below it).

## Two decisions worth reviewing

**`hitl` is no longer declared.** It's dropped from `FEATURE_NAMES`, so `supportedFeatures` stops claiming it and the remote learns from the handshake that it isn't controllable here.

Disabling local HITL only makes sense once approval moves to the remote, and it can't yet: the remote is **stateless**, so it has no back-channel to send `elicitation/create` on. URL-mode elicitation and `notifications/elicitation/complete` (both already in the SDK) remove the need to hold a request open across the approval window, but they're still server→client — no help to a server that cannot initiate at all. That waits on `2026-07-28` server-side.

Until then, a remote-disabled HITL would leave **no gate at all** — and under Claude Code it'd be worse than having no policy, because the plugin's PreToolUse hook auto-approves `run_tool` on the premise that the local prompt *is* the gate. A remote needing to stop such a plugin deactivates the version instead.

The design keeps `hitl` as contract for a later plugin. `supportedFeatures` is a per-build declaration, and the two are meant to differ. A remote that sends `features.hitl` takes the ordinary forward-compat path — accepted, reported as unrecognized, inert — and the same policy starts applying once a build declares it. ([design update](https://github.com/askscio/scio/pull/273428))

**An omitted policy is silence, not revocation.** A response carrying no policy object used to clear the decision back to "everything enabled, no version rule". That's right for a remote that doesn't implement negotiation and wrong for one that does but didn't attach policy to *this* response — and policy rides every request, so a remote may reasonably attach it to `tools/list` but not `tools/call` (a list is answered once; calls are the hot path).

Measured against the old behaviour, `metaTools` went `false, true, false, true` across four exchanges, and because each clear changes the reachable surface it also emitted `tools/list_changed` per call — so the host would re-fetch on every tool call and the advertised surface would visibly flicker. N tool calls, N extra round-trips.

No-policy now retains a cached policy and falls back to the compatibility path only when this remote has *never* sent one, which is that path's actual condition. The cost is that a remote lifts a restriction with an explicit `enabled: true` rather than by going quiet — better for a control plane, and consistent with the unreachable and malformed paths, which already retain the cache. [Design amended](https://github.com/askscio/scio/pull/273428) to match.

**A cached policy is applied before any exchange.** `tools/list` doesn't always reach the remote — the `unconfigured` / `unauthenticated` / `connect-error` paths return first — so a fresh process would have no decision. Treating that as "no policy, everything on" would mean a cached deactivation was silently undone by every process start, which the design forbids explicitly. `decisionInForce()` therefore seeds from `loadCachedPolicy` once per process and memoizes. Never per gated call: `_meta` rides every remote request, so a process that reaches the remote refreshes constantly.

## Also in here

- **The remote's upgrade text now reaches the user.** `upgradeRecommendation.message` was accepted by `validatePolicy` but absent from the `UpgradeRecommendation` type and never carried into the `Decision` — so a remote could write user-facing text into the field the design designates for it and see nothing. `showUpgrade` was likewise computed on every exchange and displayed nowhere. Both now surface in `setup` output, and the upgrade text doubles as the remedy in a deactivation refusal (the design assigns it that second job). `latestVersion` is deliberately *not* carried: the remote owns the wording and can name a version itself.
- **`tools/list_changed`** is wired to the previously-unused `changed` flag, but only from the `tools/call` path and only once a previous decision exists. A `tools/list` response *is* the update, so notifying there makes `notify → list → resolve → notify` a cycle; and `!previous` counts as changed, so without that guard every process's first call would notify and cost a round-trip for every user in a no-policy world.
- **`setup`'s closing line is derived from the decision**, since naming `find_skills` and `run_tool` unconditionally is wrong once policy withholds them and misleading when only `setup` works.

## Testing

`280 passed`. Enforcement lives in `src/policy/enforce.ts` as pure functions rather than inline in `index.ts`, which calls `main()` at module load and has zero handler coverage — so every rule is unit-testable without an MCP server.

Three tests were confirmed by mutation rather than assumed: a `delete`-based `withoutFileArgs` fails the two no-mutation tests, and removing the `tools/list` notification guard fails exactly the test that names it.

**Verified end to end against the built bundle**, driving it over stdio against a fake remote serving real policies:

| Scenario | Advertised | `file_args` | `search` called directly | `find_skills` called directly |
|---|---|---|---|---|
| `no-policy` | full surface | `true` | EXECUTED | — |
| `promotion-off` | `find_skills, run_tool, setup` | `true` | **refused by policy** | — |
| `metatools-off` | `setup, search, chat` | n/a | EXECUTED | **refused by policy** |
| `below-minimum` | `setup` | n/a | **refused by policy** | **refused by policy** |
| `fileargs-off` | full surface | **removed from schema** | — | — |
| `malformed` | full surface | `true` | — | — |

`fileargs-off` was checked in more detail, since it is the only gate that alters a schema rather than a tool list: the advertised `run_tool` properties come back as `arguments, server_id, tool_name`, the tool-level description contains no `file_args` reference to contradict that, a call passing `file_args` anyway is refused, and one passing none still executes. The refused call used a path that does not exist — a guard placed after `resolveFileArgs` would have surfaced "cannot read" instead of the policy message, so this confirms the check short-circuits before any disk access.

`promotion-off` and `metatools-off` are proper mirrors, which is what shows the gates act per-feature rather than as a blanket. Refusals were confirmed from `policy.refused` log lines, not from the probe's exit status — the fake remote doesn't execute `find_skills`, so its error is indistinguishable from a refusal at the wire level. `no-policy` produced **zero** `policy.refused` lines and wrote no cache file.

`malformed` is the fail-open row: a policy that fails validation must never be able to deactivate a working plugin. The surface comes back complete, `file_args` intact, and the rejection is visible as `policy.malformed` with the specific reason (`plugin.latestVersion must be a string`) rather than being silently swallowed.

**A cached policy survives a restart with the remote unreachable.** A deactivating policy was seeded into `policy-cache.json`, then the plugin started with nothing listening on the configured URL:

```
policy.seeded-from-cache {"versionState":"below-minimum","deactivated":true,…}
tools-list.served {"static":1,"dynamic":0,"withheld":["find_skills","run_tool"],
                   "deactivated":true,"state":"connect-error"}
```

`setup` only, on the `connect-error` path — one of the three that return before any negotiation. Calls to `search` and `find_skills` are both refused with `[POLICY_DEACTIVATED]`, carrying the remote's own upgrade text as the remedy. `setup` itself is *not* refused: it fails on the network instead, which is the correct distinction, since it's checked ahead of the deactivation gate and is the only way the deactivation gets lifted.

**The flip-flop is reproduced and fixed.** The fake remote gained a `LIST_ONLY=1` mode that attaches policy to `tools/list` but not `tools/call`, which is the split that made omission-as-revocation flicker. Driving one process through list → call → list → call → list:

```
1. ADVERTISED: ["setup","search","chat"]
2. CALL search:      executed
3. ADVERTISED: ["setup","search","chat"]
4. CALL find_skills: refused by policy
5. ADVERTISED: ["setup","search","chat"]
tools/list_changed notifications: 0
```

Step 2's response carried **no** policy, and step 4 still refused — under the old reading, step 2 would have cleared the cached `metaTools: false` and step 4 would have executed. The log shows the mechanism directly: `policy.absent-kept-cache` on the call, then `outcome: no-policy` resolving to `metaTools: false` regardless. The advertised list is byte-identical across all three lists and no notification fires, so the flicker is gone too.

**Verified live in Cursor against production**, on the build in this PR:

```
policy.resolved {"label":"tools/list","outcome":"no-policy","versionState":"unenforced",
  "deactivated":false,"features":{"toolPromotion":true,"metaTools":true,"fileArgs":true}}
tools-list.served {"static":3,"dynamic":7,"withheld":[],"state":"fetched"}
policy.resolved {"label":"tools/call(find_skills)",…}
policy.resolved {"label":"tools/call(run_tool)",…}
```

Two processes, both clean, across `tools/list`, `find_skills` and `run_tool` — every `_meta`-carrying path. `features` shows exactly three keys, confirming the `hitl` removal propagates to a real install. Zero `policy.refused`, and no `policy-cache.json` written.

Worth being precise about what that run does and doesn't prove, since production sends no policy. Two absences are real evidence: nothing was refused on the path every current user is on, and no `backend-error`/`fetch-failed` means the added `_meta` doesn't disturb the real gateway. The other absences are vacuous there by construction — `seeded-from-cache` can't fire with no cache, `caps-not-enforced` can't fire with no caps sent, and `surface-changed` can't fire when the decision never changes. Those are covered by the scenarios above and by `tests/policy-session.test.ts`; the flip-flop in particular could never have surfaced against production.

**The POC had drifted the other way, which is the strongest evidence for this change.** Preserving the scenarios above into the POC surfaced that its `negotiate()` still cleared the resolved policy to `undefined` on `no-policy`, so a cached restriction was dropped by any policy-less `tools/list`. The new scenario fails against that behaviour with `find_skills` coming back advertised **and executing** — so it was an enforcement hole, not just the surface flicker measured earlier. Its `malformed` and `unreachable` branches already retained the cache; `no-policy` was the odd one out, and the POC's unit tests cover the pure classifier rather than `negotiate()`, so nothing caught it. Fixed in [gleanwork/glean-plugin-policy-poc@27f0407](https://github.com/gleanwork/glean-plugin-policy-poc/commit/27f0407), which also adds `scripts/drive-stateful.mjs` for the two rules a clean-process-per-fixture driver structurally cannot reach.

That the design doc, this PR, and the POC each needed the same correction separately is the argument for the retain-the-cache rule being non-obvious enough to be worth the comment it now carries in all three.

Still unit-only, for the record: the `surface-changed` notification actually firing (needs a remote that changes fixtures mid-process), `caps-not-enforced`, and `blocked-version` as distinct from `below-minimum` — the same code path with a different `versionState`.

## Not in here

`dailyCap`/`weeklyCap` frequency capping stays deferred per the design — the remote is told to send them for forward compatibility and only `show` needs honouring in v0. They remain *tolerated* rather than rejected, deliberately: unlike `hitl` there is no false promise to withdraw, since declaring a feature in `supportedFeatures` claims the remote can control it whereas listing a field in `KNOWN_UPGRADE` only says we won't call the policy malformed for including it. Rejecting them would instead give a design-following remote `policy.unknown-keys` noise and force every policy to be revisited once capping lands.

What that did leave wrong is that the non-enforcement was invisible — a remote setting `dailyCap: 1` sees the recommendation on every `setup` and had no way to learn why. It's now logged as `policy.caps-not-enforced`, once per process and only when a remote actually sets one. Capping also has nothing to cap yet: `setup` is the only surface and is user-initiated, so rate-limiting the answer to a question the user just asked would be wrong. Remote-driven elicitation and the `hitl` gate wait on `2026-07-28`.

One test hop is knowingly uncovered: `policySummary()`'s string assembly for the upgrade and deactivated lines. Both need `versionState` to be version-derived, and the build constant is absent under vitest, so no version rule can fire through `session.ts`. The inputs are covered where they are reachable, and there's a comment in the test file saying why the middle is skipped rather than a test that pretends to exercise it.


