### PR TITLE
Print one authoritative tool list in setup, not two that disagree

### DIFF
--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -25128,7 +25128,7 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/version.ts
-var BUILD_VERSION = true ? "0.2.48" : void 0;
+var BUILD_VERSION = true ? "0.2.49" : void 0;
 function pluginVersion() {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
   return { version: "0.0.0", source: "unknown" };
@@ -26449,6 +26449,20 @@ This version of the Glean plugin is not supported by your Glean instance, so onl
   return void 0;
 }
 var FILE_ARGS_DISABLED_TEXT = "`file_args` is disabled for your Glean instance by remote policy, so no file was read and the tool was not executed. Retry `run_tool` with the values inline in `arguments` instead.";
+function setupClosingLine(input) {
+  const { decision: decision2, promoted } = input;
+  if (decision2.deactivated) {
+    return `This plugin version is not supported by your Glean instance, so only \`${SETUP_TOOL_NAME}\` is available. Upgrade the Glean plugin to restore the rest.`;
+  }
+  const usable = [
+    ...decision2.features.metaTools ? [...META_TOOL_NAMES] : [],
+    ...decision2.features.toolPromotion ? promoted : []
+  ];
+  if (usable.length === 0) {
+    return `Remote policy has disabled the tools this plugin provides, so only \`${SETUP_TOOL_NAME}\` is available.`;
+  }
+  return `You can now use ${usable.join(", ")}.`;
+}
 
 // src/tools/approval-args.ts
 import fs6 from "node:fs/promises";
