### PR TITLE
Notify the host when setup learns a surface-changing policy

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25128,7 +25128,7 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/version.ts
-var BUILD_VERSION = true ? "0.2.49" : void 0;
+var BUILD_VERSION = true ? "0.2.50" : void 0;
 function pluginVersion() {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
   return { version: "0.0.0", source: "unknown" };
@@ -25708,7 +25708,7 @@ function reportInventoryGap(inventory2) {
 function negotiationMeta() {
   return metaFor(negotiationRequest());
 }
-function recordPolicyFromResult(result, label) {
+function recordPolicyFromResult(result, label, { hostReceivingList = false } = {}) {
   const serverUrl = cacheKeyUrl;
   if (!serverUrl) return;
   const outcome = classifyResult(result);
@@ -25756,7 +25756,7 @@ function recordPolicyFromResult(result, label) {
       reasons: next.reasons
     });
   }
-  if (changed && previous && label !== TOOLS_LIST_LABEL) {
+  if (changed && previous && !hostReceivingList) {
     logLine("policy.surface-changed", {
       label,
       from: { deactivated: previous.deactivated, features: previous.features },
@@ -26938,7 +26938,7 @@ function augmentSchemaForLocal(schema) {
     required: required2
   };
 }
-async function fetchAllowedRemoteTools(remoteClient) {
+async function fetchAllowedRemoteTools(remoteClient, { hostReceivingList = false } = {}) {
   const collected = [];
   let cursor;
   do {
@@ -26946,7 +26946,7 @@ async function fetchAllowedRemoteTools(remoteClient) {
       ...cursor ? { cursor } : {},
       ...negotiationMeta()
     });
-    recordPolicyFromResult(page, TOOLS_LIST_LABEL);
+    recordPolicyFromResult(page, TOOLS_LIST_LABEL, { hostReceivingList });
     for (const tool of page.tools) {
       if (!REMOTE_TOOLS_ALLOWLIST.has(tool.name)) continue;
       collected.push({
@@ -27263,7 +27263,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     return serve("connect-error", cachedRemoteTools);
   }
   try {
-    const remoteTools = await fetchAllowedRemoteTools(remoteClient);
+    const remoteTools = await fetchAllowedRemoteTools(remoteClient, {
+      hostReceivingList: true
+    });
     cachedRemoteTools = remoteTools;
     saveRemoteTools(serverUrl, remoteTools);
     return serve("fetched", remoteTools);

--- a/src/index.ts
+++ b/src/index.ts
@@ -384,7 +384,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   }
 
   try {
-    const remoteTools = await fetchAllowedRemoteTools(remoteClient);
+    // The host asked for this list and is about to receive it, so any policy learned here
+    // needs no notification -- this response IS the update.
+    const remoteTools = await fetchAllowedRemoteTools(remoteClient, {
+      hostReceivingList: true,
+    });
     cachedRemoteTools = remoteTools;
     saveRemoteTools(serverUrl, remoteTools);
     return serve("fetched", remoteTools);

--- a/src/policy/session.ts
+++ b/src/policy/session.ts
@@ -38,9 +38,10 @@ let cacheKeyUrl: string | undefined;
 
 export const protocolVersion = new ProtocolVersionObserver();
 
-// The label recordPolicyFromResult receives for a tools/list exchange. Exported so the
-// caller and the notification guard cannot drift apart on a string literal — the guard
-// depends on distinguishing that path from tools/call.
+// The label recordPolicyFromResult receives for a tools/list exchange, shared by the
+// tools/list handler and by setup's own catalog fetch. Exported so both spell it the same
+// way in the log. The notification guard deliberately does NOT key off it -- see
+// RecordPolicyOptions.hostReceivingList, which is what distinguishes those two callers.
 export const TOOLS_LIST_LABEL = "tools/list";
 
 export function initPolicySession(server: Server, log: LogFn): void {
@@ -108,6 +109,19 @@ export function negotiationMeta(): { _meta: Record<string, unknown> } {
   return metaFor(negotiationRequest());
 }
 
+export interface RecordPolicyOptions {
+  /**
+   * True only when the host requested this tool list and is about to receive the surface
+   * this decision produces. It suppresses the re-fetch notification, because the response
+   * itself is the update.
+   *
+   * An explicit flag rather than a label check: `setup` fetches the catalog through the
+   * same helper and carries the same label, but the host is receiving setup's text, so it
+   * does need telling.
+   */
+  hostReceivingList?: boolean;
+}
+
 /**
  * Record the policy carried on a remote response, if any.
  *
@@ -137,7 +151,11 @@ export function negotiationMeta(): { _meta: Record<string, unknown> } {
  * clearing-by-silence is exactly what makes the flicker possible -- and it makes this
  * agree with the unreachable path, which already retains the cached policy.
  */
-export function recordPolicyFromResult(result: unknown, label: string): void {
+export function recordPolicyFromResult(
+  result: unknown,
+  label: string,
+  { hostReceivingList = false }: RecordPolicyOptions = {},
+): void {
   // No configured remote yet means nothing to key the cache by, and no exchange to
   // record. Silent no-op rather than an error: this runs on every remote call.
   const serverUrl = cacheKeyUrl;
@@ -210,20 +228,25 @@ export function recordPolicyFromResult(result: unknown, label: string): void {
     });
   }
 
-  // Tell the host to re-fetch, but only from the tools/call path and only once a
-  // previous decision existed.
+  // Tell the host to re-fetch when the reachable surface changed under it.
   //
-  // Not from tools/list: there the response IS the update -- the host has just asked and
-  // is about to receive the freshly filtered surface, so a notification would only make
-  // it ask again for what it already holds, and notify -> tools/list -> resolve ->
-  // notify would be a cycle. A policy arriving on a tools/call response is the case that
-  // needs this, because the surface changed and the host has no reason to re-fetch.
+  // Suppressed for exactly one case: the host asked for the list and is about to receive
+  // the freshly filtered surface, so a notification would make it ask again for what it
+  // already holds, and notify -> tools/list -> resolve -> notify would be a cycle. That
+  // is what `hostReceivingList` means, and it is passed by the tools/list handler alone.
+  //
+  // It deliberately is NOT inferred from the label. `setup` fetches the remote catalog
+  // through the same helper and therefore carries the same `tools/list` label, but the
+  // host is receiving setup's text, not a tool list -- so a policy that changes the
+  // surface during setup used to leave the host holding a stale list with nothing to
+  // prompt a refresh. Observed against a real remote: setup learned `toolPromotion: true`
+  // and the promoted tools stayed invisible until the next unrelated list.
   //
   // Not on the first decision either: `!previous` counts as changed, so without that
   // guard every process's first gated call would notify, costing a host tools/list and a
   // remote round-trip for every user in a world where no policy exists. The stale-list
   // window on a first call is closed by the refusal, which is the real gate anyway.
-  if (changed && previous && label !== TOOLS_LIST_LABEL) {
+  if (changed && previous && !hostReceivingList) {
     logLine("policy.surface-changed", {
       label,
       from: { deactivated: previous.deactivated, features: previous.features },

--- a/src/tools/remote-passthrough.ts
+++ b/src/tools/remote-passthrough.ts
@@ -57,9 +57,14 @@ export function augmentSchemaForLocal(schema: unknown): ToolInputSchema {
  * each surviving tool with its input schema augmented for local exposure.
  *
  * Walks pagination cursors to exhaustion in case the remote ever paginates.
+ *
+ * `hostReceivingList` must be true only when the caller is answering a host `tools/list`.
+ * Setup calls this too, and there the host is receiving setup's text rather than a tool
+ * list, so a surface-changing policy learned here has to notify.
  */
 export async function fetchAllowedRemoteTools(
   remoteClient: Client,
+  { hostReceivingList = false }: { hostReceivingList?: boolean } = {},
 ): Promise<Tool[]> {
   const collected: Tool[] = [];
   let cursor: string | undefined;
@@ -70,7 +75,7 @@ export async function fetchAllowedRemoteTools(
       ...(cursor ? { cursor } : {}),
       ...negotiationMeta(),
     });
-    recordPolicyFromResult(page, TOOLS_LIST_LABEL);
+    recordPolicyFromResult(page, TOOLS_LIST_LABEL, { hostReceivingList });
     for (const tool of page.tools) {
       if (!REMOTE_TOOLS_ALLOWLIST.has(tool.name)) continue;
       collected.push({

--- a/tests/policy-session.test.ts
+++ b/tests/policy-session.test.ts
@@ -214,9 +214,14 @@ describe("decisionInForce", () => {
     const seen: boolean[] = [];
 
     for (const label of ["tools/list", "tools/call(search)", "tools/list", "tools/call(chat)"]) {
+      const isList = label === "tools/list";
       session.recordPolicyFromResult(
-        label === "tools/list" ? resultWith(policy) : { content: [] },
+        isList ? resultWith(policy) : { content: [] },
         label,
+        // Mirrors the real handlers: a host-requested list suppresses the notification,
+        // a tool call does not. Without this the test would exercise a combination that
+        // never occurs in production.
+        isList ? { hostReceivingList: true } : undefined,
       );
       seen.push(session.decisionInForce().features.metaTools);
     }
@@ -289,7 +294,28 @@ describe("tools/list_changed notification", () => {
   // The response to a tools/list IS the update -- the host asked and is about to receive
   // the filtered surface. Notifying would make it ask again, and notify -> list ->
   // resolve -> notify is a cycle.
-  it("never notifies from the tools/list path, even on a change", async () => {
+  // The suppression is about whether the HOST is receiving the surface, not about which
+  // remote method produced it. When it asked for the list, the response is the update, and
+  // notifying would make it ask again -- notify -> list -> resolve -> notify is a cycle.
+  it("does not notify when the host is receiving the list it asked for", async () => {
+    const { session, server } = await armed();
+
+    session.recordPolicyFromResult(
+      resultWith({ features: { metaTools: { enabled: false } } }),
+      "tools/list",
+      { hostReceivingList: true },
+    );
+
+    expect(server.sendToolListChanged).not.toHaveBeenCalled();
+  });
+
+  // The regression this replaced a label check for. `setup` fetches the remote catalog
+  // through the same helper, so it carries the same "tools/list" label -- but the host is
+  // receiving setup's text, not a tool list. Keying suppression off the label therefore
+  // left the host holding a stale list with nothing to prompt a refresh. Observed against
+  // a real remote: setup learned toolPromotion: true and the promoted tools stayed
+  // invisible until some later unrelated list.
+  it("notifies when setup learns a surface change, despite the tools/list label", async () => {
     const { session, server } = await armed();
 
     session.recordPolicyFromResult(
@@ -297,7 +323,7 @@ describe("tools/list_changed notification", () => {
       "tools/list",
     );
 
-    expect(server.sendToolListChanged).not.toHaveBeenCalled();
+    expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
   });
 
   it("does not notify when only advisory fields differ", async () => {


### PR DESCRIPTION
## What

The `tools/list_changed` notification was suppressed whenever the label said `tools/list`. The reasoning was sound — there the response **is** the update, so notifying would only make the host ask again, and `notify → list → resolve → notify` is a cycle — but **the label does not identify that case**.

`setup` fetches the remote catalog through the same `fetchAllowedRemoteTools` helper, so it records policy under the same label, while the host is receiving setup's *text*, not a tool list. A policy that changed the reachable surface during setup therefore left the host holding a stale list with nothing to prompt a refresh.

## Found against a real server, not by reading code

An experimental QE pod flipped `toolPromotion` from `false` to `true` mid-session. `setup` picked the new policy up — the plugin would have executed the promoted tools — but they stayed invisible to the host until a later unrelated `tools/list`:

```
12:01:24  client.capabilities                       ← setup running
12:01:25  policy.resolved  features{toolPromotion:true, …}
          (no policy.surface-changed, no notification)
```

Enforcement was never wrong: the call-time gate is the real one, and it tracked the new policy immediately. What was wrong is the advertised surface going stale by a route the design never contemplated. In the *disabling* direction it degrades to withdrawn-but-still-advertised tools, which the design explicitly tolerates because they are refused on call — so this is the documented acceptable state reached by an undocumented path, rather than a safety hole.

## The fix

An explicit `hostReceivingList` flag instead of inferring intent from a string:

| Caller | Flag | Notifies? |
|---|---|---|
| `tools/list` handler | `true` | no — the host is receiving this surface right now |
| `setup` | default `false` | **yes** — the host is receiving text |
| every `tools/call` | default `false` | yes, unchanged |

Defaulting to *notify* is the safe direction: suppression is the narrow special case, so a new call site has to opt into silence rather than inherit it by accident.

## Tests

`281 passed`. The test that encoded the old rule — *"never notifies from the tools/list path, even on a change"* — is replaced by the two halves of the corrected one: a host-requested list stays silent, and the same label **without** the flag notifies. Mutation-verified by restoring the label check, which fails exactly the second test and nothing else.

The flip-flop test also now passes the flag on its list iterations. It previously exercised a combination that cannot occur in production — a list response with no suppression — and so would have kept passing whichever way this went.

## Notes for review

Branched off `main`, so it does not depend on #53. Both touch `session.ts` in different regions, so whichever merges second may want a trivial rebase.

One related defect found in the same session is **not** fixed here, to keep this reviewable: `policy.resolved` is logged on the same `surfaceKey` predicate that drives the notification, so an **advisory-only** policy change (new `latestVersion`, `upgradeRecommendation`, or `message`, with features untouched) logs nothing but `policy.unknown-keys`. Same root cause — one signal answering two questions — but it is an observability gap rather than a behavioural one, and it wants its own change plus a test that an advisory-only change logs while staying silent on the wire.