@@ -27393,12 +27407,10 @@ async function advanceSetup() {
     const remoteTools = await fetchAllowedRemoteTools(remoteClient);
     cachedRemoteTools = remoteTools;
     saveRemoteTools(serverUrl, remoteTools);
-    const toolNames = remoteTools.map((t) => t.name).join(", ") || "(none)";
-    const decision2 = decisionInForce();
-    const closing = decision2.deactivated ? `This plugin version is not supported by your Glean instance, so only \`setup\` is available. Upgrade the Glean plugin to restore the rest.` : `You can now use ` + [
-      ...decision2.features.metaTools ? ["find_skills", "run_tool"] : [],
-      ...decision2.features.toolPromotion && remoteTools.length > 0 ? ["any of the listed remote tools"] : []
-    ].join(", ") + `.`;
+    const closing = setupClosingLine({
+      decision: decisionInForce(),
+      promoted: remoteTools.map((t) => t.name)
+    });
     return {
       content: [
         {
@@ -27406,7 +27418,6 @@ async function advanceSetup() {
           text: `Glean setup is complete.
 Server URL: ${serverUrl}
 Authenticated: yes
-Remote tools: ${toolNames}
 ${policySummary().join("\n")}
 
 ` + closing

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -26451,15 +26451,12 @@ This version of the Glean plugin is not supported by your Glean instance, so onl
 var FILE_ARGS_DISABLED_TEXT = "`file_args` is disabled for your Glean instance by remote policy, so no file was read and the tool was not executed. Retry `run_tool` with the values inline in `arguments` instead.";
 function setupClosingLine(input) {
   const { decision: decision2, promoted } = input;
-  if (decision2.deactivated) {
-    return `This plugin version is not supported by your Glean instance, so only \`${SETUP_TOOL_NAME}\` is available. Upgrade the Glean plugin to restore the rest.`;
-  }
   const usable = [
     ...decision2.features.metaTools ? [...META_TOOL_NAMES] : [],
     ...decision2.features.toolPromotion ? promoted : []
   ];
   if (usable.length === 0) {
-    return `Remote policy has disabled the tools this plugin provides, so only \`${SETUP_TOOL_NAME}\` is available.`;
+    return `No tools are available beyond \`${SETUP_TOOL_NAME}\`.`;
   }
   return `You can now use ${usable.join(", ")}.`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import {
   protocolVersion,
   setPolicyServerUrl,
 } from "./policy/session.js";
-import { advertisedTools, policyRefusal } from "./policy/enforce.js";
+import { advertisedTools, policyRefusal, setupClosingLine } from "./policy/enforce.js";
 
 function readEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
@@ -563,22 +563,10 @@ async function advanceSetup(): Promise<CallToolResult> {
     const remoteTools = await fetchAllowedRemoteTools(remoteClient);
     cachedRemoteTools = remoteTools;
     saveRemoteTools(serverUrl, remoteTools);
-    const toolNames = remoteTools.map((t) => t.name).join(", ") || "(none)";
-    // Derived from the decision rather than asserted. Naming find_skills and run_tool
-    // unconditionally would be wrong the moment policy withholds them, and actively
-    // misleading when the plugin is deactivated and only `setup` works.
-    const decision = decisionInForce();
-    const closing = decision.deactivated
-      ? `This plugin version is not supported by your Glean instance, so only ` +
-        `\`setup\` is available. Upgrade the Glean plugin to restore the rest.`
-      : `You can now use ` +
-        [
-          ...(decision.features.metaTools ? ["find_skills", "run_tool"] : []),
-          ...(decision.features.toolPromotion && remoteTools.length > 0
-            ? ["any of the listed remote tools"]
-            : []),
-        ].join(", ") +
-        `.`;
+    const closing = setupClosingLine({
+      decision: decisionInForce(),
+      promoted: remoteTools.map((t) => t.name),
+    });
     return {
       content: [
         {
@@ -587,7 +575,6 @@ async function advanceSetup(): Promise<CallToolResult> {
             `Glean setup is complete.\n` +
             `Server URL: ${serverUrl}\n` +
             `Authenticated: yes\n` +
-            `Remote tools: ${toolNames}\n` +
             // Surfacing the negotiated context here is what makes a build with a
             // missing version constant, or an unobserved MCP revision, visible per
             // install rather than only in logs.

--- a/src/policy/enforce.ts
+++ b/src/policy/enforce.ts
@@ -155,3 +155,45 @@ export const FILE_ARGS_DISABLED_TEXT =
   "`file_args` is disabled for your Glean instance by remote policy, so no file was " +
   "read and the tool was not executed. Retry `run_tool` with the values inline in " +
   "`arguments` instead.";
+
+/**
+ * The closing sentence of `setup`: exactly what the caller may invoke right now.
+ *
+ * There used to be two lists here, and they disagreed the moment policy withheld
+ * anything -- `setup` printed the remote's whole catalog ("Remote tools: search, chat,
+ * ...") and then closed with "You can now use find_skills, run_tool". A model reading
+ * that has been handed names it may call, most of which are not advertised and would be
+ * refused on call. The remote's catalog is the remote's business, so it is gone and this
+ * is the single authoritative list.
+ *
+ * Every clause is derived rather than asserted, because every one of them moves:
+ * `metaTools` and `toolPromotion` are policy, and deactivation withdraws all of it.
+ * Meta-tool names come from META_TOOL_NAMES so this cannot drift from what
+ * advertisedTools() actually serves.
+ */
+export function setupClosingLine(input: {
+  decision: Decision;
+  promoted: readonly string[];
+}): string {
+  const { decision, promoted } = input;
+  if (decision.deactivated) {
+    return (
+      `This plugin version is not supported by your Glean instance, so only ` +
+      `\`${SETUP_TOOL_NAME}\` is available. Upgrade the Glean plugin to restore the rest.`
+    );
+  }
+  const usable = [
+    ...(decision.features.metaTools ? [...META_TOOL_NAMES] : []),
+    ...(decision.features.toolPromotion ? promoted : []),
+  ];
+  // Reachable without deactivation: a policy may disable metaTools and toolPromotion
+  // together, which leaves `setup` as the only callable tool. Without this branch the
+  // sentence degrades to "You can now use ."
+  if (usable.length === 0) {
+    return (
+      `Remote policy has disabled the tools this plugin provides, so only ` +
+      `\`${SETUP_TOOL_NAME}\` is available.`
+    );
+  }
+  return `You can now use ${usable.join(", ")}.`;
+}

--- a/src/policy/enforce.ts
+++ b/src/policy/enforce.ts
@@ -166,34 +166,33 @@ export const FILE_ARGS_DISABLED_TEXT =
  * refused on call. The remote's catalog is the remote's business, so it is gone and this
  * is the single authoritative list.
  *
- * Every clause is derived rather than asserted, because every one of them moves:
- * `metaTools` and `toolPromotion` are policy, and deactivation withdraws all of it.
- * Meta-tool names come from META_TOOL_NAMES so this cannot drift from what
- * advertisedTools() actually serves.
+ * Scoped to naming tools and nothing else. Deactivation status and the remote's upgrade
+ * message belong to policySummary(), which prints them a few lines above -- stating the
+ * consequence here as well duplicated it, and when the remote supplied its own wording
+ * the specific instruction ("Run `claude plugin update glean`") was immediately followed
+ * by a vaguer restatement of it.
+ *
+ * No deactivation branch is needed to achieve that: evaluate() reports every feature as
+ * false when deactivated, so the empty case below is reached without asking. Meta-tool
+ * names come from META_TOOL_NAMES so this cannot drift from what advertisedTools()
+ * actually serves.
  */
 export function setupClosingLine(input: {
   decision: Decision;
   promoted: readonly string[];
 }): string {
   const { decision, promoted } = input;
-  if (decision.deactivated) {
-    return (
-      `This plugin version is not supported by your Glean instance, so only ` +
-      `\`${SETUP_TOOL_NAME}\` is available. Upgrade the Glean plugin to restore the rest.`
-    );
-  }
   const usable = [
     ...(decision.features.metaTools ? [...META_TOOL_NAMES] : []),
     ...(decision.features.toolPromotion ? promoted : []),
   ];
-  // Reachable without deactivation: a policy may disable metaTools and toolPromotion
-  // together, which leaves `setup` as the only callable tool. Without this branch the
-  // sentence degrades to "You can now use ."
+  // Two ways to get here, deliberately answered the same way: a deactivated plugin, and
+  // a policy that disables metaTools and toolPromotion together without deactivating.
+  // The cause is on the `Policy:`/`Deactivated:` lines above; this states only the
+  // consequence, because without it the second case leaves the feature JSON as the sole
+  // hint that nothing is callable. Unguarded, the sentence degrades to "You can now use ."
   if (usable.length === 0) {
-    return (
-      `Remote policy has disabled the tools this plugin provides, so only ` +
-      `\`${SETUP_TOOL_NAME}\` is available.`
-    );
+    return `No tools are available beyond \`${SETUP_TOOL_NAME}\`.`;
   }
   return `You can now use ${usable.join(", ")}.`;
 }

--- a/tests/policy-enforce.test.ts
+++ b/tests/policy-enforce.test.ts
@@ -375,18 +375,42 @@ describe("setupClosingLine", () => {
     });
 
     // Not "You can now use ." -- the empty join is the failure this branch exists for.
-    expect(line).toContain("only `setup` is available");
+    // Reached without the deactivated flag, which is why the branch cannot key on it.
+    expect(line).toBe("No tools are available beyond `setup`.");
     expect(line).not.toContain("You can now use");
   });
 
-  it("tells a deactivated install to upgrade rather than listing tools", () => {
+  // Deactivation reaches the empty case through evaluate(), which reports every feature
+  // as false -- so this needs no branch of its own, and asserting it here is what pins
+  // that. The status and the upgrade instruction are policySummary()'s, and saying them
+  // here as well was the duplication this scoping removes.
+  it("names no tools for a deactivated install, and does not restate the upgrade", () => {
     const line = setupClosingLine({
-      decision: decision({ deactivated: true }),
+      decision: decision({
+        deactivated: true,
+        features: { toolPromotion: false, metaTools: false, fileArgs: false },
+        showUpgrade: true,
+        upgradeMessage: "Run `claude plugin update glean`.",
+      }),
       promoted,
     });
 
-    expect(line).toContain("not supported by your Glean instance");
-    expect(line).toContain("Upgrade the Glean plugin");
+    expect(line).toBe("No tools are available beyond `setup`.");
+    expect(line).not.toContain("Upgrade");
+    expect(line).not.toContain("claude plugin update");
     expect(line).not.toContain("find_skills");
+  });
+
+  // The reason a deactivated decision must not be special-cased: evaluate() has already
+  // zeroed the features, so a branch keyed on the flag would be a second source of truth
+  // for the same fact.
+  it("is driven by the features, not by the deactivated flag", () => {
+    const asIfDeactivated = decision({
+      features: { toolPromotion: false, metaTools: false, fileArgs: false },
+    });
+
+    expect(setupClosingLine({ decision: asIfDeactivated, promoted })).toBe(
+      "No tools are available beyond `setup`.",
+    );
   });
 });

--- a/tests/policy-enforce.test.ts
+++ b/tests/policy-enforce.test.ts
@@ -3,6 +3,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   advertisedTools,
   policyRefusal,
+  setupClosingLine,
   withoutFileArgs,
 } from "../src/policy/enforce.js";
 import { evaluate } from "../src/policy/evaluate.js";
@@ -316,5 +317,76 @@ describe("withoutFileArgs", () => {
 
   it("is a no-op for a tool that never had file_args", () => {
     expect(withoutFileArgs(findSkillsTool)).toBe(findSkillsTool);
+  });
+});
+
+// setup's closing sentence is the only place a user or a model is TOLD what it may call,
+// and it had no coverage while it was assembled inline in index.ts -- which is how it came
+// to contradict the advertised surface. The contract asserted here is agreement: whatever
+// this sentence names, advertisedTools() serves.
+describe("setupClosingLine", () => {
+  const promoted = ["search", "chat"];
+
+  it("names the meta tools and the promoted tools when policy allows both", () => {
+    expect(setupClosingLine({ decision: decision(), promoted })).toBe(
+      "You can now use find_skills, run_tool, search, chat.",
+    );
+  });
+
+  // The defect this change fixes: setup printed the remote's catalog, so a withheld
+  // feature produced a sentence naming tools the very next call would refuse. Asserted
+  // against the gate as well, so the sentence and the served surface cannot drift.
+  it("omits the promoted tools when toolPromotion is off, and says nothing about them", () => {
+    const d = decision({ features: { ...allSupported, toolPromotion: false } });
+
+    const line = setupClosingLine({ decision: d, promoted });
+
+    expect(line).toBe("You can now use find_skills, run_tool.");
+    for (const name of promoted) {
+      expect(line).not.toContain(name);
+      expect(names(d)).not.toContain(name);
+    }
+  });
+
+  it("omits the meta tools when metaTools is off", () => {
+    const d = decision({ features: { ...allSupported, metaTools: false } });
+
+    const line = setupClosingLine({ decision: d, promoted });
+
+    expect(line).toBe("You can now use search, chat.");
+    expect(names(d)).not.toContain("find_skills");
+    expect(names(d)).not.toContain("run_tool");
+  });
+
+  // A remote that promotes nothing differs from one whose promotion was withheld, and
+  // neither may leave a dangling reference to a list setup no longer prints.
+  it("names only the meta tools when the remote promotes nothing", () => {
+    expect(setupClosingLine({ decision: decision(), promoted: [] })).toBe(
+      "You can now use find_skills, run_tool.",
+    );
+  });
+
+  it("says only setup is available when policy disables both features", () => {
+    const line = setupClosingLine({
+      decision: decision({
+        features: { ...allSupported, metaTools: false, toolPromotion: false },
+      }),
+      promoted,
+    });
+
+    // Not "You can now use ." -- the empty join is the failure this branch exists for.
+    expect(line).toContain("only `setup` is available");
+    expect(line).not.toContain("You can now use");
+  });
+
+  it("tells a deactivated install to upgrade rather than listing tools", () => {
+    const line = setupClosingLine({
+      decision: decision({ deactivated: true }),
+      promoted,
+    });
+
+    expect(line).toContain("not supported by your Glean instance");
+    expect(line).toContain("Upgrade the Glean plugin");
+    expect(line).not.toContain("find_skills");
   });
 });

--- a/tests/setup-output.test.ts
+++ b/tests/setup-output.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CAPABILITY_POLICY_KEY } from "../src/policy/key.js";
+
+// policySummary() and setupClosingLine() are only ever printed together, by the setup
+// handler, and the defect they had was one of composition rather than of either half:
+// each said "only `setup` is available" and each restated the upgrade instruction, so a
+// deactivated install was told twice -- and when the remote supplied its own wording, its
+// specific instruction was followed by a vaguer generic one. Neither unit test could see
+// that. This asserts the assembled text.
+//
+// Deactivation is gated on version provenance, and the build constant is absent under
+// vitest, which is why policy-session.test.ts documents these lines as unreachable there.
+// Mocking the version module is what unlocks them.
+vi.mock("../src/version.js", () => ({
+  pluginVersion: () => ({ version: "0.2.49", source: "build" }),
+  pluginVersionString: () => "0.2.49",
+}));
+
+const URL_A = "https://a-be.glean.com/mcp/gateway/proxy";
+const REMOTE_UPGRADE_TEXT = "Run `claude plugin update glean` to reach 9.9.9 or later.";
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+/** The setup handler's text, assembled exactly as index.ts assembles it. */
+async function setupText(policy: unknown, promoted: string[]) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "setup-output-"));
+  vi.resetModules();
+  vi.stubEnv("PLUGIN_DATA_DIR", dir);
+  const session = await import("../src/policy/session.js");
+  const { setupClosingLine } = await import("../src/policy/enforce.js");
+
+  session.initPolicySession(
+    {
+      getClientVersion: () => ({ name: "claude-code", version: "1.2.3" }),
+      getClientCapabilities: () => ({}),
+      sendToolListChanged: async () => {},
+    } as never,
+    () => {},
+  );
+  session.setPolicyServerUrl(URL_A);
+  session.recordPolicyFromResult(
+    { tools: [], _meta: { [CAPABILITY_POLICY_KEY]: policy } },
+    "tools/call(search)",
+  );
+
+  const text =
+    `Glean setup is complete.\n` +
+    `Server URL: ${URL_A}\n` +
+    `Authenticated: yes\n` +
+    `${session.policySummary().join("\n")}\n\n` +
+    setupClosingLine({ decision: session.decisionInForce(), promoted });
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  return text;
+}
+
+describe("the assembled setup output", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const deactivating = {
+    plugin: {
+      minimumSupportedVersion: "9.9.9",
+      upgradeRecommendation: { show: true, message: REMOTE_UPGRADE_TEXT },
+    },
+  };
+
+  it("gives the remote's upgrade instruction exactly once when deactivated", async () => {
+    const text = await setupText(deactivating, ["search", "chat"]);
+
+    expect(text).toContain("Deactivated:");
+    expect(occurrences(text, REMOTE_UPGRADE_TEXT)).toBe(1);
+    // The generic fallback must not appear alongside the remote's own wording, which is
+    // what the closing used to add.
+    expect(text).not.toContain("Upgrade the Glean plugin");
+  });
+
+  it("names no tools when deactivated, and states it once", async () => {
+    const text = await setupText(deactivating, ["search", "chat"]);
+
+    expect(text).toContain("No tools are available beyond `setup`.");
+    expect(text).not.toContain("You can now use");
+    for (const name of ["find_skills", "run_tool", "search", "chat"]) {
+      expect(text).not.toContain(name);
+    }
+  });
+
+  it("never prints the remote's catalog alongside the usable list", async () => {
+    const text = await setupText(
+      { features: { toolPromotion: { enabled: false } } },
+      ["search", "chat", "employee_search"],
+    );
+
+    expect(text).toContain("You can now use find_skills, run_tool.");
+    // The regression: a withheld feature used to leave these named in "Remote tools: ..."
+    // while being unusable and unadvertised.
+    expect(text).not.toContain("Remote tools:");
+    for (const name of ["search", "chat", "employee_search"]) {
+      expect(text).not.toContain(name);
+    }
+  });
+
+  it("promotes the remote's tools into the one usable list when policy allows", async () => {
+    const text = await setupText({ features: {} }, ["search", "chat"]);
+
+    expect(text).toContain("You can now use find_skills, run_tool, search, chat.");
+    expect(text).not.toContain("Remote tools:");
+  });
+});


### PR DESCRIPTION
## What

`setup` printed two lists that disagreed:

```
Remote tools: search, read_document, chat, memory, memory_schema, user_activity, employee_search
...
You can now use find_skills, run_tool.
```

Seven tools named, none of them usable — `toolPromotion` was off. The closing then pointed *at* that catalog with "any of the listed remote tools", so the output handed a model names it may call, most of which were not advertised and would be refused on call.

The remote's catalog is the remote's business, not the caller's. It's gone, and the closing is now scoped to naming what is callable.

| Policy | Before | After |
|---|---|---|
| all features on | catalog + `find_skills, run_tool, any of the listed remote tools` | `You can now use find_skills, run_tool, search, chat, …` |
| `toolPromotion: false` | **catalog** + `find_skills, run_tool` | `You can now use find_skills, run_tool.` |
| `metaTools: false` | catalog + `any of the listed remote tools` | `You can now use search, chat, …` |
| both off | catalog + `You can now use .` | `No tools are available beyond \`setup\`.` |
| deactivated | catalog + a second copy of the upgrade instruction | `No tools are available beyond \`setup\`.` |

## The deactivated case said everything twice

Found by rendering it rather than reading it (second commit):

```
Deactivated: only `setup` is available. Run `claude plugin update glean` to reach 9.9.9 or later.

This plugin version is not supported by your Glean instance, so only `setup` is available. Upgrade the Glean plugin to restore the rest.
```

The consequence twice and the instruction twice — and when the remote supplies its own `upgradeMessage`, its **specific** remedy was immediately followed by our vaguer generic one. This predates the first commit; the old inline closing had the identical branch.

So `policySummary()` keeps deactivation status and the upgrade message, and the closing names tools only. That needs **no deactivation branch**: `evaluate()` already reports every feature as false when deactivated, so the empty case is reached without asking, and a branch keyed on the flag would be a second source of truth for a fact the features already carry. There is a test pinning that.

The empty sentence stays rather than emitting nothing, because a policy may disable `metaTools` and `toolPromotion` together **without** deactivating — there `policySummary` prints no `Deactivated:` line, so the feature JSON would be the only hint that nothing is callable. The residual cost is a mild overlap in the deactivated case only.

## Why it moved to `enforce.ts`

- **It was untestable where it lived.** `index.ts` has no handler coverage, so this sentence was assembled inline with nothing asserting it — which is how it came to contradict the advertised surface in the first place.
- **The meta-tool names were a duplicated literal.** They now derive from `META_TOOL_NAMES`, the same set `advertisedTools()` filters on, so the sentence cannot drift from what is served. This also makes the agent-plugins port a straight copy — that repo names the tool `find_skills_and_tools`, and nothing here hardcodes it.

## Tests

`329 passed`. Two layers, because the two defects live at different levels:

- **Unit** (`policy-enforce.test.ts`): every branch of `setupClosingLine`, each cross-checked against `advertisedTools()` where the two must agree.
- **Composition** (`tests/setup-output.test.ts`, new): asserts the **assembled** setup text, including that the upgrade instruction appears exactly once. The duplication was a property of the two halves together, so no unit test on either could see it. Mocking `version.js` is what makes deactivation reachable under vitest at all — it is gated on version provenance, which is why `policy-session.test.ts` documents the branch as untestable.

Mutation-verified throughout: ignoring `toolPromotion` fails two tests; dropping the empty guard yields exactly `"You can now use ."`; re-adding an upgrade line to the closing fails four.

## Notes for review

Branched off `main`, independent of #54. Both bump to 0.2.49, so whichever merges second needs a trivial rebase (the version hook is idempotent, but `dist` must be rebuilt so its baked version matches the manifests).
