### PR TITLE
[PACT-428] Bridge remote MCP elicitation to plugin hosts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,15 +6,18 @@
     "": {
       "name": "glean",
       "dependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
         "@types/node": "^22.0.0",
         "esbuild": "^0.28.1",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
-        "vitest": "^3.0.0"
+        "vitest": "^3.0.0",
+        "zod": "^4.5.4"
       },
       "engines": {
         "node": ">=22 <26"
@@ -481,6 +484,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -519,6 +552,20 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2766,9 +2813,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -15,15 +15,18 @@
     "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/server": "^2.0.0",
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.1",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "zod": "^4.5.4"
   },
   "//overrides": "Pin hono>=4.12.25 (CVE-2026-54290, transitive from @modelcontextprotocol/sdk); pin esbuild/vite to clear CVE blocks that prevented install",
   "overrides": {

--- a/plugins/glean/.claude-plugin/plugin.json
+++ b/plugins/glean/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "description": "Glean plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.codex-plugin/plugin.json
+++ b/plugins/glean/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glean-vnext",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "description": "Glean Codex plugin for discovering skills and running tools.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/.cursor-plugin/plugin.json
+++ b/plugins/glean/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glean-vnext",
   "displayName": "Glean vNext",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "description": "Search and act across your company's apps — Jira, Slack, Salesforce, Google Workspace, and more — without leaving Cursor.",
   "author": {
     "name": "Glean"

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -42461,11 +42461,7 @@ async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args, poli
     throw err;
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
-  if (hitlEnabled && toolMeta?.requires_approval && mcpServer2.getClientCapabilities()?.elicitation && // Modern Glean servers own the approval and return input_required. The
-  // remote v2 client forwards that request to this same local host, so
-  // prompting here as well would ask the user twice. Keep this gate only as
-  // a fallback for legacy remote servers.
-  remoteClient.getProtocolEra() !== "modern") {
+  if (hitlEnabled && toolMeta?.requires_approval && mcpServer2.getClientCapabilities()?.elicitation) {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
       const message = await buildApprovalMessage(toolName, resolvedArgs);

--- a/plugins/glean/dist/index.js
+++ b/plugins/glean/dist/index.js
@@ -847,8 +847,8 @@ var require_codegen = __commonJS({
       endIf() {
         return this._endBlockNode(If, Else);
       }
-      _for(node, forBody) {
-        this._blockNode(node);
+      _for(node2, forBody) {
+        this._blockNode(node2);
         if (forBody)
           this.code(forBody).endFor();
         return this;
@@ -897,10 +897,10 @@ var require_codegen = __commonJS({
       }
       // `return` statement
       return(value) {
-        const node = new Return();
-        this._blockNode(node);
+        const node2 = new Return();
+        this._blockNode(node2);
         this.code(value);
-        if (node.nodes.length !== 1)
+        if (node2.nodes.length !== 1)
           throw new Error('CodeGen: "return" should have one node');
         return this._endBlockNode(Return);
       }
@@ -908,16 +908,16 @@ var require_codegen = __commonJS({
       try(tryBody, catchCode, finallyCode) {
         if (!catchCode && !finallyCode)
           throw new Error('CodeGen: "try" without "catch" and "finally"');
-        const node = new Try();
-        this._blockNode(node);
+        const node2 = new Try();
+        this._blockNode(node2);
         this.code(tryBody);
         if (catchCode) {
           const error2 = this.name("e");
-          this._currNode = node.catch = new Catch(error2);
+          this._currNode = node2.catch = new Catch(error2);
           catchCode(error2);
         }
         if (finallyCode) {
-          this._currNode = node.finally = new Finally();
+          this._currNode = node2.finally = new Finally();
           this.code(finallyCode);
         }
         return this._endBlockNode(Catch, Finally);
@@ -962,13 +962,13 @@ var require_codegen = __commonJS({
           this._root.optimizeNames(this._root.names, this._constants);
         }
       }
-      _leafNode(node) {
-        this._currNode.nodes.push(node);
+      _leafNode(node2) {
+        this._currNode.nodes.push(node2);
         return this;
       }
-      _blockNode(node) {
-        this._currNode.nodes.push(node);
-        this._nodes.push(node);
+      _blockNode(node2) {
+        this._currNode.nodes.push(node2);
+        this._nodes.push(node2);
       }
       _endBlockNode(N1, N2) {
         const n = this._currNode;
@@ -978,12 +978,12 @@ var require_codegen = __commonJS({
         }
         throw new Error(`CodeGen: not in block "${N2 ? `${N1.kind}/${N2.kind}` : N1.kind}"`);
       }
-      _elseNode(node) {
+      _elseNode(node2) {
         const n = this._currNode;
         if (!(n instanceof If)) {
           throw new Error('CodeGen: "else" without "if"');
         }
-        this._currNode = n.else = node;
+        this._currNode = n.else = node2;
         return this;
       }
       get _root() {
@@ -993,9 +993,9 @@ var require_codegen = __commonJS({
         const ns = this._nodes;
         return ns[ns.length - 1];
       }
-      set _currNode(node) {
+      set _currNode(node2) {
         const ns = this._nodes;
-        ns[ns.length - 1] = node;
+        ns[ns.length - 1] = node2;
       }
     };
     exports.CodeGen = CodeGen;
@@ -1877,8 +1877,8 @@ var require_keyword = __commonJS({
       var _a3;
       const { gen, keyword, schema, parentSchema, $data, it } = cxt;
       checkAsyncKeyword(it, def);
-      const validate = !$data && def.compile ? def.compile.call(it.self, schema, parentSchema, it) : def.validate;
-      const validateRef = useKeyword(gen, keyword, validate);
+      const validate2 = !$data && def.compile ? def.compile.call(it.self, schema, parentSchema, it) : def.validate;
+      const validateRef = useKeyword(gen, keyword, validate2);
       const valid = gen.let("valid");
       cxt.block$data(valid, validateKeyword);
       cxt.ok((_a3 = def.valid) !== null && _a3 !== void 0 ? _a3 : valid);
@@ -1889,13 +1889,13 @@ var require_keyword = __commonJS({
             modifyData(cxt);
           reportErrs(() => cxt.error());
         } else {
-          const ruleErrs = def.async ? validateAsync() : validateSync();
+          const ruleErrs = def.async ? validateAsync2() : validateSync();
           if (def.modifying)
             modifyData(cxt);
           reportErrs(() => addErrs(cxt, ruleErrs));
         }
       }
-      function validateAsync() {
+      function validateAsync2() {
         const ruleErrs = gen.let("ruleErrs", null);
         gen.try(() => assignValid((0, codegen_1._)`await `), (e) => gen.assign(valid, false).if((0, codegen_1._)`${e} instanceof ${it.ValidationError}`, () => gen.assign(ruleErrs, (0, codegen_1._)`${e}.errors`), () => gen.throw(e)));
         return ruleErrs;
@@ -2305,11 +2305,11 @@ var require_resolve = __commonJS({
           }
           return ref;
         }
-        function addAnchor(anchor) {
-          if (typeof anchor == "string") {
-            if (!ANCHOR.test(anchor))
-              throw new Error(`invalid anchor "${anchor}"`);
-            addRef.call(this, `#${anchor}`);
+        function addAnchor(anchor2) {
+          if (typeof anchor2 == "string") {
+            if (!ANCHOR.test(anchor2))
+              throw new Error(`invalid anchor "${anchor2}"`);
+            addRef.call(this, `#${anchor2}`);
           }
         }
       });
@@ -2951,28 +2951,28 @@ var require_compile = __commonJS({
         if (this.opts.code.process)
           sourceCode = this.opts.code.process(sourceCode, sch);
         const makeValidate = new Function(`${names_1.default.self}`, `${names_1.default.scope}`, sourceCode);
-        const validate = makeValidate(this, this.scope.get());
-        this.scope.value(validateName, { ref: validate });
-        validate.errors = null;
-        validate.schema = sch.schema;
-        validate.schemaEnv = sch;
+        const validate2 = makeValidate(this, this.scope.get());
+        this.scope.value(validateName, { ref: validate2 });
+        validate2.errors = null;
+        validate2.schema = sch.schema;
+        validate2.schemaEnv = sch;
         if (sch.$async)
-          validate.$async = true;
+          validate2.$async = true;
         if (this.opts.code.source === true) {
-          validate.source = { validateName, validateCode, scopeValues: gen._values };
+          validate2.source = { validateName, validateCode, scopeValues: gen._values };
         }
         if (this.opts.unevaluated) {
           const { props, items } = schemaCxt;
-          validate.evaluated = {
+          validate2.evaluated = {
             props: props instanceof codegen_1.Name ? void 0 : props,
             items: items instanceof codegen_1.Name ? void 0 : items,
             dynamicProps: props instanceof codegen_1.Name,
             dynamicItems: items instanceof codegen_1.Name
           };
-          if (validate.source)
-            validate.source.evaluated = (0, codegen_1.stringify)(validate.evaluated);
+          if (validate2.source)
+            validate2.source.evaluated = (0, codegen_1.stringify)(validate2.evaluated);
         }
-        sch.validate = validate;
+        sch.validate = validate2;
         return sch;
       } catch (e) {
         delete sch.validate;
@@ -4038,7 +4038,7 @@ var require_core = __commonJS({
         uriResolver
       };
     }
-    var Ajv2 = class {
+    var Ajv3 = class {
       constructor(opts = {}) {
         this.schemas = {};
         this.refs = {};
@@ -4408,9 +4408,9 @@ var require_core = __commonJS({
         }
       }
     };
-    Ajv2.ValidationError = validation_error_1.default;
-    Ajv2.MissingRefError = ref_error_1.default;
-    exports.default = Ajv2;
+    Ajv3.ValidationError = validation_error_1.default;
+    Ajv3.MissingRefError = ref_error_1.default;
+    exports.default = Ajv3;
     function checkOptions(checkOpts, options, msg, log = "error") {
       for (const key in checkOpts) {
         const opt = key;
@@ -6521,7 +6521,7 @@ var require_ajv = __commonJS({
     var draft7MetaSchema = require_json_schema_draft_07();
     var META_SUPPORT_DATA = ["/properties"];
     var META_SCHEMA_ID = "http://json-schema.org/draft-07/schema";
-    var Ajv2 = class extends core_1.default {
+    var Ajv3 = class extends core_1.default {
       _addVocabularies() {
         super._addVocabularies();
         draft7_1.default.forEach((v) => this.addVocabulary(v));
@@ -6540,11 +6540,11 @@ var require_ajv = __commonJS({
         return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
       }
     };
-    exports.Ajv = Ajv2;
-    module.exports = exports = Ajv2;
-    module.exports.Ajv = Ajv2;
+    exports.Ajv = Ajv3;
+    module.exports = exports = Ajv3;
+    module.exports.Ajv = Ajv3;
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.default = Ajv2;
+    exports.default = Ajv3;
     var validate_1 = require_validate();
     Object.defineProperty(exports, "KeywordCxt", { enumerable: true, get: function() {
       return validate_1.KeywordCxt;
@@ -6585,8 +6585,8 @@ var require_formats = __commonJS({
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
-    function fmtDef(validate, compare) {
-      return { validate, compare };
+    function fmtDef(validate2, compare) {
+      return { validate: validate2, compare };
     }
     exports.fullFormats = {
       // date: http://tools.ietf.org/html/rfc3339#section-5.6
@@ -6866,12 +6866,12 @@ var require_dist = __commonJS({
     var fastName = new codegen_1.Name("fastFormats");
     var formatsPlugin = (ajv, opts = { keywords: true }) => {
       if (Array.isArray(opts)) {
-        addFormats(ajv, opts, formats_1.fullFormats, fullName);
+        addFormats2(ajv, opts, formats_1.fullFormats, fullName);
         return ajv;
       }
       const [formats, exportName] = opts.mode === "fast" ? [formats_1.fastFormats, fastName] : [formats_1.fullFormats, fullName];
       const list = opts.formats || formats_1.formatNames;
-      addFormats(ajv, list, formats, exportName);
+      addFormats2(ajv, list, formats, exportName);
       if (opts.keywords)
         (0, limit_1.default)(ajv);
       return ajv;
@@ -6883,7 +6883,7 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs11, exportName) {
+    function addFormats2(ajv, list, fs11, exportName) {
       var _a3;
       var _b;
       (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 ? _a3 : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
@@ -6907,24 +6907,24 @@ var require_identity = __commonJS({
     var SCALAR = /* @__PURE__ */ Symbol.for("yaml.scalar");
     var SEQ = /* @__PURE__ */ Symbol.for("yaml.seq");
     var NODE_TYPE = /* @__PURE__ */ Symbol.for("yaml.node.type");
-    var isAlias = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === ALIAS;
-    var isDocument = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === DOC;
-    var isMap = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === MAP;
-    var isPair = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === PAIR;
-    var isScalar = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SCALAR;
-    var isSeq = (node) => !!node && typeof node === "object" && node[NODE_TYPE] === SEQ;
-    function isCollection(node) {
-      if (node && typeof node === "object")
-        switch (node[NODE_TYPE]) {
+    var isAlias = (node2) => !!node2 && typeof node2 === "object" && node2[NODE_TYPE] === ALIAS;
+    var isDocument = (node2) => !!node2 && typeof node2 === "object" && node2[NODE_TYPE] === DOC;
+    var isMap = (node2) => !!node2 && typeof node2 === "object" && node2[NODE_TYPE] === MAP;
+    var isPair = (node2) => !!node2 && typeof node2 === "object" && node2[NODE_TYPE] === PAIR;
+    var isScalar = (node2) => !!node2 && typeof node2 === "object" && node2[NODE_TYPE] === SCALAR;
+    var isSeq = (node2) => !!node2 && typeof node2 === "object" && node2[NODE_TYPE] === SEQ;
+    function isCollection(node2) {
+      if (node2 && typeof node2 === "object")
+        switch (node2[NODE_TYPE]) {
           case MAP:
           case SEQ:
             return true;
         }
       return false;
     }
-    function isNode(node) {
-      if (node && typeof node === "object")
-        switch (node[NODE_TYPE]) {
+    function isNode(node2) {
+      if (node2 && typeof node2 === "object")
+        switch (node2[NODE_TYPE]) {
           case ALIAS:
           case MAP:
           case SCALAR:
@@ -6933,7 +6933,7 @@ var require_identity = __commonJS({
         }
       return false;
     }
-    var hasAnchor = (node) => (isScalar(node) || isCollection(node)) && !!node.anchor;
+    var hasAnchor = (node2) => (isScalar(node2) || isCollection(node2)) && !!node2.anchor;
     exports.ALIAS = ALIAS;
     exports.DOC = DOC;
     exports.MAP = MAP;
@@ -6961,98 +6961,98 @@ var require_visit = __commonJS({
     var BREAK = /* @__PURE__ */ Symbol("break visit");
     var SKIP = /* @__PURE__ */ Symbol("skip children");
     var REMOVE = /* @__PURE__ */ Symbol("remove node");
-    function visit(node, visitor) {
+    function visit(node2, visitor) {
       const visitor_ = initVisitor(visitor);
-      if (identity.isDocument(node)) {
-        const cd = visit_(null, node.contents, visitor_, Object.freeze([node]));
+      if (identity.isDocument(node2)) {
+        const cd = visit_(null, node2.contents, visitor_, Object.freeze([node2]));
         if (cd === REMOVE)
-          node.contents = null;
+          node2.contents = null;
       } else
-        visit_(null, node, visitor_, Object.freeze([]));
+        visit_(null, node2, visitor_, Object.freeze([]));
     }
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path12) {
-      const ctrl = callVisitor(key, node, visitor, path12);
+    function visit_(key, node2, visitor, path12) {
+      const ctrl = callVisitor(key, node2, visitor, path12);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
         replaceNode(key, path12, ctrl);
         return visit_(key, ctrl, visitor, path12);
       }
       if (typeof ctrl !== "symbol") {
-        if (identity.isCollection(node)) {
-          path12 = Object.freeze(path12.concat(node));
-          for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path12);
+        if (identity.isCollection(node2)) {
+          path12 = Object.freeze(path12.concat(node2));
+          for (let i = 0; i < node2.items.length; ++i) {
+            const ci = visit_(i, node2.items[i], visitor, path12);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
               return BREAK;
             else if (ci === REMOVE) {
-              node.items.splice(i, 1);
+              node2.items.splice(i, 1);
               i -= 1;
             }
           }
-        } else if (identity.isPair(node)) {
-          path12 = Object.freeze(path12.concat(node));
-          const ck = visit_("key", node.key, visitor, path12);
+        } else if (identity.isPair(node2)) {
+          path12 = Object.freeze(path12.concat(node2));
+          const ck = visit_("key", node2.key, visitor, path12);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
-            node.key = null;
-          const cv = visit_("value", node.value, visitor, path12);
+            node2.key = null;
+          const cv = visit_("value", node2.value, visitor, path12);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
-            node.value = null;
+            node2.value = null;
         }
       }
       return ctrl;
     }
-    async function visitAsync(node, visitor) {
+    async function visitAsync(node2, visitor) {
       const visitor_ = initVisitor(visitor);
-      if (identity.isDocument(node)) {
-        const cd = await visitAsync_(null, node.contents, visitor_, Object.freeze([node]));
+      if (identity.isDocument(node2)) {
+        const cd = await visitAsync_(null, node2.contents, visitor_, Object.freeze([node2]));
         if (cd === REMOVE)
-          node.contents = null;
+          node2.contents = null;
       } else
-        await visitAsync_(null, node, visitor_, Object.freeze([]));
+        await visitAsync_(null, node2, visitor_, Object.freeze([]));
     }
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path12) {
-      const ctrl = await callVisitor(key, node, visitor, path12);
+    async function visitAsync_(key, node2, visitor, path12) {
+      const ctrl = await callVisitor(key, node2, visitor, path12);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
         replaceNode(key, path12, ctrl);
         return visitAsync_(key, ctrl, visitor, path12);
       }
       if (typeof ctrl !== "symbol") {
-        if (identity.isCollection(node)) {
-          path12 = Object.freeze(path12.concat(node));
-          for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path12);
+        if (identity.isCollection(node2)) {
+          path12 = Object.freeze(path12.concat(node2));
+          for (let i = 0; i < node2.items.length; ++i) {
+            const ci = await visitAsync_(i, node2.items[i], visitor, path12);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
               return BREAK;
             else if (ci === REMOVE) {
-              node.items.splice(i, 1);
+              node2.items.splice(i, 1);
               i -= 1;
             }
           }
-        } else if (identity.isPair(node)) {
-          path12 = Object.freeze(path12.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path12);
+        } else if (identity.isPair(node2)) {
+          path12 = Object.freeze(path12.concat(node2));
+          const ck = await visitAsync_("key", node2.key, visitor, path12);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
-            node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path12);
+            node2.key = null;
+          const cv = await visitAsync_("value", node2.value, visitor, path12);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
-            node.value = null;
+            node2.value = null;
         }
       }
       return ctrl;
@@ -7075,32 +7075,32 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path12) {
+    function callVisitor(key, node2, visitor, path12) {
       if (typeof visitor === "function")
-        return visitor(key, node, path12);
-      if (identity.isMap(node))
-        return visitor.Map?.(key, node, path12);
-      if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path12);
-      if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path12);
-      if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path12);
-      if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path12);
+        return visitor(key, node2, path12);
+      if (identity.isMap(node2))
+        return visitor.Map?.(key, node2, path12);
+      if (identity.isSeq(node2))
+        return visitor.Seq?.(key, node2, path12);
+      if (identity.isPair(node2))
+        return visitor.Pair?.(key, node2, path12);
+      if (identity.isScalar(node2))
+        return visitor.Scalar?.(key, node2, path12);
+      if (identity.isAlias(node2))
+        return visitor.Alias?.(key, node2, path12);
       return void 0;
     }
-    function replaceNode(key, path12, node) {
+    function replaceNode(key, path12, node2) {
       const parent = path12[path12.length - 1];
       if (identity.isCollection(parent)) {
-        parent.items[key] = node;
+        parent.items[key] = node2;
       } else if (identity.isPair(parent)) {
         if (key === "key")
-          parent.key = node;
+          parent.key = node2;
         else
-          parent.value = node;
+          parent.value = node2;
       } else if (identity.isDocument(parent)) {
-        parent.contents = node;
+        parent.contents = node2;
       } else {
         const pt = identity.isAlias(parent) ? "alias" : "scalar";
         throw new Error(`Cannot replace node with ${pt} parent`);
@@ -7260,9 +7260,9 @@ var require_directives = __commonJS({
         let tagNames;
         if (doc && tagEntries.length > 0 && identity.isNode(doc.contents)) {
           const tags = {};
-          visit.visit(doc.contents, (_key, node) => {
-            if (identity.isNode(node) && node.tag)
-              tags[node.tag] = true;
+          visit.visit(doc.contents, (_key, node2) => {
+            if (identity.isNode(node2) && node2.tag)
+              tags[node2.tag] = true;
           });
           tagNames = Object.keys(tags);
         } else
@@ -7288,9 +7288,9 @@ var require_anchors = __commonJS({
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
-    function anchorIsValid(anchor) {
-      if (/[\x00-\x19\s,[\]{}]/.test(anchor)) {
-        const sa = JSON.stringify(anchor);
+    function anchorIsValid(anchor2) {
+      if (/[\x00-\x19\s,[\]{}]/.test(anchor2)) {
+        const sa = JSON.stringify(anchor2);
         const msg = `Anchor must not contain whitespace or control characters: ${sa}`;
         throw new Error(msg);
       }
@@ -7299,9 +7299,9 @@ var require_anchors = __commonJS({
     function anchorNames(root) {
       const anchors = /* @__PURE__ */ new Set();
       visit.visit(root, {
-        Value(_key, node) {
-          if (node.anchor)
-            anchors.add(node.anchor);
+        Value(_key, node2) {
+          if (node2.anchor)
+            anchors.add(node2.anchor);
         }
       });
       return anchors;
@@ -7321,9 +7321,9 @@ var require_anchors = __commonJS({
         onAnchor: (source) => {
           aliasObjects.push(source);
           prevAnchors ?? (prevAnchors = anchorNames(doc));
-          const anchor = findNewAnchor(prefix, prevAnchors);
-          prevAnchors.add(anchor);
-          return anchor;
+          const anchor2 = findNewAnchor(prefix, prevAnchors);
+          prevAnchors.add(anchor2);
+          return anchor2;
         },
         /**
          * With circular references, the source node is only resolved after all
@@ -7505,20 +7505,20 @@ var require_Alias = __commonJS({
         } else {
           nodes = [];
           visit.visit(doc, {
-            Node: (_key, node) => {
-              if (identity.isAlias(node) || identity.hasAnchor(node))
-                nodes.push(node);
+            Node: (_key, node2) => {
+              if (identity.isAlias(node2) || identity.hasAnchor(node2))
+                nodes.push(node2);
             }
           });
           if (ctx)
             ctx.aliasResolveCache = nodes;
         }
         let found = void 0;
-        for (const node of nodes) {
-          if (node === this)
+        for (const node2 of nodes) {
+          if (node2 === this)
             break;
-          if (node.anchor === this.source)
-            found = node;
+          if (node2.anchor === this.source)
+            found = node2;
         }
         return found;
       }
@@ -7565,22 +7565,22 @@ var require_Alias = __commonJS({
         return src;
       }
     };
-    function getAliasCount(doc, node, anchors2) {
-      if (identity.isAlias(node)) {
-        const source = node.resolve(doc);
-        const anchor = anchors2 && source && anchors2.get(source);
-        return anchor ? anchor.count * anchor.aliasCount : 0;
-      } else if (identity.isCollection(node)) {
+    function getAliasCount(doc, node2, anchors2) {
+      if (identity.isAlias(node2)) {
+        const source = node2.resolve(doc);
+        const anchor2 = anchors2 && source && anchors2.get(source);
+        return anchor2 ? anchor2.count * anchor2.aliasCount : 0;
+      } else if (identity.isCollection(node2)) {
         let count = 0;
-        for (const item of node.items) {
+        for (const item of node2.items) {
           const c = getAliasCount(doc, item, anchors2);
           if (c > count)
             count = c;
         }
         return count;
-      } else if (identity.isPair(node)) {
-        const kc = getAliasCount(doc, node.key, anchors2);
-        const vc = getAliasCount(doc, node.value, anchors2);
+      } else if (identity.isPair(node2)) {
+        const kc = getAliasCount(doc, node2.key, anchors2);
+        const vc = getAliasCount(doc, node2.value, anchors2);
         return Math.max(kc, vc);
       }
       return 1;
@@ -7670,10 +7670,10 @@ var require_createNode = __commonJS({
           value = value.toJSON();
         }
         if (!value || typeof value !== "object") {
-          const node2 = new Scalar.Scalar(value);
+          const node3 = new Scalar.Scalar(value);
           if (ref)
-            ref.node = node2;
-          return node2;
+            ref.node = node3;
+          return node3;
         }
         tagObj = value instanceof Map ? schema[identity.MAP] : Symbol.iterator in Object(value) ? schema[identity.SEQ] : schema[identity.MAP];
       }
@@ -7681,14 +7681,14 @@ var require_createNode = __commonJS({
         onTagObj(tagObj);
         delete ctx.onTagObj;
       }
-      const node = tagObj?.createNode ? tagObj.createNode(ctx.schema, value, ctx) : typeof tagObj?.nodeClass?.from === "function" ? tagObj.nodeClass.from(ctx.schema, value, ctx) : new Scalar.Scalar(value);
+      const node2 = tagObj?.createNode ? tagObj.createNode(ctx.schema, value, ctx) : typeof tagObj?.nodeClass?.from === "function" ? tagObj.nodeClass.from(ctx.schema, value, ctx) : new Scalar.Scalar(value);
       if (tagName)
-        node.tag = tagName;
+        node2.tag = tagName;
       else if (!tagObj.default)
-        node.tag = tagObj.tag;
+        node2.tag = tagObj.tag;
       if (ref)
-        ref.node = node;
-      return node;
+        ref.node = node2;
+      return node2;
     }
     exports.createNode = createNode;
   }
@@ -7758,10 +7758,10 @@ var require_Collection = __commonJS({
           this.add(value);
         else {
           const [key, ...rest] = path12;
-          const node = this.get(key, true);
-          if (identity.isCollection(node))
-            node.addIn(rest, value);
-          else if (node === void 0 && this.schema)
+          const node2 = this.get(key, true);
+          if (identity.isCollection(node2))
+            node2.addIn(rest, value);
+          else if (node2 === void 0 && this.schema)
             this.set(key, collectionFromPath(this.schema, rest, value));
           else
             throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
@@ -7775,9 +7775,9 @@ var require_Collection = __commonJS({
         const [key, ...rest] = path12;
         if (rest.length === 0)
           return this.delete(key);
-        const node = this.get(key, true);
-        if (identity.isCollection(node))
-          return node.deleteIn(rest);
+        const node2 = this.get(key, true);
+        if (identity.isCollection(node2))
+          return node2.deleteIn(rest);
         else
           throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
       }
@@ -7788,17 +7788,17 @@ var require_Collection = __commonJS({
        */
       getIn(path12, keepScalar) {
         const [key, ...rest] = path12;
-        const node = this.get(key, true);
+        const node2 = this.get(key, true);
         if (rest.length === 0)
-          return !keepScalar && identity.isScalar(node) ? node.value : node;
+          return !keepScalar && identity.isScalar(node2) ? node2.value : node2;
         else
-          return identity.isCollection(node) ? node.getIn(rest, keepScalar) : void 0;
+          return identity.isCollection(node2) ? node2.getIn(rest, keepScalar) : void 0;
       }
       hasAllNullValues(allowScalar) {
-        return this.items.every((node) => {
-          if (!identity.isPair(node))
+        return this.items.every((node2) => {
+          if (!identity.isPair(node2))
             return false;
-          const n = node.value;
+          const n = node2.value;
           return n == null || allowScalar && identity.isScalar(n) && n.value == null && !n.commentBefore && !n.comment && !n.tag;
         });
       }
@@ -7809,8 +7809,8 @@ var require_Collection = __commonJS({
         const [key, ...rest] = path12;
         if (rest.length === 0)
           return this.has(key);
-        const node = this.get(key, true);
-        return identity.isCollection(node) ? node.hasIn(rest) : false;
+        const node2 = this.get(key, true);
+        return identity.isCollection(node2) ? node2.hasIn(rest) : false;
       }
       /**
        * Sets a value in this collection. For `!!set`, `value` needs to be a
@@ -7821,10 +7821,10 @@ var require_Collection = __commonJS({
         if (rest.length === 0) {
           this.set(key, value);
         } else {
-          const node = this.get(key, true);
-          if (identity.isCollection(node))
-            node.setIn(rest, value);
-          else if (node === void 0 && this.schema)
+          const node2 = this.get(key, true);
+          if (identity.isCollection(node2))
+            node2.setIn(rest, value);
+          else if (node2 === void 0 && this.schema)
             this.set(key, collectionFromPath(this.schema, rest, value));
           else
             throw new Error(`Expected YAML collection at ${key}. Remaining path: ${rest}`);
@@ -8350,16 +8350,16 @@ var require_stringify = __commonJS({
       }
       return tagObj;
     }
-    function stringifyProps(node, tagObj, { anchors: anchors$1, doc }) {
+    function stringifyProps(node2, tagObj, { anchors: anchors$1, doc }) {
       if (!doc.directives)
         return "";
       const props = [];
-      const anchor = (identity.isScalar(node) || identity.isCollection(node)) && node.anchor;
-      if (anchor && anchors.anchorIsValid(anchor)) {
-        anchors$1.add(anchor);
-        props.push(`&${anchor}`);
+      const anchor2 = (identity.isScalar(node2) || identity.isCollection(node2)) && node2.anchor;
+      if (anchor2 && anchors.anchorIsValid(anchor2)) {
+        anchors$1.add(anchor2);
+        props.push(`&${anchor2}`);
       }
-      const tag = node.tag ?? (tagObj.default ? null : tagObj.tag);
+      const tag = node2.tag ?? (tagObj.default ? null : tagObj.tag);
       if (tag)
         props.push(doc.directives.tagString(tag));
       return props.join(" ");
@@ -8381,15 +8381,15 @@ var require_stringify = __commonJS({
         }
       }
       let tagObj = void 0;
-      const node = identity.isNode(item) ? item : ctx.doc.createNode(item, { onTagObj: (o) => tagObj = o });
-      tagObj ?? (tagObj = getTagObject(ctx.doc.schema.tags, node));
-      const props = stringifyProps(node, tagObj, ctx);
+      const node2 = identity.isNode(item) ? item : ctx.doc.createNode(item, { onTagObj: (o) => tagObj = o });
+      tagObj ?? (tagObj = getTagObject(ctx.doc.schema.tags, node2));
+      const props = stringifyProps(node2, tagObj, ctx);
       if (props.length > 0)
         ctx.indentAtStart = (ctx.indentAtStart ?? 0) + props.length + 1;
-      const str = typeof tagObj.stringify === "function" ? tagObj.stringify(node, ctx, onComment, onChompKeep) : identity.isScalar(node) ? stringifyString.stringifyString(node, ctx, onComment, onChompKeep) : node.toString(ctx, onComment, onChompKeep);
+      const str = typeof tagObj.stringify === "function" ? tagObj.stringify(node2, ctx, onComment, onChompKeep) : identity.isScalar(node2) ? stringifyString.stringifyString(node2, ctx, onComment, onChompKeep) : node2.toString(ctx, onComment, onChompKeep);
       if (!props)
         return str;
-      return identity.isScalar(node) || str[0] === "{" || str[0] === "[" ? `${props} ${str}` : `${props}
+      return identity.isScalar(node2) || str[0] === "{" || str[0] === "[" ? `${props} ${str}` : `${props}
 ${ctx.indent}${str}`;
     }
     exports.createStringifyContext = createStringifyContext;
@@ -8656,8 +8656,8 @@ var require_addPairToJSMap = __commonJS({
       if (identity.isNode(key) && ctx?.doc) {
         const strCtx = stringify.createStringifyContext(ctx.doc, {});
         strCtx.anchors = /* @__PURE__ */ new Set();
-        for (const node of ctx.anchors.keys())
-          strCtx.anchors.add(node.anchor);
+        for (const node2 of ctx.anchors.keys())
+          strCtx.anchors.add(node2.anchor);
         strCtx.inFlow = true;
         strCtx.inStringifyKey = true;
         const strKey = key.toString(strCtx);
@@ -8966,8 +8966,8 @@ var require_YAMLMap = __commonJS({
       }
       get(key, keepScalar) {
         const it = findPair(this.items, key);
-        const node = it?.value;
-        return (!keepScalar && identity.isScalar(node) ? node.value : node) ?? void 0;
+        const node2 = it?.value;
+        return (!keepScalar && identity.isScalar(node2) ? node2.value : node2) ?? void 0;
       }
       has(key) {
         return !!findPair(this.items, key);
@@ -9280,9 +9280,9 @@ var require_float = __commonJS({
       format: "EXP",
       test: /^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)[eE][-+]?[0-9]+$/,
       resolve: (str) => parseFloat(str),
-      stringify(node) {
-        const num = Number(node.value);
-        return isFinite(num) ? num.toExponential() : stringifyNumber.stringifyNumber(node);
+      stringify(node2) {
+        const num = Number(node2.value);
+        return isFinite(num) ? num.toExponential() : stringifyNumber.stringifyNumber(node2);
       }
     };
     var float = {
@@ -9291,11 +9291,11 @@ var require_float = __commonJS({
       tag: "tag:yaml.org,2002:float",
       test: /^[-+]?(?:\.[0-9]+|[0-9]+\.[0-9]*)$/,
       resolve(str) {
-        const node = new Scalar.Scalar(parseFloat(str));
+        const node2 = new Scalar.Scalar(parseFloat(str));
         const dot = str.indexOf(".");
         if (dot !== -1 && str[str.length - 1] === "0")
-          node.minFractionDigits = str.length - dot - 1;
-        return node;
+          node2.minFractionDigits = str.length - dot - 1;
+        return node2;
       },
       stringify: stringifyNumber.stringifyNumber
     };
@@ -9312,11 +9312,11 @@ var require_int = __commonJS({
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
     var intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
-    function intStringify(node, radix, prefix) {
-      const { value } = node;
+    function intStringify(node2, radix, prefix) {
+      const { value } = node2;
       if (intIdentify(value) && value >= 0)
         return prefix + value.toString(radix);
-      return stringifyNumber.stringifyNumber(node);
+      return stringifyNumber.stringifyNumber(node2);
     }
     var intOct = {
       identify: (value) => intIdentify(value) && value >= 0,
@@ -9325,7 +9325,7 @@ var require_int = __commonJS({
       format: "OCT",
       test: /^0o[0-7]+$/,
       resolve: (str, _onError, opt) => intResolve(str, 2, 8, opt),
-      stringify: (node) => intStringify(node, 8, "0o")
+      stringify: (node2) => intStringify(node2, 8, "0o")
     };
     var int2 = {
       identify: intIdentify,
@@ -9342,7 +9342,7 @@ var require_int = __commonJS({
       format: "HEX",
       test: /^0x[0-9a-fA-F]+$/,
       resolve: (str, _onError, opt) => intResolve(str, 2, 16, opt),
-      stringify: (node) => intStringify(node, 16, "0x")
+      stringify: (node2) => intStringify(node2, 16, "0x")
     };
     exports.int = int2;
     exports.intHex = intHex;
@@ -9351,7 +9351,7 @@ var require_int = __commonJS({
 });
 
 // node_modules/yaml/dist/schema/core/schema.js
-var require_schema = __commonJS({
+var require_schema2 = __commonJS({
   "node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map = require_map();
@@ -9379,7 +9379,7 @@ var require_schema = __commonJS({
 });
 
 // node_modules/yaml/dist/schema/json/schema.js
-var require_schema2 = __commonJS({
+var require_schema3 = __commonJS({
   "node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
@@ -9720,9 +9720,9 @@ var require_float2 = __commonJS({
       format: "EXP",
       test: /^[-+]?(?:[0-9][0-9_]*)?(?:\.[0-9_]*)?[eE][-+]?[0-9]+$/,
       resolve: (str) => parseFloat(str.replace(/_/g, "")),
-      stringify(node) {
-        const num = Number(node.value);
-        return isFinite(num) ? num.toExponential() : stringifyNumber.stringifyNumber(node);
+      stringify(node2) {
+        const num = Number(node2.value);
+        return isFinite(num) ? num.toExponential() : stringifyNumber.stringifyNumber(node2);
       }
     };
     var float = {
@@ -9731,14 +9731,14 @@ var require_float2 = __commonJS({
       tag: "tag:yaml.org,2002:float",
       test: /^[-+]?(?:[0-9][0-9_]*)?\.[0-9_]*$/,
       resolve(str) {
-        const node = new Scalar.Scalar(parseFloat(str.replace(/_/g, "")));
+        const node2 = new Scalar.Scalar(parseFloat(str.replace(/_/g, "")));
         const dot = str.indexOf(".");
         if (dot !== -1) {
           const f = str.substring(dot + 1).replace(/_/g, "");
           if (f[f.length - 1] === "0")
-            node.minFractionDigits = f.length;
+            node2.minFractionDigits = f.length;
         }
-        return node;
+        return node2;
       },
       stringify: stringifyNumber.stringifyNumber
     };
@@ -9777,13 +9777,13 @@ var require_int2 = __commonJS({
       const n = parseInt(str, radix);
       return sign === "-" ? -1 * n : n;
     }
-    function intStringify(node, radix, prefix) {
-      const { value } = node;
+    function intStringify(node2, radix, prefix) {
+      const { value } = node2;
       if (intIdentify(value)) {
         const str = value.toString(radix);
         return value < 0 ? "-" + prefix + str.substr(1) : prefix + str;
       }
-      return stringifyNumber.stringifyNumber(node);
+      return stringifyNumber.stringifyNumber(node2);
     }
     var intBin = {
       identify: intIdentify,
@@ -9792,7 +9792,7 @@ var require_int2 = __commonJS({
       format: "BIN",
       test: /^[-+]?0b[0-1_]+$/,
       resolve: (str, _onError, opt) => intResolve(str, 2, 2, opt),
-      stringify: (node) => intStringify(node, 2, "0b")
+      stringify: (node2) => intStringify(node2, 2, "0b")
     };
     var intOct = {
       identify: intIdentify,
@@ -9801,7 +9801,7 @@ var require_int2 = __commonJS({
       format: "OCT",
       test: /^[-+]?0[0-7_]+$/,
       resolve: (str, _onError, opt) => intResolve(str, 1, 8, opt),
-      stringify: (node) => intStringify(node, 8, "0")
+      stringify: (node2) => intStringify(node2, 8, "0")
     };
     var int2 = {
       identify: intIdentify,
@@ -9818,7 +9818,7 @@ var require_int2 = __commonJS({
       format: "HEX",
       test: /^[-+]?0x[0-9a-fA-F_]+$/,
       resolve: (str, _onError, opt) => intResolve(str, 2, 16, opt),
-      stringify: (node) => intStringify(node, 16, "0x")
+      stringify: (node2) => intStringify(node2, 16, "0x")
     };
     exports.int = int2;
     exports.intBin = intBin;
@@ -9928,13 +9928,13 @@ var require_timestamp = __commonJS({
       const res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
       return sign === "-" ? num(-1) * res : res;
     }
-    function stringifySexagesimal(node) {
-      let { value } = node;
+    function stringifySexagesimal(node2) {
+      let { value } = node2;
       let num = (n) => n;
       if (typeof value === "bigint")
         num = (n) => BigInt(n);
       else if (isNaN(value) || !isFinite(value))
-        return stringifyNumber.stringifyNumber(node);
+        return stringifyNumber.stringifyNumber(node2);
       let sign = "";
       if (value < 0) {
         sign = "-";
@@ -10005,7 +10005,7 @@ var require_timestamp = __commonJS({
 });
 
 // node_modules/yaml/dist/schema/yaml-1.1/schema.js
-var require_schema3 = __commonJS({
+var require_schema4 = __commonJS({
   "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map = require_map();
@@ -10059,13 +10059,13 @@ var require_tags = __commonJS({
     var bool = require_bool();
     var float = require_float();
     var int2 = require_int();
-    var schema = require_schema();
-    var schema$1 = require_schema2();
+    var schema = require_schema2();
+    var schema$1 = require_schema3();
     var binary = require_binary();
     var merge2 = require_merge();
     var omap = require_omap();
     var pairs = require_pairs();
-    var schema$2 = require_schema3();
+    var schema$2 = require_schema4();
     var set = require_set();
     var timestamp = require_timestamp();
     var schemas = /* @__PURE__ */ new Map([
@@ -10345,13 +10345,13 @@ var require_Document = __commonJS({
        * `name` will be used as a prefix for a new unique anchor.
        * If `name` is undefined, the generated anchor will use 'a' as a prefix.
        */
-      createAlias(node, name) {
-        if (!node.anchor) {
+      createAlias(node2, name) {
+        if (!node2.anchor) {
           const prev = anchors.anchorNames(this);
-          node.anchor = // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          node2.anchor = // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           !name || prev.has(name) ? anchors.findNewAnchor(name || "a", prev) : name;
         }
-        return new Alias.Alias(node.anchor);
+        return new Alias.Alias(node2.anchor);
       }
       createNode(value, replacer, options) {
         let _replacer = void 0;
@@ -10383,11 +10383,11 @@ var require_Document = __commonJS({
           schema: this.schema,
           sourceObjects
         };
-        const node = createNode.createNode(value, tag, ctx);
-        if (flow && identity.isCollection(node))
-          node.flow = true;
+        const node2 = createNode.createNode(value, tag, ctx);
+        if (flow && identity.isCollection(node2))
+          node2.flow = true;
         setAnchors();
-        return node;
+        return node2;
       }
       /**
        * Convert a key and a value into a `Pair` using the current schema,
@@ -10564,7 +10564,7 @@ var require_Document = __commonJS({
 });
 
 // node_modules/yaml/dist/errors.js
-var require_errors2 = __commonJS({
+var require_errors3 = __commonJS({
   "node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
@@ -10641,7 +10641,7 @@ var require_resolve_props = __commonJS({
       let hasNewline = false;
       let reqSpace = false;
       let tab = null;
-      let anchor = null;
+      let anchor2 = null;
       let tag = null;
       let newlineAfterProp = null;
       let comma = null;
@@ -10688,16 +10688,16 @@ var require_resolve_props = __commonJS({
               commentSep += token.source;
             atNewline = true;
             hasNewline = true;
-            if (anchor || tag)
+            if (anchor2 || tag)
               newlineAfterProp = token;
             hasSpace = true;
             break;
           case "anchor":
-            if (anchor)
+            if (anchor2)
               onError(token, "MULTIPLE_ANCHORS", "A node can have at most one anchor");
             if (token.source.endsWith(":"))
               onError(token.offset + token.source.length - 1, "BAD_ALIAS", "Anchor ending in : is ambiguous", true);
-            anchor = token;
+            anchor2 = token;
             start ?? (start = token.offset);
             atNewline = false;
             hasSpace = false;
@@ -10714,7 +10714,7 @@ var require_resolve_props = __commonJS({
             break;
           }
           case indicator:
-            if (anchor || tag)
+            if (anchor2 || tag)
               onError(token, "BAD_PROP_ORDER", `Anchors and tags must be after the ${token.source} indicator`);
             if (found)
               onError(token, "UNEXPECTED_TOKEN", `Unexpected ${token.source} in ${flow ?? "collection"}`);
@@ -10751,7 +10751,7 @@ var require_resolve_props = __commonJS({
         spaceBefore,
         comment,
         hasNewline,
-        anchor,
+        anchor: anchor2,
         tag,
         newlineAfterProp,
         end,
@@ -10984,11 +10984,11 @@ var require_resolve_block_seq = __commonJS({
             continue;
           }
         }
-        const node = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, start, null, props, onError);
+        const node2 = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, start, null, props, onError);
         if (ctx.schema.compat)
           utilFlowIndentCheck.flowIndentCheck(bs.indent, value, onError);
-        offset = node.range[2];
-        seq.items.push(node);
+        offset = node2.range[2];
+        seq.items.push(node2);
       }
       seq.range = [bs.offset, offset, commentEnd ?? offset];
       return seq;
@@ -11260,8 +11260,8 @@ var require_compose_collection = __commonJS({
       const tagToken = props.tag;
       const tagName = !tagToken ? null : ctx.directives.tagName(tagToken.source, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg));
       if (token.type === "block-seq") {
-        const { anchor, newlineAfterProp: nl } = props;
-        const lastProp = anchor && tagToken ? anchor.offset > tagToken.offset ? anchor : tagToken : anchor ?? tagToken;
+        const { anchor: anchor2, newlineAfterProp: nl } = props;
+        const lastProp = anchor2 && tagToken ? anchor2.offset > tagToken.offset ? anchor2 : tagToken : anchor2 ?? tagToken;
         if (lastProp && (!nl || nl.offset < lastProp.offset)) {
           const message = "Missing newline after block sequence props";
           onError(lastProp, "MISSING_CHAR", message);
@@ -11288,12 +11288,12 @@ var require_compose_collection = __commonJS({
       }
       const coll = resolveCollection(CN, ctx, token, onError, tagName, tag);
       const res = tag.resolve?.(coll, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg), ctx.options) ?? coll;
-      const node = identity.isNode(res) ? res : new Scalar.Scalar(res);
-      node.range = coll.range;
-      node.tag = tagName;
+      const node2 = identity.isNode(res) ? res : new Scalar.Scalar(res);
+      node2.range = coll.range;
+      node2.tag = tagName;
       if (tag?.format)
-        node.format = tag.format;
-      return node;
+        node2.format = tag.format;
+      return node2;
     }
     exports.composeCollection = composeCollection;
   }
@@ -11826,30 +11826,30 @@ var require_compose_node = __commonJS({
     var CN = { composeNode, composeEmptyNode };
     function composeNode(ctx, token, props, onError) {
       const atKey = ctx.atKey;
-      const { spaceBefore, comment, anchor, tag } = props;
-      let node;
+      const { spaceBefore, comment, anchor: anchor2, tag } = props;
+      let node2;
       let isSrcToken = true;
       switch (token.type) {
         case "alias":
-          node = composeAlias(ctx, token, onError);
-          if (anchor || tag)
+          node2 = composeAlias(ctx, token, onError);
+          if (anchor2 || tag)
             onError(token, "ALIAS_PROPS", "An alias node must not specify any properties");
           break;
         case "scalar":
         case "single-quoted-scalar":
         case "double-quoted-scalar":
         case "block-scalar":
-          node = composeScalar.composeScalar(ctx, token, tag, onError);
-          if (anchor)
-            node.anchor = anchor.source.substring(1);
+          node2 = composeScalar.composeScalar(ctx, token, tag, onError);
+          if (anchor2)
+            node2.anchor = anchor2.source.substring(1);
           break;
         case "block-map":
         case "block-seq":
         case "flow-collection":
           try {
-            node = composeCollection.composeCollection(CN, ctx, token, props, onError);
-            if (anchor)
-              node.anchor = anchor.source.substring(1);
+            node2 = composeCollection.composeCollection(CN, ctx, token, props, onError);
+            if (anchor2)
+              node2.anchor = anchor2.source.substring(1);
           } catch (error2) {
             const message = error2 instanceof Error ? error2.message : String(error2);
             onError(token, "RESOURCE_EXHAUSTION", message);
@@ -11861,45 +11861,45 @@ var require_compose_node = __commonJS({
           isSrcToken = false;
         }
       }
-      node ?? (node = composeEmptyNode(ctx, token.offset, void 0, null, props, onError));
-      if (anchor && node.anchor === "")
-        onError(anchor, "BAD_ALIAS", "Anchor cannot be an empty string");
-      if (atKey && ctx.options.stringKeys && (!identity.isScalar(node) || typeof node.value !== "string" || node.tag && node.tag !== "tag:yaml.org,2002:str")) {
+      node2 ?? (node2 = composeEmptyNode(ctx, token.offset, void 0, null, props, onError));
+      if (anchor2 && node2.anchor === "")
+        onError(anchor2, "BAD_ALIAS", "Anchor cannot be an empty string");
+      if (atKey && ctx.options.stringKeys && (!identity.isScalar(node2) || typeof node2.value !== "string" || node2.tag && node2.tag !== "tag:yaml.org,2002:str")) {
         const msg = "With stringKeys, all keys must be strings";
         onError(tag ?? token, "NON_STRING_KEY", msg);
       }
       if (spaceBefore)
-        node.spaceBefore = true;
+        node2.spaceBefore = true;
       if (comment) {
         if (token.type === "scalar" && token.source === "")
-          node.comment = comment;
+          node2.comment = comment;
         else
-          node.commentBefore = comment;
+          node2.commentBefore = comment;
       }
       if (ctx.options.keepSourceTokens && isSrcToken)
-        node.srcToken = token;
-      return node;
+        node2.srcToken = token;
+      return node2;
     }
-    function composeEmptyNode(ctx, offset, before, pos, { spaceBefore, comment, anchor, tag, end }, onError) {
+    function composeEmptyNode(ctx, offset, before, pos, { spaceBefore, comment, anchor: anchor2, tag, end }, onError) {
       const token = {
         type: "scalar",
         offset: utilEmptyScalarPosition.emptyScalarPosition(offset, before, pos),
         indent: -1,
         source: ""
       };
-      const node = composeScalar.composeScalar(ctx, token, tag, onError);
-      if (anchor) {
-        node.anchor = anchor.source.substring(1);
-        if (node.anchor === "")
-          onError(anchor, "BAD_ALIAS", "Anchor cannot be an empty string");
+      const node2 = composeScalar.composeScalar(ctx, token, tag, onError);
+      if (anchor2) {
+        node2.anchor = anchor2.source.substring(1);
+        if (node2.anchor === "")
+          onError(anchor2, "BAD_ALIAS", "Anchor cannot be an empty string");
       }
       if (spaceBefore)
-        node.spaceBefore = true;
+        node2.spaceBefore = true;
       if (comment) {
-        node.comment = comment;
-        node.range[2] = end;
+        node2.comment = comment;
+        node2.range[2] = end;
       }
-      return node;
+      return node2;
     }
     function composeAlias({ options }, { offset, source, end }, onError) {
       const alias = new Alias.Alias(source.substring(1));
@@ -11969,7 +11969,7 @@ var require_composer = __commonJS({
     var node_process = __require("process");
     var directives = require_directives();
     var Document = require_Document();
-    var errors = require_errors2();
+    var errors = require_errors3();
     var identity = require_identity();
     var composeDoc = require_compose_doc();
     var resolveEnd = require_resolve_end();
@@ -12176,7 +12176,7 @@ var require_cst_scalar = __commonJS({
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
-    var errors = require_errors2();
+    var errors = require_errors3();
     var stringifyString = require_stringifyString();
     function resolveAsScalar(token, strict = true, onError) {
       if (token) {
@@ -14080,7 +14080,7 @@ var require_public_api = __commonJS({
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
-    var errors = require_errors2();
+    var errors = require_errors3();
     var log = require_log();
     var identity = require_identity();
     var lineCounter = require_line_counter();
@@ -14172,13 +14172,13 @@ var require_public_api = __commonJS({
 });
 
 // node_modules/yaml/dist/index.js
-var require_dist2 = __commonJS({
+var require_dist3 = __commonJS({
   "node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
     var Schema = require_Schema();
-    var errors = require_errors2();
+    var errors = require_errors3();
     var Alias = require_Alias();
     var identity = require_identity();
     var Pair = require_Pair();
@@ -14223,86 +14223,11 @@ var require_dist2 = __commonJS({
   }
 });
 
-// node_modules/zod/v4/core/core.js
-var _a;
-var NEVER = /* @__PURE__ */ Object.freeze({
-  status: "aborted"
-});
-// @__NO_SIDE_EFFECTS__
-function $constructor(name, initializer3, params) {
-  function init(inst, def) {
-    if (!inst._zod) {
-      Object.defineProperty(inst, "_zod", {
-        value: {
-          def,
-          constr: _,
-          traits: /* @__PURE__ */ new Set()
-        },
-        enumerable: false
-      });
-    }
-    if (inst._zod.traits.has(name)) {
-      return;
-    }
-    inst._zod.traits.add(name);
-    initializer3(inst, def);
-    const proto = _.prototype;
-    const keys = Object.keys(proto);
-    for (let i = 0; i < keys.length; i++) {
-      const k = keys[i];
-      if (!(k in inst)) {
-        inst[k] = proto[k].bind(inst);
-      }
-    }
-  }
-  const Parent = params?.Parent ?? Object;
-  class Definition extends Parent {
-  }
-  Object.defineProperty(Definition, "name", { value: name });
-  function _(def) {
-    var _a3;
-    const inst = params?.Parent ? new Definition() : this;
-    init(inst, def);
-    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
-    for (const fn of inst._zod.deferred) {
-      fn();
-    }
-    return inst;
-  }
-  Object.defineProperty(_, "init", { value: init });
-  Object.defineProperty(_, Symbol.hasInstance, {
-    value: (inst) => {
-      if (params?.Parent && inst instanceof params.Parent)
-        return true;
-      return inst?._zod?.traits?.has(name);
-    }
-  });
-  Object.defineProperty(_, "name", { value: name });
-  return _;
-}
-var $ZodAsyncError = class extends Error {
-  constructor() {
-    super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
-  }
-};
-var $ZodEncodeError = class extends Error {
-  constructor(name) {
-    super(`Encountered unidirectional transform during encode: ${name}`);
-    this.name = "ZodEncodeError";
-  }
-};
-(_a = globalThis).__zod_globalConfig ?? (_a.__zod_globalConfig = {});
-var globalConfig = globalThis.__zod_globalConfig;
-function config(newConfig) {
-  if (newConfig)
-    Object.assign(globalConfig, newConfig);
-  return globalConfig;
-}
-
 // node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
+  CONSTANT_CATCH: () => CONSTANT_CATCH,
   Class: () => Class,
   NUMBER_FORMAT_RANGES: () => NUMBER_FORMAT_RANGES,
   aborted: () => aborted,
@@ -14313,6 +14238,7 @@ __export(util_exports, {
   assertNever: () => assertNever,
   assertNotEqual: () => assertNotEqual,
   assignProp: () => assignProp,
+  attachSchema: () => attachSchema,
   base64ToUint8Array: () => base64ToUint8Array,
   base64urlToUint8Array: () => base64urlToUint8Array,
   cached: () => cached,
@@ -14321,8 +14247,11 @@ __export(util_exports, {
   cleanRegex: () => cleanRegex,
   clone: () => clone,
   cloneDef: () => cloneDef,
+  codePointLength: () => codePointLength,
+  constantCatch: () => constantCatch,
   createTransparentProxy: () => createTransparentProxy,
   defineLazy: () => defineLazy,
+  defineLazyInternal: () => defineLazyInternal,
   esc: () => esc,
   escapeRegex: () => escapeRegex,
   explicitlyAborted: () => explicitlyAborted,
@@ -14335,11 +14264,14 @@ __export(util_exports, {
   getParsedType: () => getParsedType,
   getSizableOrigin: () => getSizableOrigin,
   hexToUint8Array: () => hexToUint8Array,
+  hide: () => hide,
+  installLazyProp: () => installLazyProp,
   isObject: () => isObject,
   isPlainObject: () => isPlainObject,
   issue: () => issue,
   joinValues: () => joinValues,
   jsonStringifyReplacer: () => jsonStringifyReplacer,
+  members: () => members,
   merge: () => merge,
   mergeDefs: () => mergeDefs,
   normalizeParams: () => normalizeParams,
@@ -14348,6 +14280,7 @@ __export(util_exports, {
   objectClone: () => objectClone,
   omit: () => omit,
   optionalKeys: () => optionalKeys,
+  own: () => own,
   parsedType: () => parsedType,
   partial: () => partial,
   pick: () => pick,
@@ -14361,6 +14294,7 @@ __export(util_exports, {
   shallowClone: () => shallowClone,
   slugify: () => slugify,
   stringifyPrimitive: () => stringifyPrimitive,
+  toZod: () => toZod,
   uint8ArrayToBase64: () => uint8ArrayToBase64,
   uint8ArrayToBase64url: () => uint8ArrayToBase64url,
   uint8ArrayToHex: () => uint8ArrayToHex,
@@ -14371,6 +14305,9 @@ function assertEqual(val) {
 }
 function assertNotEqual(val) {
   return val;
+}
+function toZod() {
+  return (schema) => schema;
 }
 function assertIs(_arg) {
 }
@@ -14416,7 +14353,7 @@ function cleanRegex(source) {
 function floatSafeRemainder(val, step) {
   const ratio = val / step;
   const roundedRatio = Math.round(ratio);
-  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  const tolerance = 4 * Number.EPSILON * Math.max(Math.abs(ratio), 1);
   if (Math.abs(ratio - roundedRatio) < tolerance)
     return 0;
   return ratio - roundedRatio;
@@ -14672,16 +14609,16 @@ function stringifyPrimitive(value) {
 }
 function optionalKeys(shape) {
   return Object.keys(shape).filter((k) => {
-    return shape[k]._zod.optin === "optional" && shape[k]._zod.optout === "optional";
+    return shape[k]._zod.optin !== void 0 && shape[k]._zod.optout === "optional";
   });
 }
-var NUMBER_FORMAT_RANGES = {
+var NUMBER_FORMAT_RANGES = /* @__PURE__ */ (() => ({
   safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
   int32: [-2147483648, 2147483647],
   uint32: [0, 4294967295],
   float32: [-34028234663852886e22, 34028234663852886e22],
   float64: [-Number.MAX_VALUE, Number.MAX_VALUE]
-};
+}))();
 var BIGINT_FORMAT_RANGES = {
   int64: [/* @__PURE__ */ BigInt("-9223372036854775808"), /* @__PURE__ */ BigInt("9223372036854775807")],
   uint64: [/* @__PURE__ */ BigInt(0), /* @__PURE__ */ BigInt("18446744073709551615")]
@@ -14696,13 +14633,13 @@ function pick(schema, mask) {
   const def = mergeDefs(schema._zod.def, {
     get shape() {
       const newShape = {};
-      for (const key in mask) {
-        if (!(key in currDef.shape)) {
-          throw new Error(`Unrecognized key: "${key}"`);
+      for (const key of Reflect.ownKeys(mask)) {
+        if (!Object.prototype.hasOwnProperty.call(currDef.shape, key)) {
+          throw new Error(`Unrecognized key: "${String(key)}"`);
         }
         if (!mask[key])
           continue;
-        newShape[key] = currDef.shape[key];
+        assignProp(newShape, key, currDef.shape[key]);
       }
       assignProp(this, "shape", newShape);
       return newShape;
@@ -14721,9 +14658,9 @@ function omit(schema, mask) {
   const def = mergeDefs(schema._zod.def, {
     get shape() {
       const newShape = { ...schema._zod.def.shape };
-      for (const key in mask) {
-        if (!(key in currDef.shape)) {
-          throw new Error(`Unrecognized key: "${key}"`);
+      for (const key of Reflect.ownKeys(mask)) {
+        if (!Object.prototype.hasOwnProperty.call(currDef.shape, key)) {
+          throw new Error(`Unrecognized key: "${String(key)}"`);
         }
         if (!mask[key])
           continue;
@@ -14744,7 +14681,7 @@ function extend(schema, shape) {
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
     const existingShape = schema._zod.def.shape;
-    for (const key in shape) {
+    for (const key of Reflect.ownKeys(shape)) {
       if (Object.getOwnPropertyDescriptor(existingShape, key) !== void 0) {
         throw new Error("Cannot overwrite keys on object schemas containing refinements. Use `.safeExtend()` instead.");
       }
@@ -14773,6 +14710,9 @@ function safeExtend(schema, shape) {
   return clone(schema, def);
 }
 function merge(a, b) {
+  if (!b?._zod?.def) {
+    throw new Error("Invalid input to merge: expected an object schema. To merge a plain shape, use `.extend()`.");
+  }
   if (a._zod.def.checks?.length) {
     throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
   }
@@ -14789,21 +14729,21 @@ function merge(a, b) {
   });
   return clone(a, def);
 }
-function partial(Class2, schema, mask) {
+function partial(Class2, schema, mask, name = "partial") {
   const currDef = schema._zod.def;
   const checks = currDef.checks;
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
-    throw new Error(".partial() cannot be used on object schemas containing refinements");
+    throw new Error(`.${name}() cannot be used on object schemas containing refinements`);
   }
   const def = mergeDefs(schema._zod.def, {
     get shape() {
       const oldShape = schema._zod.def.shape;
       const shape = { ...oldShape };
       if (mask) {
-        for (const key in mask) {
-          if (!(key in oldShape)) {
-            throw new Error(`Unrecognized key: "${key}"`);
+        for (const key of Reflect.ownKeys(mask)) {
+          if (!Object.prototype.hasOwnProperty.call(oldShape, key)) {
+            throw new Error(`Unrecognized key: "${String(key)}"`);
           }
           if (!mask[key])
             continue;
@@ -14813,7 +14753,7 @@ function partial(Class2, schema, mask) {
           }) : oldShape[key];
         }
       } else {
-        for (const key in oldShape) {
+        for (const key of Reflect.ownKeys(oldShape)) {
           shape[key] = Class2 ? new Class2({
             type: "optional",
             innerType: oldShape[key]
@@ -14833,9 +14773,9 @@ function required(Class2, schema, mask) {
       const oldShape = schema._zod.def.shape;
       const shape = { ...oldShape };
       if (mask) {
-        for (const key in mask) {
-          if (!(key in shape)) {
-            throw new Error(`Unrecognized key: "${key}"`);
+        for (const key of Reflect.ownKeys(mask)) {
+          if (!Object.prototype.hasOwnProperty.call(shape, key)) {
+            throw new Error(`Unrecognized key: "${String(key)}"`);
           }
           if (!mask[key])
             continue;
@@ -14845,7 +14785,7 @@ function required(Class2, schema, mask) {
           });
         }
       } else {
-        for (const key in oldShape) {
+        for (const key of Reflect.ownKeys(oldShape)) {
           shape[key] = new Class2({
             type: "nonoptional",
             innerType: oldShape[key]
@@ -14889,9 +14829,24 @@ function prefixIssues(path12, issues) {
 function unwrapMessage(message) {
   return typeof message === "string" ? message : message?.message;
 }
+function attachSchema(issues, start, inst) {
+  var _a3;
+  for (let i = start; i < issues.length; i++) {
+    (_a3 = issues[i]).schema ?? (_a3.schema = inst);
+  }
+}
 function finalizeIssue(iss, ctx, config2) {
-  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
-  const { inst: _inst, continue: _continue, input: _input, ...rest } = iss;
+  var _a3;
+  const traits = iss.inst?._zod?.traits;
+  if (traits?.has("$ZodType")) {
+    if (traits.has("$ZodCheck"))
+      (_a3 = iss).schema ?? (_a3.schema = iss.inst);
+    else
+      iss.schema = iss.inst;
+  }
+  const schemaError = iss.schema !== iss.inst ? iss.schema?._zod.def?.error : void 0;
+  const message = iss.message ? iss.message : unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ?? unwrapMessage(schemaError?.(iss)) ?? unwrapMessage(ctx?.error?.(iss)) ?? unwrapMessage(config2.customError?.(iss)) ?? unwrapMessage(config2.localeError?.(iss)) ?? "Invalid input";
+  const { inst: _inst, schema: _schema, continue: _continue, input: _input, ...rest } = iss;
   rest.path ?? (rest.path = []);
   rest.message = message;
   if (ctx?.reportInput) {
@@ -14907,6 +14862,20 @@ function getSizableOrigin(input) {
   if (input instanceof File)
     return "file";
   return "unknown";
+}
+var highSurrogate = /[\uD800-\uDBFF]/;
+function codePointLength(str) {
+  const units = str.length;
+  if (!highSurrogate.test(str))
+    return units;
+  let count = units;
+  for (let i = 0; i < units - 1; i++) {
+    if ((str.charCodeAt(i) & 64512) === 55296 && (str.charCodeAt(i + 1) & 64512) === 56320) {
+      count--;
+      i++;
+    }
+  }
+  return count;
 }
 function getLengthableOrigin(input) {
   if (Array.isArray(input))
@@ -14994,33 +14963,289 @@ var Class = class {
   constructor(..._args) {
   }
 };
+function members(proto, table) {
+  for (const key in table) {
+    const desc = Object.getOwnPropertyDescriptor(table, key);
+    if (desc.get)
+      Object.defineProperty(proto, key, { ...desc, enumerable: false });
+    else
+      defineBound(proto, key, desc.value);
+  }
+}
+function own(inst, key, value, enumerable = true) {
+  Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable, value });
+  return value;
+}
+function hide(inst, key, value) {
+  return own(inst, key, value, false);
+}
+function defineBound(proto, key, fn) {
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    get() {
+      return this == null ? fn : own(this, key, fn.bind(this));
+    },
+    set(value) {
+      own(this, key, value);
+    }
+  });
+}
+function claim(inst, sentinel) {
+  const proto = Object.getPrototypeOf(inst);
+  return sentinel in proto ? void 0 : proto;
+}
+var installing;
+var broke = false;
+var breaker = {
+  configurable: true,
+  get() {
+    broke = true;
+    return void 0;
+  }
+};
+function defineLazyInternal(inst, key, compute) {
+  const proto = Object.getPrototypeOf(inst._zod);
+  if (key in proto && installing !== inst._zod) {
+    installing = void 0;
+    return;
+  }
+  installing = inst._zod;
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    get() {
+      Object.defineProperty(this, key, breaker);
+      const outer = broke;
+      broke = false;
+      try {
+        const value = compute(this);
+        if (broke)
+          delete this[key];
+        else
+          Object.defineProperty(this, key, { configurable: true, writable: true, value });
+        broke = broke || outer;
+        return value;
+      } catch (err) {
+        delete this[key];
+        broke = broke || outer;
+        throw err;
+      }
+    },
+    set(value) {
+      Object.defineProperty(this, key, { configurable: true, writable: true, value });
+    }
+  });
+}
+function installLazyProp(inst, key, make, enumerable) {
+  const proto = claim(inst, key);
+  if (!proto)
+    return;
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    get() {
+      const desc = { configurable: true, writable: true, enumerable, value: void 0 };
+      Object.defineProperty(this, key, desc);
+      desc.value = make(this);
+      Object.defineProperty(this, key, desc);
+      return desc.value;
+    },
+    set(value) {
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable, value });
+    }
+  });
+}
+var CONSTANT_CATCH = "~constantCatch";
+function constantCatch(value) {
+  const fn = () => value;
+  fn[CONSTANT_CATCH] = true;
+  return fn;
+}
+
+// node_modules/zod/v4/core/core.js
+var _a;
+var NEVER = /* @__PURE__ */ Object.freeze({
+  status: "aborted"
+});
+var _zodDesc = { value: void 0, enumerable: false };
+var _E = "captureStackTrace" in Error ? Error : null;
+function newError(Definition) {
+  const E = _E;
+  if (E) {
+    const saved = E.stackTraceLimit;
+    if (typeof saved === "number") {
+      try {
+        E.stackTraceLimit = 0;
+      } catch {
+        _E = null;
+        return new Definition();
+      }
+      try {
+        return new Definition();
+      } finally {
+        E.stackTraceLimit = saved;
+      }
+    }
+  }
+  return new Definition();
+}
+// @__NO_SIDE_EFFECTS__
+function $constructor(name, initializer3, proto, params) {
+  const zodProto = {};
+  function Internals(def) {
+    this.def = def;
+    this.constr = _;
+    this.traits = /* @__PURE__ */ new Set();
+  }
+  Internals.prototype = zodProto;
+  const protoMembers = proto;
+  const initialized = protoMembers && /* @__PURE__ */ new WeakSet();
+  function init(inst, def) {
+    if (!inst._zod) {
+      _zodDesc.value = new Internals(def);
+      try {
+        Object.defineProperty(inst, "_zod", _zodDesc);
+      } finally {
+        _zodDesc.value = void 0;
+      }
+    }
+    if (inst._zod.traits.has(name)) {
+      return;
+    }
+    inst._zod.traits.add(name);
+    initializer3(inst, def);
+    if (initialized) {
+      const own2 = Object.getPrototypeOf(inst);
+      const ctorProto = inst._zod.constr.prototype;
+      let up = own2;
+      while (up && up !== ctorProto)
+        up = Object.getPrototypeOf(up);
+      const target = up ?? own2;
+      if (!initialized.has(target)) {
+        initialized.add(target);
+        members(target, protoMembers);
+      }
+    }
+    const proto2 = _.prototype;
+    for (const k in proto2) {
+      if (!Object.prototype.hasOwnProperty.call(proto2, k))
+        continue;
+      if (!(k in inst)) {
+        inst[k] = proto2[k].bind(inst);
+      }
+    }
+  }
+  const Parent = params?.Parent ?? Object;
+  class Definition extends Parent {
+  }
+  Object.defineProperty(Definition, "name", { value: name });
+  function _(def) {
+    const inst = params?.Parent ? newError(Definition) : this;
+    init(inst, def);
+    const deferred = inst._zod.deferred;
+    if (deferred) {
+      for (const fn of deferred) {
+        fn();
+      }
+      inst._zod.deferred = void 0;
+    }
+    const pp = globalThis.__zod_globalConfig?.postProcessor;
+    if (pp)
+      pp(inst);
+    return inst;
+  }
+  Object.defineProperty(_, "init", { value: init });
+  Object.defineProperty(_, Symbol.hasInstance, {
+    value: (inst) => {
+      if (params?.Parent && inst instanceof params.Parent)
+        return true;
+      return inst?._zod?.traits?.has(name);
+    }
+  });
+  Object.defineProperty(_, "name", { value: name });
+  return _;
+}
+var $ZodAsyncError = class extends Error {
+  constructor() {
+    super(`Encountered Promise during synchronous parse. Use .parseAsync() instead.`);
+  }
+};
+var $ZodEncodeError = class extends Error {
+  constructor(name) {
+    super(`Encountered unidirectional transform during encode: ${name}`);
+    this.name = "ZodEncodeError";
+  }
+};
+(_a = globalThis).__zod_globalConfig ?? (_a.__zod_globalConfig = {});
+var globalConfig = globalThis.__zod_globalConfig;
+function config(newConfig) {
+  if (newConfig)
+    Object.assign(globalConfig, newConfig);
+  return globalConfig;
+}
 
 // node_modules/zod/v4/core/errors.js
+function _getMessage() {
+  const internals = this._zod;
+  internals.message ?? (internals.message = JSON.stringify(internals.def, jsonStringifyReplacer, 2));
+  return internals.message;
+}
+function _setMessage(value) {
+  this._zod.message = value;
+}
+var _messageDesc = {
+  get: _getMessage,
+  set: _setMessage,
+  enumerable: true,
+  configurable: true
+};
+var _zodDesc2 = { value: void 0, enumerable: false };
+var _issuesDesc = { value: void 0, enumerable: false };
+var _installedToString = /* @__PURE__ */ new WeakSet([Object.prototype, Error.prototype]);
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
-  Object.defineProperty(inst, "_zod", {
-    value: inst._zod,
-    enumerable: false
-  });
-  Object.defineProperty(inst, "issues", {
-    value: def,
-    enumerable: false
-  });
-  inst.message = JSON.stringify(def, jsonStringifyReplacer, 2);
-  Object.defineProperty(inst, "toString", {
-    value: () => inst.message,
-    enumerable: false
-  });
+  _zodDesc2.value = inst._zod;
+  Object.defineProperty(inst, "_zod", _zodDesc2);
+  _issuesDesc.value = def;
+  Object.defineProperty(inst, "issues", _issuesDesc);
+  _zodDesc2.value = void 0;
+  _issuesDesc.value = void 0;
+  Object.defineProperty(inst, "message", _messageDesc);
+  const proto = Object.getPrototypeOf(inst);
+  if (!_installedToString.has(proto)) {
+    _installedToString.add(proto);
+    Object.defineProperty(proto, "toString", {
+      configurable: true,
+      enumerable: false,
+      get() {
+        const value = () => this.message;
+        Object.defineProperty(this, "toString", { value, configurable: true, writable: true });
+        return value;
+      },
+      set(value) {
+        Object.defineProperty(this, "toString", { value, configurable: true, writable: true });
+      }
+    });
+  }
 };
 var $ZodError = $constructor("$ZodError", initializer);
-var $ZodRealError = $constructor("$ZodError", initializer, { Parent: Error });
+var $ZodRealError = $constructor("$ZodError", initializer, void 0, {
+  Parent: Error
+});
+function node(obj, key, make) {
+  if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (key === "__proto__") {
+      Object.defineProperty(obj, key, { value: make(), writable: true, enumerable: true, configurable: true });
+    } else {
+      obj[key] = make();
+    }
+  }
+  return obj[key];
+}
 function flattenError(error2, mapper = (issue2) => issue2.message) {
   const fieldErrors = {};
   const formErrors = [];
   for (const sub of error2.issues) {
     if (sub.path.length > 0) {
-      fieldErrors[sub.path[0]] = fieldErrors[sub.path[0]] || [];
-      fieldErrors[sub.path[0]].push(mapper(sub));
+      node(fieldErrors, sub.path[0], () => []).push(mapper(sub));
     } else {
       formErrors.push(mapper(sub));
     }
@@ -15047,13 +15272,25 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
           while (i < fullpath.length) {
             const el = fullpath[i];
             const terminal = i === fullpath.length - 1;
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
-              curr[el]._errors.push(mapper(issue2));
+            if (el === "_errors") {
+              if (terminal)
+                curr._errors.push(mapper(issue2));
+              i++;
+              continue;
             }
-            curr = curr[el];
+            if (!Object.prototype.hasOwnProperty.call(curr, el)) {
+              Object.defineProperty(curr, el, {
+                value: { _errors: [] },
+                enumerable: true,
+                writable: true,
+                configurable: true
+              });
+            }
+            const node2 = curr[el];
+            if (terminal) {
+              node2._errors.push(mapper(issue2));
+            }
+            curr = node2;
             i++;
           }
         }
@@ -15065,30 +15302,39 @@ function formatError(error2, mapper = (issue2) => issue2.message) {
 }
 
 // node_modules/zod/v4/core/parse.js
-var _parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
-  const result = schema._zod.run({ value, issues: [] }, ctx);
-  if (result instanceof Promise) {
-    throw new $ZodAsyncError();
-  }
-  if (result.issues.length) {
-    const e = new (_params?.Err ?? _Err)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())));
-    captureStackTrace(e, _params?.callee);
-    throw e;
-  }
-  return result.value;
+function finalizeParams(callee, params) {
+  return { callee: params?.callee ?? callee, Err: params?.Err };
+}
+var _parse = (_Err) => {
+  const fn = (schema, value, _ctx, _params) => {
+    const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
+    const result = schema._zod.run({ value, issues: [] }, ctx);
+    if (result instanceof Promise) {
+      throw new $ZodAsyncError();
+    }
+    if (result.issues.length) {
+      const e = new (_params?.Err ?? _Err)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())));
+      captureStackTrace(e, _params?.callee ?? fn);
+      throw e;
+    }
+    return result.value;
+  };
+  return fn;
 };
-var _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
-  let result = schema._zod.run({ value, issues: [] }, ctx);
-  if (result instanceof Promise)
-    result = await result;
-  if (result.issues.length) {
-    const e = new (params?.Err ?? _Err)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())));
-    captureStackTrace(e, params?.callee);
-    throw e;
-  }
-  return result.value;
+var _parseAsync = (_Err) => {
+  const fn = async (schema, value, _ctx, params) => {
+    const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
+    let result = schema._zod.run({ value, issues: [] }, ctx);
+    if (result instanceof Promise)
+      result = await result;
+    if (result.issues.length) {
+      const e = new (params?.Err ?? _Err)(result.issues.map((iss) => finalizeIssue(iss, ctx, config())));
+      captureStackTrace(e, params?.callee ?? fn);
+      throw e;
+    }
+    return result.value;
+  };
+  return fn;
 };
 var _safeParse = (_Err) => (schema, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
@@ -15113,19 +15359,35 @@ var _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
   } : { success: true, data: result.value };
 };
 var safeParseAsync = /* @__PURE__ */ _safeParseAsync($ZodRealError);
-var _encode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
-  return _parse(_Err)(schema, value, ctx);
+var _encode = (_Err) => {
+  const parse3 = _parse(_Err);
+  const fn = (schema, value, _ctx, _params) => {
+    const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+    return parse3(schema, value, ctx, finalizeParams(fn, _params));
+  };
+  return fn;
 };
-var _decode = (_Err) => (schema, value, _ctx) => {
-  return _parse(_Err)(schema, value, _ctx);
+var _decode = (_Err) => {
+  const parse3 = _parse(_Err);
+  const fn = (schema, value, _ctx, _params) => {
+    return parse3(schema, value, _ctx, finalizeParams(fn, _params));
+  };
+  return fn;
 };
-var _encodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
-  return _parseAsync(_Err)(schema, value, ctx);
+var _encodeAsync = (_Err) => {
+  const parseAsync3 = _parseAsync(_Err);
+  const fn = async (schema, value, _ctx, _params) => {
+    const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
+    return await parseAsync3(schema, value, ctx, finalizeParams(fn, _params));
+  };
+  return fn;
 };
-var _decodeAsync = (_Err) => async (schema, value, _ctx) => {
-  return _parseAsync(_Err)(schema, value, _ctx);
+var _decodeAsync = (_Err) => {
+  const parseAsync3 = _parseAsync(_Err);
+  const fn = async (schema, value, _ctx, _params) => {
+    return await parseAsync3(schema, value, _ctx, finalizeParams(fn, _params));
+  };
+  return fn;
 };
 var _safeEncode = (_Err) => (schema, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
@@ -15145,10 +15407,13 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
 // node_modules/zod/v4/core/regexes.js
 var cuid = /^[cC][0-9a-z]{6,}$/;
 var cuid2 = /^[0-9a-z]+$/;
-var ulid = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
+var ulid = /^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$/;
 var xid = /^[0-9a-vA-V]{20}$/;
 var ksuid = /^[A-Za-z0-9]{27}$/;
 var nanoid = /^[a-zA-Z0-9_-]{21}$/;
+function nanoidOfLength(length) {
+  return new RegExp(`^[a-zA-Z0-9_-]{${length}}$`);
+}
 var duration = /^P(?:(\d+W)|(?!.*W)(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+([.,]\d+)?S)?)?)$/;
 var guid = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
 var uuid = (version2) => {
@@ -15157,36 +15422,37 @@ var uuid = (version2) => {
   return new RegExp(`^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-${version2}[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$`);
 };
 var email = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/;
-var _emoji = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
+var _emoji = `^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$`;
 function emoji() {
   return new RegExp(_emoji, "u");
 }
 var ipv4 = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
 var ipv6 = /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))$/;
 var cidrv4 = /^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/([0-9]|[1-2][0-9]|3[0-2])$/;
-var cidrv6 = /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
+var cidrv6 = /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
 var base64 = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/;
 var base64url = /^[A-Za-z0-9_-]*$/;
 var httpProtocol = /^https?$/;
 var e164 = /^\+[1-9]\d{6,14}$/;
 var dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`;
-var date = /* @__PURE__ */ new RegExp(`^${dateSource}$`);
+function anchor(source) {
+  return new RegExp(`^${source}$`);
+}
+var date = /* @__PURE__ */ anchor(dateSource);
 function timeSource(args) {
   const hhmm = `(?:[01]\\d|2[0-3]):[0-5]\\d`;
-  const regex = typeof args.precision === "number" ? args.precision === -1 ? `${hhmm}` : args.precision === 0 ? `${hhmm}:[0-5]\\d` : `${hhmm}:[0-5]\\d\\.\\d{${args.precision}}` : `${hhmm}(?::[0-5]\\d(?:\\.\\d+)?)?`;
+  const regex = typeof args.precision === "number" ? args.precision === -1 ? `${hhmm}` : args.precision === 0 ? `${hhmm}:[0-5]\\d` : `${hhmm}:[0-5]\\d\\.\\d{${args.precision}}` : args.seconds ? `${hhmm}:[0-5]\\d(?:\\.\\d+)?` : `${hhmm}(?::[0-5]\\d(?:\\.\\d+)?)?`;
   return regex;
 }
 function time(args) {
   return new RegExp(`^${timeSource(args)}$`);
 }
 function datetime(args) {
-  const time3 = timeSource({ precision: args.precision });
   const opts = ["Z"];
-  if (args.local)
-    opts.push("");
   if (args.offset)
     opts.push(`([+-](?:[01]\\d|2[0-3]):[0-5]\\d)`);
-  const timeRegex = `${time3}(?:${opts.join("|")})`;
+  const qualified = `${timeSource({ precision: args.precision, seconds: true })}(?:${opts.join("|")})`;
+  const timeRegex = args.local ? `${qualified}|${timeSource({ precision: args.precision })}` : qualified;
   return new RegExp(`^${dateSource}T(?:${timeRegex})$`);
 }
 var string = (params) => {
@@ -15208,6 +15474,10 @@ var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   inst._zod.def = def;
   (_a3 = inst._zod).onattach ?? (_a3.onattach = []);
 });
+var _whenHasLength = (payload) => {
+  const val = payload.value;
+  return !nullish(val) && val.length !== void 0;
+};
 var numericOriginMap = {
   number: "number",
   bigint: "bigint",
@@ -15231,7 +15501,7 @@ var $ZodCheckLessThan = /* @__PURE__ */ $constructor("$ZodCheckLessThan", (inst,
       return;
     }
     payload.issues.push({
-      origin,
+      origin: numericOriginMap[typeof payload.value] ?? origin,
       code: "too_big",
       maximum: typeof def.value === "object" ? def.value.getTime() : def.value,
       input: payload.value,
@@ -15259,7 +15529,7 @@ var $ZodCheckGreaterThan = /* @__PURE__ */ $constructor("$ZodCheckGreaterThan", 
       return;
     }
     payload.issues.push({
-      origin,
+      origin: numericOriginMap[typeof payload.value] ?? origin,
       code: "too_small",
       minimum: typeof def.value === "object" ? def.value.getTime() : def.value,
       input: payload.value,
@@ -15278,7 +15548,10 @@ var $ZodCheckMultipleOf = /* @__PURE__ */ $constructor("$ZodCheckMultipleOf", (i
   inst._zod.check = (payload) => {
     if (typeof payload.value !== typeof def.value)
       throw new Error("Cannot mix number and bigint in multiple_of check.");
-    const isMultiple = typeof payload.value === "bigint" ? payload.value % def.value === BigInt(0) : floatSafeRemainder(payload.value, def.value) === 0;
+    const isMultiple = typeof payload.value === "bigint" ? (
+      // `value % 0n` throws, and nothing is a multiple of zero — the number branch already fails this way via NaN
+      def.value !== BigInt(0) && payload.value % def.value === BigInt(0)
+    ) : floatSafeRemainder(payload.value, def.value) === 0;
     if (isMultiple)
       return;
     payload.issues.push({
@@ -15373,10 +15646,7 @@ var $ZodCheckNumberFormat = /* @__PURE__ */ $constructor("$ZodCheckNumberFormat"
 var $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (inst, def) => {
   var _a3;
   $ZodCheck.init(inst, def);
-  (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
-    const val = payload.value;
-    return !nullish(val) && val.length !== void 0;
-  });
+  (_a3 = inst._zod.def).when ?? (_a3.when = _whenHasLength);
   inst._zod.onattach.push((inst2) => {
     const curr = inst2._zod.bag.maximum ?? Number.POSITIVE_INFINITY;
     if (def.maximum < curr)
@@ -15384,7 +15654,8 @@ var $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (ins
   });
   inst._zod.check = (payload) => {
     const input = payload.value;
-    const length = input.length;
+    const units = input.length;
+    const length = typeof input === "string" && units > def.maximum ? codePointLength(input) : units;
     if (length <= def.maximum)
       return;
     const origin = getLengthableOrigin(input);
@@ -15402,10 +15673,7 @@ var $ZodCheckMaxLength = /* @__PURE__ */ $constructor("$ZodCheckMaxLength", (ins
 var $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (inst, def) => {
   var _a3;
   $ZodCheck.init(inst, def);
-  (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
-    const val = payload.value;
-    return !nullish(val) && val.length !== void 0;
-  });
+  (_a3 = inst._zod.def).when ?? (_a3.when = _whenHasLength);
   inst._zod.onattach.push((inst2) => {
     const curr = inst2._zod.bag.minimum ?? Number.NEGATIVE_INFINITY;
     if (def.minimum > curr)
@@ -15413,7 +15681,8 @@ var $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (ins
   });
   inst._zod.check = (payload) => {
     const input = payload.value;
-    const length = input.length;
+    const units = input.length;
+    const length = typeof input === "string" && units >= def.minimum && units < def.minimum * 2 ? codePointLength(input) : units;
     if (length >= def.minimum)
       return;
     const origin = getLengthableOrigin(input);
@@ -15431,10 +15700,7 @@ var $ZodCheckMinLength = /* @__PURE__ */ $constructor("$ZodCheckMinLength", (ins
 var $ZodCheckLengthEquals = /* @__PURE__ */ $constructor("$ZodCheckLengthEquals", (inst, def) => {
   var _a3;
   $ZodCheck.init(inst, def);
-  (_a3 = inst._zod.def).when ?? (_a3.when = (payload) => {
-    const val = payload.value;
-    return !nullish(val) && val.length !== void 0;
-  });
+  (_a3 = inst._zod.def).when ?? (_a3.when = _whenHasLength);
   inst._zod.onattach.push((inst2) => {
     const bag = inst2._zod.bag;
     bag.minimum = def.length;
@@ -15443,7 +15709,8 @@ var $ZodCheckLengthEquals = /* @__PURE__ */ $constructor("$ZodCheckLengthEquals"
   });
   inst._zod.check = (payload) => {
     const input = payload.value;
-    const length = input.length;
+    const units = input.length;
+    const length = typeof input === "string" && units >= def.length && units <= def.length * 2 ? codePointLength(input) : units;
     if (length === def.length)
       return;
     const origin = getLengthableOrigin(input);
@@ -15517,7 +15784,7 @@ var $ZodCheckUpperCase = /* @__PURE__ */ $constructor("$ZodCheckUpperCase", (ins
 var $ZodCheckIncludes = /* @__PURE__ */ $constructor("$ZodCheckIncludes", (inst, def) => {
   $ZodCheck.init(inst, def);
   const escapedRegex = escapeRegex(def.includes);
-  const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position}}${escapedRegex}` : escapedRegex);
+  const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position},}${escapedRegex}` : escapedRegex);
   def.pattern = pattern;
   inst._zod.onattach.push((inst2) => {
     const bag = inst2._zod.bag;
@@ -15593,11 +15860,11 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
 
 // node_modules/zod/v4/core/doc.js
 var Doc = class {
-  constructor(args = []) {
+  constructor(args = [], closed = {}) {
     this.content = [];
     this.indent = 0;
-    if (this)
-      this.args = args;
+    this.args = args;
+    this.closed = closed;
   }
   indented(fn) {
     this.indent += 1;
@@ -15620,18 +15887,19 @@ var Doc = class {
   }
   compile() {
     const F = Function;
-    const args = this?.args;
     const content = this?.content ?? [``];
-    const lines = [...content.map((x) => `  ${x}`)];
-    return new F(...args, lines.join("\n"));
+    const factory = new F(...Object.keys(this.closed), `return function (${this.args.join(", ")}) {
+${content.join("\n")}
+};`);
+    return factory(...Object.values(this.closed));
   }
 };
 
 // node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
-  minor: 4,
-  patch: 3
+  minor: 5,
+  patch: 4
 };
 
 // node_modules/zod/v4/core/schemas.js
@@ -15641,10 +15909,8 @@ var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   inst._zod.def = def;
   inst._zod.bag = inst._zod.bag || {};
   inst._zod.version = version;
-  const checks = [...inst._zod.def.checks ?? []];
-  if (inst._zod.traits.has("$ZodCheck")) {
-    checks.unshift(inst);
-  }
+  const defChecks = inst._zod.def.checks;
+  const checks = inst._zod.traits.has("$ZodCheck") ? [inst, ...defChecks ?? []] : defChecks?.length ? [...defChecks] : [];
   for (const ch of checks) {
     for (const fn of ch._zod.onattach) {
       fn(inst);
@@ -15657,6 +15923,8 @@ var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
     });
   } else {
     const runChecks = (payload, checks2, ctx) => {
+      if (payload.memo)
+        return payload;
       let isAborted = aborted(payload);
       let asyncResult;
       for (const ch of checks2) {
@@ -15680,6 +15948,7 @@ var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
             const nextLen = payload.issues.length;
             if (nextLen === currLen)
               return;
+            attachSchema(payload.issues, currLen, inst);
             if (!isAborted)
               isAborted = aborted(payload, currLen);
           });
@@ -15687,6 +15956,7 @@ var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
           const nextLen = payload.issues.length;
           if (nextLen === currLen)
             continue;
+          attachSchema(payload.issues, currLen, inst);
           if (!isAborted)
             isAborted = aborted(payload, currLen);
         }
@@ -15733,19 +16003,29 @@ var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
       return runChecks(result, checks, ctx);
     };
   }
-  defineLazy(inst, "~standard", () => ({
+}, {
+  // Wrappers extend this by installing a richer factory over it; reading it eagerly would defeat the laziness.
+  get "~standard"() {
+    return hide(this, "~standard", standardProps(this));
+  },
+  set "~standard"(value) {
+    own(this, "~standard", value);
+  }
+});
+var toStandardResult = (r) => r.success ? { value: r.data } : { issues: r.error?.issues };
+function standardProps(inst) {
+  return {
     validate: (value) => {
       try {
-        const r = safeParse(inst, value);
-        return r.success ? { value: r.data } : { issues: r.error?.issues };
+        return toStandardResult(safeParse(inst, value));
       } catch (_) {
-        return safeParseAsync(inst, value).then((r) => r.success ? { value: r.data } : { issues: r.error?.issues });
+        return safeParseAsync(inst, value).then(toStandardResult);
       }
     },
     vendor: "zod",
     version: 1
-  }));
-});
+  };
+}
 var $ZodString = /* @__PURE__ */ $constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
   inst._zod.pattern = [...inst?._zod.bag?.patterns ?? []].pop() ?? string(inst._zod.bag);
@@ -15798,58 +16078,80 @@ var $ZodEmail = /* @__PURE__ */ $constructor("$ZodEmail", (inst, def) => {
   def.pattern ?? (def.pattern = email);
   $ZodStringFormat.init(inst, def);
 });
+var URL_BAD_FORMAT = 1;
+var URL_UNPARSEABLE = 2;
+function parseURLObject(trimmed, def) {
+  if (!def.normalize && def.protocol?.source === httpProtocol.source && !/^https?:\/\//i.test(trimmed)) {
+    return URL_BAD_FORMAT;
+  }
+  try {
+    return new URL(trimmed);
+  } catch {
+    return URL_UNPARSEABLE;
+  }
+}
+var asciiTabOrNewline = /[\t\n\r]/g;
+function stripTabAndNewline(value) {
+  return value.replace(asciiTabOrNewline, "");
+}
+function urlHostnameOk(url2, hostname) {
+  hostname.lastIndex = 0;
+  return hostname.test(url2.hostname);
+}
+function urlProtocolOk(url2, protocol) {
+  protocol.lastIndex = 0;
+  return protocol.test(url2.protocol.endsWith(":") ? url2.protocol.slice(0, -1) : url2.protocol);
+}
 var $ZodURL = /* @__PURE__ */ $constructor("$ZodURL", (inst, def) => {
   $ZodStringFormat.init(inst, def);
   inst._zod.check = (payload) => {
     try {
       const trimmed = payload.value.trim();
-      if (!def.normalize && def.protocol?.source === httpProtocol.source) {
-        if (!/^https?:\/\//i.test(trimmed)) {
-          payload.issues.push({
-            code: "invalid_format",
-            format: "url",
-            note: "Invalid URL format",
-            input: payload.value,
-            inst,
-            continue: !def.abort
-          });
-          return;
-        }
+      const url2 = parseURLObject(trimmed, def);
+      if (url2 === URL_BAD_FORMAT) {
+        payload.issues.push({
+          code: "invalid_format",
+          format: "url",
+          note: "Invalid URL format",
+          input: payload.value,
+          inst,
+          continue: !def.abort
+        });
+        return;
       }
-      const url2 = new URL(trimmed);
-      if (def.hostname) {
-        def.hostname.lastIndex = 0;
-        if (!def.hostname.test(url2.hostname)) {
-          payload.issues.push({
-            code: "invalid_format",
-            format: "url",
-            note: "Invalid hostname",
-            pattern: def.hostname.source,
-            input: payload.value,
-            inst,
-            continue: !def.abort
-          });
-        }
+      if (url2 === URL_UNPARSEABLE) {
+        payload.issues.push({
+          code: "invalid_format",
+          format: "url",
+          input: payload.value,
+          inst,
+          continue: !def.abort
+        });
+        return;
       }
-      if (def.protocol) {
-        def.protocol.lastIndex = 0;
-        if (!def.protocol.test(url2.protocol.endsWith(":") ? url2.protocol.slice(0, -1) : url2.protocol)) {
-          payload.issues.push({
-            code: "invalid_format",
-            format: "url",
-            note: "Invalid protocol",
-            pattern: def.protocol.source,
-            input: payload.value,
-            inst,
-            continue: !def.abort
-          });
-        }
+      if (def.hostname && !urlHostnameOk(url2, def.hostname)) {
+        payload.issues.push({
+          code: "invalid_format",
+          format: "url",
+          note: "Invalid hostname",
+          pattern: def.hostname.source,
+          input: payload.value,
+          inst,
+          continue: !def.abort
+        });
       }
-      if (def.normalize) {
-        payload.value = url2.href;
-      } else {
-        payload.value = trimmed;
+      if (def.protocol && !urlProtocolOk(url2, def.protocol)) {
+        payload.issues.push({
+          code: "invalid_format",
+          format: "url",
+          note: "Invalid protocol",
+          pattern: def.protocol.source,
+          input: payload.value,
+          inst,
+          continue: !def.abort
+        });
       }
+      payload.value = def.normalize ? url2.href : stripTabAndNewline(trimmed);
       return;
     } catch (_) {
       payload.issues.push({
@@ -15867,7 +16169,9 @@ var $ZodEmoji = /* @__PURE__ */ $constructor("$ZodEmoji", (inst, def) => {
   $ZodStringFormat.init(inst, def);
 });
 var $ZodNanoID = /* @__PURE__ */ $constructor("$ZodNanoID", (inst, def) => {
-  def.pattern ?? (def.pattern = nanoid);
+  if (def.length !== void 0 && (!Number.isInteger(def.length) || def.length < 1))
+    throw new Error(`Invalid nanoid length: ${def.length}`);
+  def.pattern ?? (def.pattern = def.length === void 0 ? nanoid : nanoidOfLength(def.length));
   $ZodStringFormat.init(inst, def);
 });
 var $ZodCUID = /* @__PURE__ */ $constructor("$ZodCUID", (inst, def) => {
@@ -15893,6 +16197,12 @@ var $ZodKSUID = /* @__PURE__ */ $constructor("$ZodKSUID", (inst, def) => {
 var $ZodISODateTime = /* @__PURE__ */ $constructor("$ZodISODateTime", (inst, def) => {
   def.pattern ?? (def.pattern = datetime(def));
   $ZodStringFormat.init(inst, def);
+  if (def.local || def.precision === -1) {
+    inst._zod.bag.laxFormat = true;
+    inst._zod.onattach.push((s) => {
+      s._zod.bag.laxFormat = true;
+    });
+  }
 });
 var $ZodISODate = /* @__PURE__ */ $constructor("$ZodISODate", (inst, def) => {
   def.pattern ?? (def.pattern = date);
@@ -15911,14 +16221,23 @@ var $ZodIPv4 = /* @__PURE__ */ $constructor("$ZodIPv4", (inst, def) => {
   $ZodStringFormat.init(inst, def);
   inst._zod.bag.format = `ipv4`;
 });
+var ipv6Alphabet = /^[0-9a-fA-F:.]+$/;
+function isValidIPv6(value) {
+  if (!ipv6Alphabet.test(value))
+    return false;
+  try {
+    new URL(`http://[${value}]`);
+    return true;
+  } catch {
+    return false;
+  }
+}
 var $ZodIPv6 = /* @__PURE__ */ $constructor("$ZodIPv6", (inst, def) => {
   def.pattern ?? (def.pattern = ipv6);
   $ZodStringFormat.init(inst, def);
   inst._zod.bag.format = `ipv6`;
   inst._zod.check = (payload) => {
-    try {
-      new URL(`http://[${payload.value}]`);
-    } catch {
+    if (!isValidIPv6(payload.value)) {
       payload.issues.push({
         code: "invalid_format",
         format: "ipv6",
@@ -15933,24 +16252,25 @@ var $ZodCIDRv4 = /* @__PURE__ */ $constructor("$ZodCIDRv4", (inst, def) => {
   def.pattern ?? (def.pattern = cidrv4);
   $ZodStringFormat.init(inst, def);
 });
+function isValidCIDRv6(value) {
+  const parts = value.split("/");
+  if (parts.length !== 2)
+    return false;
+  const [address, prefix] = parts;
+  if (!prefix)
+    return false;
+  const prefixNum = Number(prefix);
+  if (`${prefixNum}` !== prefix)
+    return false;
+  if (prefixNum < 0 || prefixNum > 128)
+    return false;
+  return isValidIPv6(address);
+}
 var $ZodCIDRv6 = /* @__PURE__ */ $constructor("$ZodCIDRv6", (inst, def) => {
   def.pattern ?? (def.pattern = cidrv6);
   $ZodStringFormat.init(inst, def);
   inst._zod.check = (payload) => {
-    const parts = payload.value.split("/");
-    try {
-      if (parts.length !== 2)
-        throw new Error();
-      const [address, prefix] = parts;
-      if (!prefix)
-        throw new Error();
-      const prefixNum = Number(prefix);
-      if (`${prefixNum}` !== prefix)
-        throw new Error();
-      if (prefixNum < 0 || prefixNum > 128)
-        throw new Error();
-      new URL(`http://[${address}]`);
-    } catch {
+    if (!isValidCIDRv6(payload.value)) {
       payload.issues.push({
         code: "invalid_format",
         format: "cidrv6",
@@ -16065,7 +16385,7 @@ var $ZodNumber = /* @__PURE__ */ $constructor("$ZodNumber", (inst, def) => {
     if (typeof input === "number" && !Number.isNaN(input) && Number.isFinite(input)) {
       return payload;
     }
-    const received = typeof input === "number" ? Number.isNaN(input) ? "NaN" : !Number.isFinite(input) ? "Infinity" : void 0 : void 0;
+    const received = typeof input === "number" ? Number.isNaN(input) ? "NaN" : !Number.isFinite(input) ? String(input) : void 0 : void 0;
     payload.issues.push({
       expected: "number",
       code: "invalid_type",
@@ -16190,6 +16510,8 @@ function handleArrayResult(result, final, index) {
 }
 var $ZodArray = /* @__PURE__ */ $constructor("$ZodArray", (inst, def) => {
   $ZodType.init(inst, def);
+  const memo3 = globalConfig.memoizer;
+  memo3?.attach(inst);
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
     if (!Array.isArray(input)) {
@@ -16201,7 +16523,7 @@ var $ZodArray = /* @__PURE__ */ $constructor("$ZodArray", (inst, def) => {
       });
       return payload;
     }
-    payload.value = Array(input.length);
+    payload.value = memo3 ? memo3.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms = [];
     for (let i = 0; i < input.length; i++) {
       const item = input[i];
@@ -16221,15 +16543,19 @@ var $ZodArray = /* @__PURE__ */ $constructor("$ZodArray", (inst, def) => {
     return payload;
   };
 });
-function handlePropertyResult(result, final, key, input, isOptionalIn, isOptionalOut) {
+function handlePropertyResult(result, final, key, input, optin, optout) {
   const isPresent = key in input;
+  const isOptionalOut = optout === "optional";
+  if (!isPresent && isOptionalOut && optin === "optional") {
+    return;
+  }
   if (result.issues.length) {
-    if (isOptionalIn && isOptionalOut && !isPresent) {
+    if (optin !== void 0 && isOptionalOut && !isPresent) {
       return;
     }
     final.issues.push(...prefixIssues(key, result.issues));
   }
-  if (!isPresent && !isOptionalIn) {
+  if (!isPresent && optin === void 0) {
     if (!result.issues.length) {
       final.issues.push({
         code: "invalid_type",
@@ -16248,17 +16574,23 @@ function handlePropertyResult(result, final, key, input, isOptionalIn, isOptiona
     final.value[key] = result.value;
   }
 }
+var NO_SYMBOL_KEYS = [];
 function normalizeDef(def) {
   const keys = Object.keys(def.shape);
-  for (const k of keys) {
+  const ownSymbols = Object.getOwnPropertySymbols(def.shape);
+  const symbolKeys = ownSymbols.length ? ownSymbols : NO_SYMBOL_KEYS;
+  const allKeys = symbolKeys.length ? [...keys, ...symbolKeys] : keys;
+  for (const k of allKeys) {
     if (!def.shape?.[k]?._zod?.traits?.has("$ZodType")) {
-      throw new Error(`Invalid element at key "${k}": expected a Zod schema`);
+      throw new Error(`Invalid element at key "${String(k)}": expected a Zod schema`);
     }
   }
   const okeys = optionalKeys(def.shape);
   return {
     ...def,
-    keys,
+    allKeys,
+    symbolKeys,
+    // string-only: handleCatchall matches it against `for...in`, which never yields a symbol
     keySet: new Set(keys),
     numKeys: keys.length,
     optionalKeys: new Set(okeys)
@@ -16269,22 +16601,25 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
   const keySet = def.keySet;
   const _catchall = def.catchall._zod;
   const t = _catchall.def.type;
-  const isOptionalIn = _catchall.optin === "optional";
-  const isOptionalOut = _catchall.optout === "optional";
+  const optin = _catchall.optin;
+  const optout = _catchall.optout;
   for (const key in input) {
-    if (key === "__proto__")
-      continue;
     if (keySet.has(key))
       continue;
+    if (key === "__proto__") {
+      if (t === "never")
+        unrecognized.push(key);
+      continue;
+    }
     if (t === "never") {
       unrecognized.push(key);
       continue;
     }
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
     if (r instanceof Promise) {
-      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
+      proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, optin, optout)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, optin, optout);
     }
   }
   if (unrecognized.length) {
@@ -16292,7 +16627,9 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
       code: "unrecognized_keys",
       keys: unrecognized,
       input,
-      inst
+      inst,
+      // Describes the shape of the input, not the validity of the parsed value, so it never aborts. The parse still fails; the schema's own checks just get to run first, and an enclosing intersection can reconcile the key against a sibling operand.
+      continue: true
     });
   }
   if (!proms.length)
@@ -16301,31 +16638,38 @@ function handleCatchall(proms, input, payload, ctx, def, inst) {
     return payload;
   });
 }
+var propShapes = /* @__PURE__ */ new WeakMap();
 var $ZodObject = /* @__PURE__ */ $constructor("$ZodObject", (inst, def) => {
   $ZodType.init(inst, def);
   const desc = Object.getOwnPropertyDescriptor(def, "shape");
   if (!desc?.get) {
     const sh = def.shape;
+    propShapes.set(def, sh);
     Object.defineProperty(def, "shape", {
       get: () => {
         const newSh = { ...sh };
         Object.defineProperty(def, "shape", {
           value: newSh
         });
+        propShapes.set(def, newSh);
         return newSh;
       }
     });
   }
   const _normalized = cached(() => normalizeDef(def));
-  defineLazy(inst._zod, "propValues", () => {
-    const shape = def.shape;
+  defineLazyInternal(inst, "propValues", (zod) => {
+    const shape = zod.def.shape;
     const propValues = {};
     for (const key in shape) {
       const field = shape[key]._zod;
       if (field.values) {
-        propValues[key] ?? (propValues[key] = /* @__PURE__ */ new Set());
+        if (!Object.prototype.hasOwnProperty.call(propValues, key)) {
+          assignProp(propValues, key, /* @__PURE__ */ new Set());
+        }
         for (const v of field.values)
           propValues[key].add(v);
+        if (field.optin !== void 0)
+          propValues[key].add(void 0);
       }
     }
     return propValues;
@@ -16333,6 +16677,8 @@ var $ZodObject = /* @__PURE__ */ $constructor("$ZodObject", (inst, def) => {
   const isObject2 = isObject;
   const catchall = def.catchall;
   let value;
+  const memo3 = globalConfig.memoizer;
+  memo3?.attach(inst);
   inst._zod.parse = (payload, ctx) => {
     value ?? (value = _normalized.value);
     const input = payload.value;
@@ -16345,18 +16691,20 @@ var $ZodObject = /* @__PURE__ */ $constructor("$ZodObject", (inst, def) => {
       });
       return payload;
     }
-    payload.value = {};
+    payload.value = memo3 ? memo3.alloc(inst, payload, {}, ctx) : {};
     const proms = [];
     const shape = value.shape;
-    for (const key of value.keys) {
+    for (const key of value.allKeys) {
+      if (key === "__proto__")
+        continue;
       const el = shape[key];
-      const isOptionalIn = el._zod.optin === "optional";
-      const isOptionalOut = el._zod.optout === "optional";
+      const optin = el._zod.optin;
+      const optout = el._zod.optout;
       const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
-        proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, isOptionalIn, isOptionalOut)));
+        proms.push(r.then((r2) => handlePropertyResult(r2, payload, key, input, optin, optout)));
       } else {
-        handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+        handlePropertyResult(r, payload, key, input, optin, optout);
       }
     }
     if (!catchall) {
@@ -16369,55 +16717,54 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
   $ZodObject.init(inst, def);
   const superParse = inst._zod.parse;
   const _normalized = cached(() => normalizeDef(def));
+  const memo3 = globalConfig.memoizer;
   const generateFastpass = (shape) => {
-    const doc = new Doc(["shape", "payload", "ctx"]);
     const normalized = _normalized.value;
-    const parseStr = (key) => {
-      const k = esc(key);
-      return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
-    };
+    const syms = normalized.symbolKeys;
+    const doc = new Doc(["payload", "ctx"], { shape, inst, memo: memo3, syms });
+    const parseStr = (k) => `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
+    const prefixStr = (id, k) => `
+          for (let i = 0; i < ${id}.issues.length; i++) {
+            const iss = ${id}.issues[i];
+            iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
+            payload.issues.push(iss);
+          }`;
     doc.write(`const input = payload.value;`);
     const ids = /* @__PURE__ */ Object.create(null);
     let counter = 0;
-    for (const key of normalized.keys) {
+    for (const key of normalized.allKeys) {
       ids[key] = `key_${counter++}`;
     }
-    doc.write(`const newResult = {};`);
-    for (const key of normalized.keys) {
+    doc.write(memo3 ? `const newResult = memo.alloc(inst, payload, {}, ctx);` : `const newResult = {};`);
+    for (const key of normalized.allKeys) {
+      if (key === "__proto__")
+        continue;
       const id = ids[key];
-      const k = esc(key);
+      const k = typeof key === "symbol" ? `syms[${syms.indexOf(key)}]` : esc(key);
+      const isPresent = `${k} in input`;
       const schema = shape[key];
-      const isOptionalIn = schema?._zod?.optin === "optional";
+      const optin = schema?._zod?.optin;
+      const isOptionalIn = optin !== void 0;
       const isOptionalOut = schema?._zod?.optout === "optional";
-      doc.write(`const ${id} = ${parseStr(key)};`);
+      doc.write(`const ${id} = ${parseStr(k)};`);
       if (isOptionalIn && isOptionalOut) {
+        const assign = optin === "optional" ? `${id}_present` : `${id}.value !== undefined || ${id}_present`;
         doc.write(`
-        if (${id}.issues.length) {
-          if (${k} in input) {
-            payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-              ...iss,
-              path: iss.path ? [${k}, ...iss.path] : [${k}]
-            })));
+        const ${id}_present = ${isPresent};
+        if (!${id}.issues.length || ${id}_present) {
+          if (${id}.issues.length) {${prefixStr(id, k)}
+          }
+
+          if (${assign}) {
+            newResult[${k}] = ${id}.value;
           }
         }
-        
-        if (${id}.value === undefined) {
-          if (${k} in input) {
-            newResult[${k}] = undefined;
-          }
-        } else {
-          newResult[${k}] = ${id}.value;
-        }
-        
+
       `);
       } else if (!isOptionalIn) {
         doc.write(`
-        const ${id}_present = ${k} in input;
-        if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
+        const ${id}_present = ${isPresent};
+        if (${id}.issues.length) {${prefixStr(id, k)}
         }
         if (!${id}_present && !${id}.issues.length) {
           payload.issues.push({
@@ -16429,38 +16776,29 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
         }
 
         if (${id}_present) {
-          if (${id}.value === undefined) {
-            newResult[${k}] = undefined;
-          } else {
-            newResult[${k}] = ${id}.value;
-          }
+          newResult[${k}] = ${id}.value;
         }
 
       `);
       } else {
         doc.write(`
-        if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
+        if (${id}.issues.length) {${prefixStr(id, k)}
         }
         
         if (${id}.value === undefined) {
-          if (${k} in input) {
+          if (${isPresent}) {
             newResult[${k}] = undefined;
           }
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
       }
     }
     doc.write(`payload.value = newResult;`);
     doc.write(`return payload;`);
-    const fn = doc.compile();
-    return (payload, ctx) => fn(shape, payload, ctx);
+    return doc.compile();
   };
   let fastpass;
   const isObject2 = isObject;
@@ -16514,17 +16852,17 @@ function handleUnionResults(results, final, inst, ctx) {
 }
 var $ZodUnion = /* @__PURE__ */ $constructor("$ZodUnion", (inst, def) => {
   $ZodType.init(inst, def);
-  defineLazy(inst._zod, "optin", () => def.options.some((o) => o._zod.optin === "optional") ? "optional" : void 0);
-  defineLazy(inst._zod, "optout", () => def.options.some((o) => o._zod.optout === "optional") ? "optional" : void 0);
-  defineLazy(inst._zod, "values", () => {
-    if (def.options.every((o) => o._zod.values)) {
-      return new Set(def.options.flatMap((option) => Array.from(option._zod.values)));
+  defineLazyInternal(inst, "optin", (zod) => zod.def.options.some((o) => o._zod.optin === "defaulted") ? "defaulted" : zod.def.options.some((o) => o._zod.optin !== void 0) ? "optional" : void 0);
+  defineLazyInternal(inst, "optout", (zod) => zod.def.options.some((o) => o._zod.optout === "optional") ? "optional" : void 0);
+  defineLazyInternal(inst, "values", (zod) => {
+    if (zod.def.options.every((o) => o._zod.values)) {
+      return new Set(zod.def.options.flatMap((option) => Array.from(option._zod.values)));
     }
     return void 0;
   });
-  defineLazy(inst._zod, "pattern", () => {
-    if (def.options.every((o) => o._zod.pattern)) {
-      const patterns = def.options.map((o) => o._zod.pattern);
+  defineLazyInternal(inst, "pattern", (zod) => {
+    if (zod.def.options.every((o) => o._zod.pattern)) {
+      const patterns = zod.def.options.map((o) => o._zod.pattern);
       return new RegExp(`^(${patterns.map((p) => cleanRegex(p.source)).join("|")})$`);
     }
     return void 0;
@@ -16561,21 +16899,28 @@ var $ZodDiscriminatedUnion = /* @__PURE__ */ $constructor("$ZodDiscriminatedUnio
   def.inclusive = false;
   $ZodUnion.init(inst, def);
   const _super = inst._zod.parse;
-  defineLazy(inst._zod, "propValues", () => {
+  defineLazyInternal(inst, "propValues", (zod) => {
     const propValues = {};
-    for (const option of def.options) {
+    for (const option of zod.def.options) {
       const pv = option._zod.propValues;
       if (!pv || Object.keys(pv).length === 0)
-        throw new Error(`Invalid discriminated union option at index "${def.options.indexOf(option)}"`);
+        throw new Error(`Invalid discriminated union option at index "${zod.def.options.indexOf(option)}"`);
       for (const [k, v] of Object.entries(pv)) {
-        if (!propValues[k])
-          propValues[k] = /* @__PURE__ */ new Set();
+        if (!Object.prototype.hasOwnProperty.call(propValues, k)) {
+          assignProp(propValues, k, /* @__PURE__ */ new Set());
+        }
         for (const val of v) {
           propValues[k].add(val);
         }
       }
     }
     return propValues;
+  });
+  def.options.forEach((option, i) => {
+    const propShape = propShapes.get(option._zod.def);
+    if (propShape && !Object.prototype.hasOwnProperty.call(propShape, def.discriminator)) {
+      throw new Error(`Invalid discriminated union option at index "${i}"`);
+    }
   });
   const disc = cached(() => {
     const opts = def.options;
@@ -16650,7 +16995,11 @@ function mergeValues(a, b) {
     const bKeys = Object.keys(b);
     const sharedKeys = Object.keys(a).filter((key) => bKeys.indexOf(key) !== -1);
     const newObj = { ...a, ...b };
+    if (Object.prototype.hasOwnProperty.call(newObj, "__proto__"))
+      delete newObj.__proto__;
     for (const key of sharedKeys) {
+      if (key === "__proto__")
+        continue;
       const sharedValue = mergeValues(a[key], b[key]);
       if (!sharedValue.valid) {
         return {
@@ -16686,37 +17035,49 @@ function mergeValues(a, b) {
 function handleIntersectionResults(result, left, right) {
   const unrecKeys = /* @__PURE__ */ new Map();
   let unrecIssue;
-  for (const iss of left.issues) {
-    if (iss.code === "unrecognized_keys") {
+  const keyIssues = /* @__PURE__ */ new Map();
+  const collect = (iss, side) => {
+    let keys;
+    if (iss.code === "unrecognized_keys" && !iss.path?.length) {
       unrecIssue ?? (unrecIssue = iss);
-      for (const k of iss.keys) {
-        if (!unrecKeys.has(k))
-          unrecKeys.set(k, {});
-        unrecKeys.get(k).l = true;
-      }
+      keys = iss.keys;
+    } else if (iss.code === "invalid_key" && iss.origin === "record" && iss.path?.length === 1) {
+      const k = String(iss.path[0]);
+      if (!keyIssues.has(k))
+        keyIssues.set(k, iss);
+      keys = [k];
     } else {
-      result.issues.push(iss);
+      return false;
     }
+    for (const k of keys) {
+      if (!unrecKeys.has(k))
+        unrecKeys.set(k, {});
+      unrecKeys.get(k)[side] = true;
+    }
+    return true;
+  };
+  for (const iss of left.issues) {
+    if (!collect(iss, "l"))
+      result.issues.push(iss);
   }
   for (const iss of right.issues) {
-    if (iss.code === "unrecognized_keys") {
-      for (const k of iss.keys) {
-        if (!unrecKeys.has(k))
-          unrecKeys.set(k, {});
-        unrecKeys.get(k).r = true;
-      }
-    } else {
+    if (!collect(iss, "r"))
       result.issues.push(iss);
-    }
   }
   const bothKeys = [...unrecKeys].filter(([, f]) => f.l && f.r).map(([k]) => k);
-  if (bothKeys.length && unrecIssue) {
-    result.issues.push({ ...unrecIssue, keys: bothKeys });
+  if (bothKeys.length) {
+    const aggregated = unrecIssue ? bothKeys.filter((k) => unrecIssue.keys.includes(k)) : [];
+    if (aggregated.length)
+      result.issues.push({ ...unrecIssue, keys: aggregated });
+    for (const k of bothKeys) {
+      if (!aggregated.includes(k) && keyIssues.has(k))
+        result.issues.push(keyIssues.get(k));
+    }
   }
-  if (aborted(result))
-    return result;
   const merged = mergeValues(left.value, right.value);
   if (!merged.valid) {
+    if (aborted(result))
+      return result;
     throw new Error(`Unmergable intersection. Error path: ${JSON.stringify(merged.mergeErrorPath)}`);
   }
   result.value = merged.data;
@@ -16724,6 +17085,8 @@ function handleIntersectionResults(result, left, right) {
 }
 var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
   $ZodType.init(inst, def);
+  const memo3 = globalConfig.memoizer;
+  memo3?.attach(inst);
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
     if (!isPlainObject(input)) {
@@ -16737,12 +17100,14 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
     }
     const proms = [];
     const values = def.keyType._zod.values;
-    if (values) {
-      payload.value = {};
+    if (values && !def.partial) {
+      payload.value = memo3 ? memo3.alloc(inst, payload, {}, ctx) : {};
       const recordKeys = /* @__PURE__ */ new Set();
       for (const key of values) {
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
           recordKeys.add(typeof key === "number" ? key.toString() : key);
+          if (key === "__proto__")
+            continue;
           const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
             throw new Error("Async schemas not supported in object keys currently");
@@ -16759,6 +17124,8 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
             continue;
           }
           const outKey = keyResult.value;
+          if (outKey === "__proto__")
+            continue;
           const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
           if (result instanceof Promise) {
             proms.push(result.then((result2) => {
@@ -16778,8 +17145,14 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
       let unrecognized;
       for (const key in input) {
         if (!recordKeys.has(key)) {
-          unrecognized = unrecognized ?? [];
-          unrecognized.push(key);
+          if (def.mode === "loose") {
+            if (key === "__proto__")
+              continue;
+            payload.value[key] = input[key];
+          } else {
+            unrecognized = unrecognized ?? [];
+            unrecognized.push(key);
+          }
         }
       }
       if (unrecognized && unrecognized.length > 0) {
@@ -16787,11 +17160,13 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
           code: "unrecognized_keys",
           input,
           inst,
-          keys: unrecognized
+          keys: unrecognized,
+          continue: true
         });
       }
     } else {
-      payload.value = {};
+      payload.value = memo3 ? memo3.alloc(inst, payload, {}, ctx) : {};
+      let unrecognized;
       for (const key of Reflect.ownKeys(input)) {
         if (key === "__proto__")
           continue;
@@ -16814,6 +17189,9 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
         if (keyResult.issues.length) {
           if (def.mode === "loose") {
             payload.value[key] = input[key];
+          } else if (values) {
+            unrecognized = unrecognized ?? [];
+            unrecognized.push(key);
           } else {
             payload.issues.push({
               code: "invalid_key",
@@ -16826,20 +17204,32 @@ var $ZodRecord = /* @__PURE__ */ $constructor("$ZodRecord", (inst, def) => {
           }
           continue;
         }
+        const outKey = keyResult.value;
+        if (outKey === "__proto__")
+          continue;
         const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
         if (result instanceof Promise) {
           proms.push(result.then((result2) => {
             if (result2.issues.length) {
               payload.issues.push(...prefixIssues(key, result2.issues));
             }
-            payload.value[keyResult.value] = result2.value;
+            payload.value[outKey] = result2.value;
           }));
         } else {
           if (result.issues.length) {
             payload.issues.push(...prefixIssues(key, result.issues));
           }
-          payload.value[keyResult.value] = result.value;
+          payload.value[outKey] = result.value;
         }
+      }
+      if (unrecognized && unrecognized.length > 0) {
+        payload.issues.push({
+          code: "unrecognized_keys",
+          input,
+          inst,
+          keys: unrecognized,
+          continue: true
+        });
       }
     }
     if (proms.length) {
@@ -16853,7 +17243,8 @@ var $ZodEnum = /* @__PURE__ */ $constructor("$ZodEnum", (inst, def) => {
   const values = getEnumValues(def.entries);
   const valuesSet = new Set(values);
   inst._zod.values = valuesSet;
-  inst._zod.pattern = new RegExp(`^(${values.filter((k) => propertyKeyTypes.has(typeof k)).map((o) => typeof o === "string" ? escapeRegex(o) : o.toString()).join("|")})$`);
+  const patternValues = values.filter((k) => propertyKeyTypes.has(typeof k));
+  inst._zod.pattern = new RegExp(patternValues.length ? `^(${patternValues.map((o) => escapeRegex(o.toString())).join("|")})$` : "^[^\\s\\S]$");
   inst._zod.parse = (payload, _ctx) => {
     const input = payload.value;
     if (valuesSet.has(input)) {
@@ -16870,12 +17261,9 @@ var $ZodEnum = /* @__PURE__ */ $constructor("$ZodEnum", (inst, def) => {
 });
 var $ZodLiteral = /* @__PURE__ */ $constructor("$ZodLiteral", (inst, def) => {
   $ZodType.init(inst, def);
-  if (def.values.length === 0) {
-    throw new Error("Cannot create literal schema with no valid values");
-  }
   const values = new Set(def.values);
   inst._zod.values = values;
-  inst._zod.pattern = new RegExp(`^(${def.values.map((o) => typeof o === "string" ? escapeRegex(o) : o ? escapeRegex(o.toString()) : String(o)).join("|")})$`);
+  inst._zod.pattern = new RegExp(def.values.length ? `^(${def.values.map((o) => typeof o === "string" ? escapeRegex(o) : o ? escapeRegex(o.toString()) : String(o)).join("|")})$` : "^[^\\s\\S]$");
   inst._zod.parse = (payload, _ctx) => {
     const input = payload.value;
     if (values.has(input)) {
@@ -16893,6 +17281,7 @@ var $ZodLiteral = /* @__PURE__ */ $constructor("$ZodLiteral", (inst, def) => {
 var $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) => {
   $ZodType.init(inst, def);
   inst._zod.optin = "optional";
+  globalConfig.memoizer?.guard(inst);
   inst._zod.parse = (payload, ctx) => {
     if (ctx.direction === "backward") {
       throw new $ZodEncodeError(inst.constructor.name);
@@ -16902,7 +17291,6 @@ var $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) =>
       const output = _out instanceof Promise ? _out : Promise.resolve(_out);
       return output.then((output2) => {
         payload.value = output2;
-        payload.fallback = true;
         return payload;
       });
     }
@@ -16910,59 +17298,55 @@ var $ZodTransform = /* @__PURE__ */ $constructor("$ZodTransform", (inst, def) =>
       throw new $ZodAsyncError();
     }
     payload.value = _out;
-    payload.fallback = true;
     return payload;
   };
 });
-function handleOptionalResult(result, input) {
-  if (input === void 0 && (result.issues.length || result.fallback)) {
-    return { issues: [], value: void 0 };
-  }
-  return result;
+function handleOptionalResult(payload, result) {
+  payload.value = result.issues.length ? void 0 : result.value;
+  return payload;
 }
 var $ZodOptional = /* @__PURE__ */ $constructor("$ZodOptional", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.optin = "optional";
+  defineLazyInternal(inst, "optin", (zod) => zod.def.innerType._zod.optin === "defaulted" ? "defaulted" : "optional");
   inst._zod.optout = "optional";
-  defineLazy(inst._zod, "values", () => {
-    return def.innerType._zod.values ? /* @__PURE__ */ new Set([...def.innerType._zod.values, void 0]) : void 0;
+  defineLazyInternal(inst, "values", (zod) => {
+    const values = zod.def.innerType._zod.values;
+    return values ? /* @__PURE__ */ new Set([...values, void 0]) : void 0;
   });
-  defineLazy(inst._zod, "pattern", () => {
-    const pattern = def.innerType._zod.pattern;
+  defineLazyInternal(inst, "pattern", (zod) => {
+    const pattern = zod.def.innerType._zod.pattern;
     return pattern ? new RegExp(`^(${cleanRegex(pattern.source)})?$`) : void 0;
   });
   inst._zod.parse = (payload, ctx) => {
-    if (def.innerType._zod.optin === "optional") {
-      const input = payload.value;
-      const result = def.innerType._zod.run(payload, ctx);
-      if (result instanceof Promise)
-        return result.then((r) => handleOptionalResult(r, input));
-      return handleOptionalResult(result, input);
-    }
     if (payload.value === void 0) {
-      return payload;
+      if (def.innerType._zod.optin !== "defaulted")
+        return payload;
+      const result = def.innerType._zod.run({ value: payload.value, issues: [] }, ctx);
+      if (result instanceof Promise)
+        return result.then((result2) => handleOptionalResult(payload, result2));
+      return handleOptionalResult(payload, result);
     }
     return def.innerType._zod.run(payload, ctx);
   };
 });
 var $ZodExactOptional = /* @__PURE__ */ $constructor("$ZodExactOptional", (inst, def) => {
   $ZodOptional.init(inst, def);
-  defineLazy(inst._zod, "values", () => def.innerType._zod.values);
-  defineLazy(inst._zod, "pattern", () => def.innerType._zod.pattern);
+  defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
+  defineLazyInternal(inst, "pattern", (zod) => zod.def.innerType._zod.pattern);
   inst._zod.parse = (payload, ctx) => {
     return def.innerType._zod.run(payload, ctx);
   };
 });
 var $ZodNullable = /* @__PURE__ */ $constructor("$ZodNullable", (inst, def) => {
   $ZodType.init(inst, def);
-  defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
-  defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
-  defineLazy(inst._zod, "pattern", () => {
-    const pattern = def.innerType._zod.pattern;
+  defineLazyInternal(inst, "optin", (zod) => zod.def.innerType._zod.optin);
+  defineLazyInternal(inst, "optout", (zod) => zod.def.innerType._zod.optout);
+  defineLazyInternal(inst, "pattern", (zod) => {
+    const pattern = zod.def.innerType._zod.pattern;
     return pattern ? new RegExp(`^(${cleanRegex(pattern.source)}|null)$`) : void 0;
   });
-  defineLazy(inst._zod, "values", () => {
-    return def.innerType._zod.values ? /* @__PURE__ */ new Set([...def.innerType._zod.values, null]) : void 0;
+  defineLazyInternal(inst, "values", (zod) => {
+    return zod.def.innerType._zod.values ? /* @__PURE__ */ new Set([...zod.def.innerType._zod.values, null]) : void 0;
   });
   inst._zod.parse = (payload, ctx) => {
     if (payload.value === null)
@@ -16972,8 +17356,8 @@ var $ZodNullable = /* @__PURE__ */ $constructor("$ZodNullable", (inst, def) => {
 });
 var $ZodDefault = /* @__PURE__ */ $constructor("$ZodDefault", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.optin = "optional";
-  defineLazy(inst._zod, "values", () => def.innerType._zod.values);
+  inst._zod.optin = "defaulted";
+  defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
   inst._zod.parse = (payload, ctx) => {
     if (ctx.direction === "backward") {
       return def.innerType._zod.run(payload, ctx);
@@ -16997,8 +17381,8 @@ function handleDefaultResult(payload, def) {
 }
 var $ZodPrefault = /* @__PURE__ */ $constructor("$ZodPrefault", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.optin = "optional";
-  defineLazy(inst._zod, "values", () => def.innerType._zod.values);
+  inst._zod.optin = "defaulted";
+  defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
   inst._zod.parse = (payload, ctx) => {
     if (ctx.direction === "backward") {
       return def.innerType._zod.run(payload, ctx);
@@ -17011,8 +17395,8 @@ var $ZodPrefault = /* @__PURE__ */ $constructor("$ZodPrefault", (inst, def) => {
 });
 var $ZodNonOptional = /* @__PURE__ */ $constructor("$ZodNonOptional", (inst, def) => {
   $ZodType.init(inst, def);
-  defineLazy(inst._zod, "values", () => {
-    const v = def.innerType._zod.values;
+  defineLazyInternal(inst, "values", (zod) => {
+    const v = zod.def.innerType._zod.values;
     return v ? new Set([...v].filter((x) => x !== void 0)) : void 0;
   });
   inst._zod.parse = (payload, ctx) => {
@@ -17034,54 +17418,45 @@ function handleNonOptionalResult(payload, inst) {
   }
   return payload;
 }
+function handleCatchResult(payload, result, def, ctx) {
+  if (!result.issues.length) {
+    payload.value = result.value;
+    if (result.memo)
+      payload.memo = true;
+    return payload;
+  }
+  payload.value = def.catchValue({
+    ...result,
+    value: payload.value,
+    error: {
+      issues: result.issues.map((iss) => finalizeIssue(iss, ctx, config()))
+    },
+    input: payload.value
+  });
+  return payload;
+}
 var $ZodCatch = /* @__PURE__ */ $constructor("$ZodCatch", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.optin = "optional";
-  defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
-  defineLazy(inst._zod, "values", () => def.innerType._zod.values);
+  defineLazyInternal(inst, "optin", (zod) => zod.def.innerType._zod.optin === "defaulted" ? "defaulted" : "optional");
+  defineLazyInternal(inst, "optout", (zod) => zod.def.innerType._zod.optout);
+  defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
   inst._zod.parse = (payload, ctx) => {
     if (ctx.direction === "backward") {
       return def.innerType._zod.run(payload, ctx);
     }
-    const result = def.innerType._zod.run(payload, ctx);
+    const result = def.innerType._zod.run({ value: payload.value, issues: [] }, ctx);
     if (result instanceof Promise) {
-      return result.then((result2) => {
-        payload.value = result2.value;
-        if (result2.issues.length) {
-          payload.value = def.catchValue({
-            ...payload,
-            error: {
-              issues: result2.issues.map((iss) => finalizeIssue(iss, ctx, config()))
-            },
-            input: payload.value
-          });
-          payload.issues = [];
-          payload.fallback = true;
-        }
-        return payload;
-      });
+      return result.then((result2) => handleCatchResult(payload, result2, def, ctx));
     }
-    payload.value = result.value;
-    if (result.issues.length) {
-      payload.value = def.catchValue({
-        ...payload,
-        error: {
-          issues: result.issues.map((iss) => finalizeIssue(iss, ctx, config()))
-        },
-        input: payload.value
-      });
-      payload.issues = [];
-      payload.fallback = true;
-    }
-    return payload;
+    return handleCatchResult(payload, result, def, ctx);
   };
 });
 var $ZodPipe = /* @__PURE__ */ $constructor("$ZodPipe", (inst, def) => {
   $ZodType.init(inst, def);
-  defineLazy(inst._zod, "values", () => def.in._zod.values);
-  defineLazy(inst._zod, "optin", () => def.in._zod.optin);
-  defineLazy(inst._zod, "optout", () => def.out._zod.optout);
-  defineLazy(inst._zod, "propValues", () => def.in._zod.propValues);
+  defineLazyInternal(inst, "values", (zod) => zod.def.in._zod.values);
+  defineLazyInternal(inst, "optin", (zod) => zod.def.in._zod.optin);
+  defineLazyInternal(inst, "optout", (zod) => zod.def.out._zod.optout);
+  defineLazyInternal(inst, "propValues", (zod) => zod.def.in._zod.propValues);
   inst._zod.parse = (payload, ctx) => {
     if (ctx.direction === "backward") {
       const right = def.out._zod.run(payload, ctx);
@@ -17098,21 +17473,21 @@ var $ZodPipe = /* @__PURE__ */ $constructor("$ZodPipe", (inst, def) => {
   };
 });
 function handlePipeResult(left, next, ctx) {
-  if (left.issues.length) {
+  if (left.issues.some((iss) => iss.code !== "unrecognized_keys")) {
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
 }
 var $ZodPreprocess = /* @__PURE__ */ $constructor("$ZodPreprocess", (inst, def) => {
   $ZodPipe.init(inst, def);
 });
 var $ZodReadonly = /* @__PURE__ */ $constructor("$ZodReadonly", (inst, def) => {
   $ZodType.init(inst, def);
-  defineLazy(inst._zod, "propValues", () => def.innerType._zod.propValues);
-  defineLazy(inst._zod, "values", () => def.innerType._zod.values);
-  defineLazy(inst._zod, "optin", () => def.innerType?._zod?.optin);
-  defineLazy(inst._zod, "optout", () => def.innerType?._zod?.optout);
+  defineLazyInternal(inst, "propValues", (zod) => zod.def.innerType._zod.propValues);
+  defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
+  defineLazyInternal(inst, "optin", (zod) => zod.def.innerType?._zod?.optin);
+  defineLazyInternal(inst, "optout", (zod) => zod.def.innerType?._zod?.optout);
   inst._zod.parse = (payload, ctx) => {
     if (ctx.direction === "backward") {
       return def.innerType._zod.run(payload, ctx);
@@ -17125,9 +17500,27 @@ var $ZodReadonly = /* @__PURE__ */ $constructor("$ZodReadonly", (inst, def) => {
   };
 });
 function handleReadonlyResult(payload) {
-  payload.value = Object.freeze(payload.value);
+  if (!payload.memo)
+    payload.value = Object.freeze(payload.value);
   return payload;
 }
+var $ZodLazy = /* @__PURE__ */ $constructor("$ZodLazy", (inst, def) => {
+  $ZodType.init(inst, def);
+  defineLazy(inst._zod, "innerType", () => {
+    const d = def;
+    if (!d._cachedInner)
+      d._cachedInner = def.getter();
+    return d._cachedInner;
+  });
+  defineLazyInternal(inst, "pattern", (zod) => zod.innerType?._zod?.pattern);
+  defineLazyInternal(inst, "propValues", (zod) => zod.innerType?._zod?.propValues);
+  defineLazyInternal(inst, "optin", (zod) => zod.innerType?._zod?.optin ?? void 0);
+  defineLazyInternal(inst, "optout", (zod) => zod.innerType?._zod?.optout ?? void 0);
+  inst._zod.parse = (payload, ctx) => {
+    const inner = inst._zod.innerType;
+    return inner._zod.run(payload, ctx);
+  };
+});
 var $ZodCustom = /* @__PURE__ */ $constructor("$ZodCustom", (inst, def) => {
   $ZodCheck.init(inst, def);
   $ZodType.init(inst, def);
@@ -17160,6 +17553,244 @@ function handleRefineResult(result, payload, input, inst) {
       _iss.params = inst._zod.def.params;
     payload.issues.push(issue(_iss));
   }
+}
+
+// node_modules/zod/v4/core/memoizer.js
+var $ZodCyclicError = class extends Error {
+  constructor() {
+    super(`Cannot parse a reference cycle that closes through a transform`);
+    this.name = "ZodCyclicError";
+  }
+};
+var STATE = "~memo";
+var NO_ISSUES = [];
+function cloneIssues(issues) {
+  return issues.map((iss) => iss.path ? { ...iss, path: iss.path.slice() } : { ...iss });
+}
+var recursive = /* @__PURE__ */ new WeakMap();
+function isRecursive(inst, stack) {
+  const cached2 = recursive.get(inst);
+  if (cached2 !== void 0)
+    return cached2;
+  if (stack.has(inst))
+    return true;
+  stack.add(inst);
+  let result = false;
+  const check = (child) => {
+    if (!result && child?._zod && isRecursive(child, stack))
+      result = true;
+  };
+  const def = inst._zod.def;
+  const kind = def.type;
+  switch (kind) {
+    case "object": {
+      for (const key of Reflect.ownKeys(def.shape))
+        check(def.shape[key]);
+      check(def.catchall);
+      break;
+    }
+    case "array":
+      check(def.element);
+      break;
+    case "tuple":
+      for (const el of def.items)
+        check(el);
+      check(def.rest);
+      break;
+    case "record":
+    case "map":
+      check(def.keyType);
+      check(def.valueType);
+      break;
+    case "set":
+      check(def.valueType);
+      break;
+    case "union":
+      for (const el of def.options)
+        check(el);
+      break;
+    case "intersection":
+      check(def.left);
+      check(def.right);
+      break;
+    case "optional":
+    case "nullable":
+    case "default":
+    case "prefault":
+    case "catch":
+    case "readonly":
+    case "nonoptional":
+    case "promise":
+    case "success":
+      check(def.innerType);
+      break;
+    case "pipe":
+      check(def.in);
+      check(def.out);
+      break;
+    case "function":
+      check(def.input);
+      check(def.output);
+      break;
+    // reading `_zod.innerType` resolves the getter once and caches it
+    case "lazy":
+      check(inst._zod.innerType);
+      break;
+    // a leaf by choice: `parts` are regex fragments, not data positions
+    case "template_literal":
+    // leaves
+    case "string":
+    case "number":
+    case "int":
+    case "boolean":
+    case "bigint":
+    case "symbol":
+    case "undefined":
+    case "null":
+    case "void":
+    case "never":
+    case "any":
+    case "unknown":
+    case "date":
+    case "nan":
+    case "enum":
+    case "literal":
+    case "file":
+    case "transform":
+    case "custom":
+      break;
+    default: {
+      kind;
+      for (const key in def) {
+        const desc = Object.getOwnPropertyDescriptor(def, key);
+        if (!desc || desc.get)
+          continue;
+        const value = desc.value;
+        if (!value || typeof value !== "object")
+          continue;
+        if (value._zod)
+          check(value);
+        else if (Array.isArray(value))
+          for (const el of value)
+            check(el);
+      }
+    }
+  }
+  stack.delete(inst);
+  recursive.set(inst, result);
+  return result;
+}
+function bucketFor(state, inst) {
+  let bucket = state.buckets.get(inst);
+  if (!bucket) {
+    bucket = /* @__PURE__ */ new Map();
+    state.buckets.set(inst, bucket);
+  }
+  return bucket;
+}
+var handoff;
+var open = [];
+var memo = {
+  alloc(_inst, payload, empty) {
+    const bucket = handoff;
+    if (!bucket)
+      return empty;
+    handoff = void 0;
+    const entry = { value: empty, issues: null };
+    bucket.set(payload.value, entry);
+    open.push(entry);
+    return empty;
+  },
+  guard(inst) {
+    var _a3;
+    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
+    inst._zod.deferred.push(() => {
+      const base = inst._zod.parse;
+      const wrapped = (payload, ctx) => {
+        if (ctx.direction !== "backward" && isBackEdge(ctx, payload.value))
+          throw new $ZodCyclicError();
+        return base(payload, ctx);
+      };
+      inst._zod.parse = wrapped;
+      if (inst._zod.run === base)
+        inst._zod.run = wrapped;
+    });
+  },
+  attach(inst) {
+    var _a3;
+    let isRecursiveInst;
+    let lastCtx;
+    let lastBucket;
+    (_a3 = inst._zod).deferred ?? (_a3.deferred = []);
+    inst._zod.deferred.push(() => {
+      const base = inst._zod.parse;
+      const wrapped = (payload, ctx) => {
+        if (isRecursiveInst === void 0) {
+          isRecursiveInst = isRecursive(inst, /* @__PURE__ */ new Set());
+          if (!isRecursiveInst) {
+            inst._zod.parse = base;
+            if (inst._zod.run === wrapped)
+              inst._zod.run = base;
+            return base(payload, ctx);
+          }
+        }
+        const input = payload.value;
+        if (input === null || typeof input !== "object")
+          return base(payload, ctx);
+        let state = ctx[STATE];
+        if (!state) {
+          state = { buckets: /* @__PURE__ */ new Map(), backEdges: void 0 };
+          ctx[STATE] = state;
+        }
+        let bucket;
+        if (lastCtx === ctx) {
+          bucket = lastBucket;
+        } else {
+          bucket = bucketFor(state, inst);
+          lastCtx = ctx;
+          lastBucket = bucket;
+        }
+        const hit = bucket.get(input);
+        if (hit) {
+          payload.value = hit.value;
+          if (hit.issues) {
+            if (hit.issues.length)
+              payload.issues.push(...cloneIssues(hit.issues));
+          } else {
+            payload.memo = true;
+            state.backEdges ?? (state.backEdges = /* @__PURE__ */ new Set());
+            state.backEdges.add(hit.value);
+          }
+          return payload;
+        }
+        handoff = bucket;
+        const depth = open.length;
+        const result = base(payload, ctx);
+        handoff = void 0;
+        const entry = open.length > depth ? open.pop() : void 0;
+        if (result instanceof Promise) {
+          return result.then((r) => {
+            if (entry)
+              entry.issues = r.issues.length ? cloneIssues(r.issues) : NO_ISSUES;
+            return r;
+          });
+        }
+        if (entry)
+          entry.issues = result.issues.length ? cloneIssues(result.issues) : NO_ISSUES;
+        return result;
+      };
+      inst._zod.parse = wrapped;
+      if (inst._zod.run === base)
+        inst._zod.run = wrapped;
+    });
+  }
+};
+function memoizer() {
+  return memo;
+}
+function isBackEdge(ctx, value) {
+  const backEdges = ctx[STATE]?.backEdges;
+  return backEdges !== void 0 && value !== null && typeof value === "object" && backEdges.has(value);
 }
 
 // node_modules/zod/v4/locales/en.js
@@ -17202,6 +17833,7 @@ var error = () => {
     base64url: "base64url-encoded string",
     json_string: "JSON string",
     e164: "E.164 number",
+    credit_card: "credit card number",
     jwt: "JWT",
     template_literal: "input"
   };
@@ -17210,12 +17842,18 @@ var error = () => {
     nan: "NaN"
     // All other type names omitted - they fall back to raw values via ?? operator
   };
+  function getTypeName(type, input) {
+    if (type === "number" && typeof input === "number" && !Number.isFinite(input)) {
+      return String(input);
+    }
+    return TypeDictionary[type] ?? type;
+  }
   return (issue2) => {
     switch (issue2.code) {
       case "invalid_type": {
-        const expected = TypeDictionary[issue2.expected] ?? issue2.expected;
+        const expected = getTypeName(issue2.expected);
         const receivedType = parsedType(issue2.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
+        const received = getTypeName(receivedType, issue2.input);
         return `Invalid input: expected ${expected}, received ${received}`;
       }
       case "invalid_value":
@@ -17223,14 +17861,14 @@ var error = () => {
           return `Invalid input: expected ${stringifyPrimitive(issue2.values[0])}`;
         return `Invalid option: expected one of ${joinValues(issue2.values, "|")}`;
       case "too_big": {
-        const adj = issue2.inclusive ? "<=" : "<";
+        const adj = issue2.exact ? "exactly " : issue2.inclusive ? "<=" : "<";
         const sizing = getSizing(issue2.origin);
         if (sizing)
           return `Too big: expected ${issue2.origin ?? "value"} to have ${adj}${issue2.maximum.toString()} ${sizing.unit ?? "elements"}`;
         return `Too big: expected ${issue2.origin ?? "value"} to be ${adj}${issue2.maximum.toString()}`;
       }
       case "too_small": {
-        const adj = issue2.inclusive ? ">=" : ">";
+        const adj = issue2.exact ? "exactly " : issue2.inclusive ? ">=" : ">";
         const sizing = getSizing(issue2.origin);
         if (sizing) {
           return `Too small: expected ${issue2.origin} to have ${adj}${issue2.minimum.toString()} ${sizing.unit}`;
@@ -17260,6 +17898,9 @@ var error = () => {
         if (issue2.options && Array.isArray(issue2.options) && issue2.options.length > 0) {
           const opts = issue2.options.map((o) => `'${o}'`).join(" | ");
           return `Invalid discriminator value. Expected ${opts}`;
+        }
+        if (issue2.inclusive === false) {
+          return "Invalid input: more than one option matched";
         }
         return "Invalid input";
       case "invalid_element":
@@ -17878,7 +18519,8 @@ function _superRefine(fn, params) {
         if (_issue.fatal)
           _issue.continue = false;
         _issue.code ?? (_issue.code = "custom");
-        _issue.input ?? (_issue.input = payload.value);
+        if (!("input" in _issue))
+          _issue.input = payload.value;
         _issue.inst ?? (_issue.inst = ch);
         _issue.continue ?? (_issue.continue = !ch._zod.def.abort);
         payload.issues.push(issue(_issue));
@@ -17899,6 +18541,16 @@ function _check(fn, params) {
 }
 
 // node_modules/zod/v4/core/to-json-schema.js
+function assignProps(target, ...sources) {
+  for (const source of sources) {
+    for (const key of Reflect.ownKeys(source)) {
+      if (Object.prototype.propertyIsEnumerable.call(source, key)) {
+        assignProp(target, key, source[key]);
+      }
+    }
+  }
+  return target;
+}
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -17915,10 +18567,23 @@ function initializeContext(params) {
     io: params?.io ?? "output",
     counter: 0,
     seen: /* @__PURE__ */ new Map(),
+    sharedDefsExtractedFor: void 0,
+    sharedEmitDoneFor: void 0,
     cycles: params?.cycles ?? "ref",
     reused: params?.reused ?? "inline",
+    intersections: [],
+    deferred: [],
     external: params?.external ?? void 0
   };
+}
+function handleUnrepresentable(schema, ctx, json, params, message) {
+  const result = typeof ctx.unrepresentable === "function" ? ctx.unrepresentable({ zodSchema: schema, path: params.path, message }) : ctx.unrepresentable;
+  if (result === "any")
+    return false;
+  if (result === void 0 || result === "throw")
+    throw new Error(message);
+  Object.assign(json, result);
+  return true;
 }
 function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
   var _a3;
@@ -17934,6 +18599,8 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
   }
   const result = { schema: {}, count: 1, cycle: void 0, path: _params.path };
   ctx.seen.set(schema, result);
+  ctx.sharedDefsExtractedFor = void 0;
+  ctx.sharedEmitDoneFor = void 0;
   const overrideSchema = schema._zod.toJSONSchema?.();
   if (overrideSchema) {
     result.schema = overrideSchema;
@@ -17963,7 +18630,7 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
   }
   const meta2 = ctx.metadataRegistry.get(schema);
   if (meta2)
-    Object.assign(result.schema, meta2);
+    assignProps(result.schema, meta2);
   if (ctx.io === "input" && isTransforming(schema)) {
     delete result.schema.examples;
     delete result.schema.default;
@@ -17974,10 +18641,15 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
   const _result = ctx.seen.get(schema);
   return _result.schema;
 }
+function encodeJSONPointerSegment(segment) {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
 function extractDefs(ctx, schema) {
   const root = ctx.seen.get(schema);
   if (!root)
     throw new Error("Unprocessed schema. This is a bug in Zod.");
+  if (ctx.external && ctx.sharedDefsExtractedFor === ctx.external)
+    return;
   const idToSchema = /* @__PURE__ */ new Map();
   for (const entry of ctx.seen.entries()) {
     const id = ctx.metadataRegistry.get(entry[0])?.id;
@@ -17999,15 +18671,15 @@ function extractDefs(ctx, schema) {
       }
       const id = entry[1].defId ?? entry[1].schema.id ?? `schema${ctx.counter++}`;
       entry[1].defId = id;
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
-    }
-    if (entry[1] === root) {
-      return { ref: "#" };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodeJSONPointerSegment(id)}` };
     }
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
+    if (entry[1] === root && !entry[1].schema.id) {
+      return { ref: uriPrefix };
+    }
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + encodeJSONPointerSegment(defId) };
   };
   const extractToDef = (entry) => {
     if (entry[1].schema.$ref) {
@@ -18063,6 +18735,116 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
       }
     }
   }
+  if (ctx.external)
+    ctx.sharedDefsExtractedFor = ctx.external;
+}
+function compactTypeUnion(schema) {
+  const options = schema.anyOf;
+  if (!Array.isArray(options) || options.length === 0 || schema.type !== void 0)
+    return;
+  const types = [];
+  for (const option of options) {
+    if (!option || typeof option !== "object")
+      return;
+    compactTypeUnion(option);
+    const keys = Object.keys(option);
+    if (keys.length !== 1 || keys[0] !== "type")
+      return;
+    const type = option.type;
+    for (const member of Array.isArray(type) ? type : [type]) {
+      if (typeof member !== "string")
+        return;
+      if (!types.includes(member))
+        types.push(member);
+    }
+  }
+  delete schema.anyOf;
+  schema.type = types.length === 1 ? types[0] : types;
+}
+var FOLDABLE_KEYS = /* @__PURE__ */ new Set(["type", "properties", "required", "additionalProperties"]);
+var UNION_KEYS = ["oneOf", "anyOf"];
+function undeclaredConstraint(member) {
+  const extra = member.additionalProperties;
+  if (extra === void 0 || extra === false || typeof extra !== "object" || extra === null)
+    return null;
+  return Object.keys(extra).length ? extra : null;
+}
+function foldObjects(members2) {
+  const objects = [];
+  for (const member of members2) {
+    if (typeof member !== "object" || member.type !== "object")
+      return null;
+    for (const key in member) {
+      if (!FOLDABLE_KEYS.has(key))
+        return null;
+    }
+    objects.push(member);
+  }
+  const properties = {};
+  const required2 = /* @__PURE__ */ new Set();
+  for (const object3 of objects) {
+    for (const key in object3.properties) {
+      if (Object.prototype.hasOwnProperty.call(properties, key))
+        continue;
+      const parts = [];
+      for (const other of objects) {
+        const part = other.properties?.[key] ?? undeclaredConstraint(other);
+        if (part === null || part === void 0)
+          continue;
+        if (!parts.some((seen) => JSON.stringify(seen) === JSON.stringify(part)))
+          parts.push(part);
+      }
+      const merged = parts.length === 1 ? parts[0] : foldObjects(parts) ?? { allOf: parts };
+      assignProp(properties, key, merged);
+    }
+    for (const key of object3.required ?? [])
+      required2.add(key);
+  }
+  const folded = { type: "object", properties };
+  if (required2.size)
+    folded.required = [...required2];
+  if (objects.every((object3) => object3.additionalProperties === false)) {
+    folded.additionalProperties = false;
+  } else {
+    const constraints = [];
+    for (const object3 of objects) {
+      const constraint = undeclaredConstraint(object3);
+      if (constraint && !constraints.some((seen) => JSON.stringify(seen) === JSON.stringify(constraint)))
+        constraints.push(constraint);
+    }
+    if (constraints.length === 1)
+      folded.additionalProperties = constraints[0];
+    else if (constraints.length > 1)
+      folded.additionalProperties = { allOf: constraints };
+  }
+  return folded;
+}
+function foldIntersection(json) {
+  const allOf = json.allOf;
+  if (!Array.isArray(allOf) || allOf.length < 2)
+    return;
+  for (const key of FOLDABLE_KEYS)
+    if (key in json)
+      return;
+  const unions = allOf.filter((m) => UNION_KEYS.some((k) => Array.isArray(m[k])));
+  let folded = null;
+  if (!unions.length) {
+    folded = foldObjects(allOf);
+  } else {
+    const union2 = unions[0];
+    const keyword = UNION_KEYS.find((k) => Array.isArray(union2[k]));
+    if (Object.keys(union2).length !== 1)
+      return;
+    const rest = allOf.filter((m) => m !== union2);
+    const branches = union2[keyword].map((branch) => foldObjects([...rest, branch]));
+    if (branches.some((b) => !b))
+      return;
+    folded = { [keyword]: branches };
+  }
+  if (!folded)
+    return;
+  delete json.allOf;
+  assignProps(json, folded);
 }
 function finalize(ctx, schema) {
   const root = ctx.seen.get(schema);
@@ -18084,9 +18866,9 @@ function finalize(ctx, schema) {
         schema2.allOf = schema2.allOf ?? [];
         schema2.allOf.push(refSchema);
       } else {
-        Object.assign(schema2, refSchema);
+        assignProps(schema2, refSchema);
       }
-      Object.assign(schema2, _cached);
+      assignProps(schema2, _cached);
       const isParentRef = zodSchema._zod.parent === ref;
       if (isParentRef) {
         for (const key in schema2) {
@@ -18130,8 +18912,36 @@ function finalize(ctx, schema) {
       path: seen.path ?? []
     });
   };
-  for (const entry of [...ctx.seen.entries()].reverse()) {
-    flattenRef(entry[0]);
+  if (!ctx.external || ctx.sharedEmitDoneFor !== ctx.external) {
+    for (const entry of [...ctx.seen.entries()].reverse()) {
+      flattenRef(entry[0]);
+    }
+    if (ctx.target !== "openapi-3.0") {
+      for (const entry of ctx.seen.entries()) {
+        compactTypeUnion(entry[1].def ?? entry[1].schema);
+      }
+    }
+    for (const rewrite of ctx.deferred)
+      rewrite();
+    if (ctx.intersections.length) {
+      const carriers = /* @__PURE__ */ new Map();
+      for (const seen of ctx.seen.values()) {
+        for (const json of [seen.schema, seen.def]) {
+          const allOf = json?.allOf;
+          if (!Array.isArray(allOf))
+            continue;
+          const existing = carriers.get(allOf);
+          if (existing)
+            existing.push(json);
+          else
+            carriers.set(allOf, [json]);
+        }
+      }
+      for (const allOf of ctx.intersections) {
+        for (const json of carriers.get(allOf) ?? [])
+          foldIntersection(json);
+      }
+    }
   }
   const result = {};
   if (ctx.target === "draft-2020-12") {
@@ -18149,19 +18959,23 @@ function finalize(ctx, schema) {
       throw new Error("Schema is missing an `id` property");
     result.$id = ctx.external.uri(id);
   }
-  Object.assign(result, root.def ?? root.schema);
+  assignProps(result, root.defId ? root.schema : root.def ?? root.schema);
   const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
   if (rootMetaId !== void 0 && result.id === rootMetaId)
     delete result.id;
   const defs = ctx.external?.defs ?? {};
-  for (const entry of ctx.seen.entries()) {
-    const seen = entry[1];
-    if (seen.def && seen.defId) {
-      if (seen.def.id === seen.defId)
-        delete seen.def.id;
-      defs[seen.defId] = seen.def;
+  if (!ctx.external || ctx.sharedEmitDoneFor !== ctx.external) {
+    for (const entry of ctx.seen.entries()) {
+      const seen = entry[1];
+      if (seen.def && seen.defId) {
+        if (seen.def.id === seen.defId)
+          delete seen.def.id;
+        assignProp(defs, seen.defId, seen.def);
+      }
     }
   }
+  if (ctx.external)
+    ctx.sharedEmitDoneFor = ctx.external;
   if (ctx.external) {
   } else {
     if (Object.keys(defs).length > 0) {
@@ -18204,7 +19018,7 @@ function isTransforming(_schema, _ctx) {
     return isTransforming(def.valueType, ctx);
   if (def.type === "lazy")
     return isTransforming(def.getter(), ctx);
-  if (def.type === "promise" || def.type === "optional" || def.type === "nonoptional" || def.type === "nullable" || def.type === "readonly" || def.type === "default" || def.type === "prefault") {
+  if (def.type === "promise" || def.type === "optional" || def.type === "nonoptional" || def.type === "nullable" || def.type === "readonly" || def.type === "default" || def.type === "prefault" || def.type === "catch") {
     return isTransforming(def.innerType, ctx);
   }
   if (def.type === "intersection") {
@@ -18269,7 +19083,7 @@ var formatMap = {
 var stringProcessor = (schema, ctx, _json, _params) => {
   const json = _json;
   json.type = "string";
-  const { minimum, maximum, format, patterns, contentEncoding } = schema._zod.bag;
+  const { minimum, maximum, format, patterns, contentEncoding, laxFormat } = schema._zod.bag;
   if (typeof minimum === "number")
     json.minLength = minimum;
   if (typeof maximum === "number")
@@ -18278,19 +19092,19 @@ var stringProcessor = (schema, ctx, _json, _params) => {
     json.format = formatMap[format] ?? format;
     if (json.format === "")
       delete json.format;
-    if (format === "time") {
+    if (format === "time" || laxFormat) {
       delete json.format;
     }
   }
   if (contentEncoding)
     json.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {
-    const regexes = [...patterns];
-    if (regexes.length === 1)
-      json.pattern = regexes[0].source;
-    else if (regexes.length > 1) {
+    const patternList = [...patterns];
+    if (patternList.length === 1)
+      json.pattern = patternList[0].source;
+    else if (patternList.length > 1) {
       json.allOf = [
-        ...regexes.map((regex) => ({
+        ...patternList.map((regex) => ({
           ...ctx.target === "draft-07" || ctx.target === "draft-04" || ctx.target === "openapi-3.0" ? { type: "string" } : {},
           pattern: regex.source
         }))
@@ -18298,7 +19112,7 @@ var stringProcessor = (schema, ctx, _json, _params) => {
     }
   }
 };
-var numberProcessor = (schema, ctx, _json, _params) => {
+var numberProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = schema._zod.bag;
   if (typeof format === "string" && format.includes("int"))
@@ -18328,16 +19142,21 @@ var numberProcessor = (schema, ctx, _json, _params) => {
   } else if (typeof maximum === "number") {
     json.maximum = maximum;
   }
-  if (typeof multipleOf === "number")
-    json.multipleOf = multipleOf;
+  if (typeof multipleOf === "number") {
+    if (Number.isFinite(multipleOf) && multipleOf !== 0)
+      json.multipleOf = Math.abs(multipleOf);
+    else
+      handleUnrepresentable(schema, ctx, json, params, `A multipleOf divisor of ${multipleOf} cannot be represented in JSON Schema`);
+  }
 };
 var booleanProcessor = (_schema, _ctx, json, _params) => {
   json.type = "boolean";
 };
-var bigintProcessor = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("BigInt cannot be represented in JSON Schema");
-  }
+var bigintProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "BigInt cannot be represented in JSON Schema");
+};
+var symbolProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Symbols cannot be represented in JSON Schema");
 };
 var nullProcessor = (_schema, ctx, json, _params) => {
   if (ctx.target === "openapi-3.0") {
@@ -18348,6 +19167,12 @@ var nullProcessor = (_schema, ctx, json, _params) => {
     json.type = "null";
   }
 };
+var undefinedProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Undefined cannot be represented in JSON Schema");
+};
+var voidProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Void cannot be represented in JSON Schema");
+};
 var neverProcessor = (_schema, _ctx, json, _params) => {
   json.not = {};
 };
@@ -18355,35 +19180,37 @@ var anyProcessor = (_schema, _ctx, _json, _params) => {
 };
 var unknownProcessor = (_schema, _ctx, _json, _params) => {
 };
-var dateProcessor = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Date cannot be represented in JSON Schema");
-  }
+var dateProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Date cannot be represented in JSON Schema");
 };
 var enumProcessor = (schema, _ctx, json, _params) => {
   const def = schema._zod.def;
   const values = getEnumValues(def.entries);
+  if (values.length === 0) {
+    json.not = {};
+    return;
+  }
   if (values.every((v) => typeof v === "number"))
     json.type = "number";
   if (values.every((v) => typeof v === "string"))
     json.type = "string";
   json.enum = values;
 };
-var literalProcessor = (schema, ctx, json, _params) => {
+var literalProcessor = (schema, ctx, json, params) => {
   const def = schema._zod.def;
+  if (def.values.length === 0) {
+    json.not = {};
+    return;
+  }
   const vals = [];
   for (const val of def.values) {
     if (val === void 0) {
-      if (ctx.unrepresentable === "throw") {
-        throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-      } else {
-      }
+      if (handleUnrepresentable(schema, ctx, json, params, "Literal `undefined` cannot be represented in JSON Schema"))
+        return;
     } else if (typeof val === "bigint") {
-      if (ctx.unrepresentable === "throw") {
-        throw new Error("BigInt literals cannot be represented in JSON Schema");
-      } else {
-        vals.push(Number(val));
-      }
+      if (handleUnrepresentable(schema, ctx, json, params, "BigInt literals cannot be represented in JSON Schema"))
+        return;
+      vals.push(Number(val));
     } else {
       vals.push(val);
     }
@@ -18409,15 +19236,58 @@ var literalProcessor = (schema, ctx, json, _params) => {
     json.enum = vals;
   }
 };
-var customProcessor = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Custom types cannot be represented in JSON Schema");
+var nanProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "NaN cannot be represented in JSON Schema");
+};
+var templateLiteralProcessor = (schema, _ctx, json, _params) => {
+  const _json = json;
+  const pattern = schema._zod.pattern;
+  if (!pattern)
+    throw new Error("Pattern not found in template literal");
+  _json.type = "string";
+  _json.pattern = pattern.source;
+};
+var fileProcessor = (schema, _ctx, json, _params) => {
+  const _json = json;
+  const file = {
+    type: "string",
+    format: "binary",
+    contentEncoding: "binary"
+  };
+  const { minimum, maximum, mime } = schema._zod.bag;
+  if (minimum !== void 0)
+    file.minLength = minimum;
+  if (maximum !== void 0)
+    file.maxLength = maximum;
+  if (mime) {
+    if (mime.length === 1) {
+      file.contentMediaType = mime[0];
+      Object.assign(_json, file);
+    } else {
+      Object.assign(_json, file);
+      _json.anyOf = mime.map((m) => ({ contentMediaType: m }));
+    }
+  } else {
+    Object.assign(_json, file);
   }
 };
-var transformProcessor = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Transforms cannot be represented in JSON Schema");
-  }
+var successProcessor = (_schema, _ctx, json, _params) => {
+  json.type = "boolean";
+};
+var customProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Custom types cannot be represented in JSON Schema");
+};
+var functionProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Function types cannot be represented in JSON Schema");
+};
+var transformProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Transforms cannot be represented in JSON Schema");
+};
+var mapProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Map cannot be represented in JSON Schema");
+};
+var setProcessor = (schema, ctx, json, params) => {
+  handleUnrepresentable(schema, ctx, json, params, "Set cannot be represented in JSON Schema");
 };
 var arrayProcessor = (schema, ctx, _json, params) => {
   const json = _json;
@@ -18433,25 +19303,39 @@ var arrayProcessor = (schema, ctx, _json, params) => {
     path: [...params.path, "items"]
   });
 };
+function inputOptin(schema) {
+  const def = schema._zod.def;
+  if (def.type === "pipe" && def.in._zod.traits.has("$ZodTransform")) {
+    return inputOptin(def.out);
+  }
+  if (def.type === "catch") {
+    return inputOptin(def.innerType);
+  }
+  return schema._zod.optin;
+}
 var objectProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const def = schema._zod.def;
+  const shape = def.shape;
+  const symbolKeys = Object.getOwnPropertySymbols(shape);
+  if (symbolKeys.length && handleUnrepresentable(schema, ctx, json, params, "Symbol keys cannot be represented in JSON Schema")) {
+    return;
+  }
   json.type = "object";
   json.properties = {};
-  const shape = def.shape;
   for (const key in shape) {
-    json.properties[key] = process2(shape[key], ctx, {
+    assignProp(json.properties, key, process2(shape[key], ctx, {
       ...params,
       path: [...params.path, "properties", key]
-    });
+    }));
   }
   const allKeys = new Set(Object.keys(shape));
   const requiredKeys = new Set([...allKeys].filter((key) => {
-    const v = def.shape[key]._zod;
+    const field = def.shape[key];
     if (ctx.io === "input") {
-      return v.optin === void 0;
+      return inputOptin(field) === void 0;
     } else {
-      return v.optout === void 0;
+      return field._zod.optout === void 0;
     }
   }));
   if (requiredKeys.size > 0) {
@@ -18498,7 +19382,135 @@ var intersectionProcessor = (schema, ctx, json, params) => {
     ...isSimpleIntersection(b) ? b.allOf : [b]
   ];
   json.allOf = allOf;
+  ctx.intersections.push(allOf);
 };
+var tupleProcessor = (schema, ctx, _json, params) => {
+  const json = _json;
+  const def = schema._zod.def;
+  json.type = "array";
+  const prefixPath = ctx.target === "draft-2020-12" ? "prefixItems" : "items";
+  const restPath = ctx.target === "draft-2020-12" ? "items" : ctx.target === "openapi-3.0" ? "items" : "additionalItems";
+  const prefixItems = def.items.map((x, i) => process2(x, ctx, {
+    ...params,
+    path: [...params.path, prefixPath, i]
+  }));
+  const rest = def.rest ? process2(def.rest, ctx, {
+    ...params,
+    path: [...params.path, restPath, ...ctx.target === "openapi-3.0" ? [def.items.length] : []]
+  }) : null;
+  let minItems = def.items.length;
+  while (minItems > 0) {
+    const item = def.items[minItems - 1];
+    const optional2 = ctx.io === "input" ? inputOptin(item) !== void 0 : item._zod.optout === "optional";
+    if (!optional2)
+      break;
+    minItems--;
+  }
+  const maxItems = def.items.length;
+  const isClosed = !def.rest;
+  if (ctx.target === "draft-2020-12") {
+    json.prefixItems = prefixItems;
+    if (isClosed) {
+      json.items = false;
+    } else if (rest) {
+      json.items = rest;
+    }
+    if (minItems > 0)
+      json.minItems = minItems;
+    if (isClosed)
+      json.maxItems = maxItems;
+  } else if (ctx.target === "openapi-3.0") {
+    json.items = {
+      anyOf: prefixItems
+    };
+    if (rest) {
+      json.items.anyOf.push(rest);
+    }
+    if (minItems > 0)
+      json.minItems = minItems;
+    if (isClosed)
+      json.maxItems = maxItems;
+  } else {
+    json.items = prefixItems;
+    if (isClosed) {
+      json.additionalItems = false;
+    } else if (rest) {
+      json.additionalItems = rest;
+    }
+    if (minItems > 0)
+      json.minItems = minItems;
+    if (isClosed)
+      json.maxItems = maxItems;
+  }
+  const { minimum, maximum } = schema._zod.bag;
+  if (typeof minimum === "number")
+    json.minItems = minimum;
+  if (typeof maximum === "number")
+    json.maxItems = maximum;
+};
+function stringifyKeyNames(bySchema, json, visited) {
+  if (json.$ref) {
+    if (visited.has(json))
+      return json;
+    visited.add(json);
+    const def = bySchema.get(json)?.def;
+    if (!def)
+      return json;
+    const inlined = stringifyKeyNames(bySchema, def, visited);
+    return inlined === def ? json : inlined;
+  }
+  for (const keyword of ["anyOf", "oneOf"]) {
+    const branches = json[keyword];
+    if (!Array.isArray(branches))
+      continue;
+    const mapped = branches.map((branch) => stringifyKeyNames(bySchema, branch, visited));
+    if (mapped.some((branch, i) => branch !== branches[i]))
+      json = { ...json, [keyword]: mapped };
+  }
+  const types = Array.isArray(json.type) ? json.type : [json.type];
+  const numericType = !types.includes("string") && types.some((t) => t === "number" || t === "integer");
+  const values = json.enum ?? (json.const !== void 0 ? [json.const] : void 0);
+  if (!numericType && !values?.some((v) => typeof v === "number"))
+    return json;
+  const { minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf, format, id, ...rest } = json;
+  if (rest.enum)
+    rest.enum = rest.enum.map((v) => typeof v === "number" ? String(v) : v);
+  else if (typeof rest.const === "number")
+    rest.const = String(rest.const);
+  if (!numericType)
+    return rest;
+  rest.type = "string";
+  if (!values)
+    rest.pattern = (types.includes("number") ? number : integer).source;
+  return rest;
+}
+var pendingRecords = /* @__PURE__ */ new WeakMap();
+function rewriteKeyNames(ctx) {
+  const bySchema = /* @__PURE__ */ new Map();
+  for (const entry of ctx.seen.values()) {
+    if (entry.def && !bySchema.has(entry.schema))
+      bySchema.set(entry.schema, entry);
+  }
+  const rewrites = /* @__PURE__ */ new Map();
+  for (const record2 of pendingRecords.get(ctx) ?? []) {
+    const seen = ctx.seen.get(record2);
+    const names = (seen?.def ?? seen?.schema)?.propertyNames;
+    if (!names || names === true || rewrites.has(names))
+      continue;
+    const rewritten = stringifyKeyNames(bySchema, names, /* @__PURE__ */ new Set());
+    if (rewritten !== names)
+      rewrites.set(names, rewritten);
+  }
+  if (!rewrites.size)
+    return;
+  for (const entry of ctx.seen.values()) {
+    for (const carrier of [entry.schema, entry.def]) {
+      const rewritten = carrier && rewrites.get(carrier.propertyNames);
+      if (rewritten)
+        carrier.propertyNames = rewritten;
+    }
+  }
+}
 var recordProcessor = (schema, ctx, _json, params) => {
   const json = _json;
   const def = schema._zod.def;
@@ -18513,7 +19525,7 @@ var recordProcessor = (schema, ctx, _json, params) => {
     });
     json.patternProperties = {};
     for (const pattern of patterns) {
-      json.patternProperties[pattern.source] = valueSchema;
+      assignProp(json.patternProperties, pattern.source, valueSchema);
     }
   } else {
     if (ctx.target === "draft-07" || ctx.target === "draft-2020-12") {
@@ -18521,6 +19533,13 @@ var recordProcessor = (schema, ctx, _json, params) => {
         ...params,
         path: [...params.path, "propertyNames"]
       });
+      let pending = pendingRecords.get(ctx);
+      if (!pending) {
+        pending = [];
+        pendingRecords.set(ctx, pending);
+        ctx.deferred.push(() => rewriteKeyNames(ctx));
+      }
+      pending.push(schema);
     }
     json.additionalProperties = process2(def.valueType, ctx, {
       ...params,
@@ -18528,10 +19547,11 @@ var recordProcessor = (schema, ctx, _json, params) => {
     });
   }
   const keyValues = keyType._zod.values;
-  if (keyValues) {
+  const omittableOnInput = ctx.io === "input" && inputOptin(def.valueType) !== void 0;
+  if (keyValues && !def.partial && !omittableOnInput) {
     const validKeyValues = [...keyValues].filter((v) => typeof v === "string" || typeof v === "number");
     if (validKeyValues.length > 0) {
-      json.required = validKeyValues;
+      json.required = validKeyValues.map(String);
     }
   }
 };
@@ -18552,20 +19572,39 @@ var nonoptionalProcessor = (schema, ctx, _json, params) => {
   const seen = ctx.seen.get(schema);
   seen.ref = def.innerType;
 };
+var UNREPRESENTABLE_DEFAULT = /* @__PURE__ */ Symbol();
+function serializeDefaultValue(value, schema, ctx, json, params) {
+  let unrepresentable = false;
+  const serialized = JSON.stringify(value, (_, val) => {
+    if (typeof val !== "bigint")
+      return val;
+    unrepresentable = true;
+    return null;
+  });
+  if (!unrepresentable)
+    return JSON.parse(serialized);
+  handleUnrepresentable(schema, ctx, json, params, "BigInt defaults cannot be represented in JSON Schema");
+  return UNREPRESENTABLE_DEFAULT;
+}
 var defaultProcessor = (schema, ctx, json, params) => {
   const def = schema._zod.def;
   process2(def.innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = def.innerType;
-  json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  const value = serializeDefaultValue(def.defaultValue, schema, ctx, json, params);
+  if (value !== UNREPRESENTABLE_DEFAULT)
+    json.default = value;
 };
 var prefaultProcessor = (schema, ctx, json, params) => {
   const def = schema._zod.def;
   process2(def.innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = def.innerType;
-  if (ctx.io === "input")
-    json._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+  if (ctx.io !== "input")
+    return;
+  const value = serializeDefaultValue(def.defaultValue, schema, ctx, json, params);
+  if (value !== UNREPRESENTABLE_DEFAULT)
+    json._prefault = value;
 };
 var catchProcessor = (schema, ctx, json, params) => {
   const def = schema._zod.def;
@@ -18576,7 +19615,8 @@ var catchProcessor = (schema, ctx, json, params) => {
   try {
     catchValue = def.catchValue(void 0);
   } catch {
-    throw new Error("Dynamic catch values are not supported in JSON Schema");
+    handleUnrepresentable(schema, ctx, json, params, "Dynamic catch values are not supported in JSON Schema");
+    return;
   }
   json.default = catchValue;
 };
@@ -18595,12 +19635,99 @@ var readonlyProcessor = (schema, ctx, json, params) => {
   seen.ref = def.innerType;
   json.readOnly = true;
 };
+var promiseProcessor = (schema, ctx, _json, params) => {
+  const def = schema._zod.def;
+  process2(def.innerType, ctx, params);
+  const seen = ctx.seen.get(schema);
+  seen.ref = def.innerType;
+};
 var optionalProcessor = (schema, ctx, _json, params) => {
   const def = schema._zod.def;
   process2(def.innerType, ctx, params);
   const seen = ctx.seen.get(schema);
   seen.ref = def.innerType;
 };
+var lazyProcessor = (schema, ctx, _json, params) => {
+  const innerType = schema._zod.innerType;
+  process2(innerType, ctx, params);
+  const seen = ctx.seen.get(schema);
+  seen.ref = innerType;
+};
+var allProcessors = {
+  string: stringProcessor,
+  number: numberProcessor,
+  boolean: booleanProcessor,
+  bigint: bigintProcessor,
+  symbol: symbolProcessor,
+  null: nullProcessor,
+  undefined: undefinedProcessor,
+  void: voidProcessor,
+  never: neverProcessor,
+  any: anyProcessor,
+  unknown: unknownProcessor,
+  date: dateProcessor,
+  enum: enumProcessor,
+  literal: literalProcessor,
+  nan: nanProcessor,
+  template_literal: templateLiteralProcessor,
+  file: fileProcessor,
+  success: successProcessor,
+  custom: customProcessor,
+  function: functionProcessor,
+  transform: transformProcessor,
+  map: mapProcessor,
+  set: setProcessor,
+  array: arrayProcessor,
+  object: objectProcessor,
+  union: unionProcessor,
+  intersection: intersectionProcessor,
+  tuple: tupleProcessor,
+  record: recordProcessor,
+  nullable: nullableProcessor,
+  nonoptional: nonoptionalProcessor,
+  default: defaultProcessor,
+  prefault: prefaultProcessor,
+  catch: catchProcessor,
+  pipe: pipeProcessor,
+  readonly: readonlyProcessor,
+  promise: promiseProcessor,
+  optional: optionalProcessor,
+  lazy: lazyProcessor
+};
+function toJSONSchema(input, params) {
+  if ("_idmap" in input) {
+    const registry2 = input;
+    const ctx2 = initializeContext({ ...params, processors: allProcessors });
+    const defs = {};
+    for (const entry of registry2._idmap.entries()) {
+      const [_, schema] = entry;
+      process2(schema, ctx2);
+    }
+    const schemas = {};
+    const external = {
+      registry: registry2,
+      uri: params?.uri,
+      defs
+    };
+    ctx2.external = external;
+    for (const entry of registry2._idmap.entries()) {
+      const [key, schema] = entry;
+      extractDefs(ctx2, schema);
+      assignProp(schemas, key, finalize(ctx2, schema));
+    }
+    if (Object.keys(defs).length > 0) {
+      const defsSegment = ctx2.target === "draft-2020-12" ? "$defs" : "definitions";
+      schemas.__shared = {
+        [defsSegment]: defs
+      };
+    }
+    return { schemas };
+  }
+  const ctx = initializeContext({ ...params, processors: allProcessors });
+  process2(input, ctx);
+  extractDefs(ctx, input);
+  return finalize(ctx, input);
+}
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
@@ -18665,83 +19792,48 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// node_modules/zod/v4/classic/iso.js
-var iso_exports = {};
-__export(iso_exports, {
-  ZodISODate: () => ZodISODate,
-  ZodISODateTime: () => ZodISODateTime,
-  ZodISODuration: () => ZodISODuration,
-  ZodISOTime: () => ZodISOTime,
-  date: () => date2,
-  datetime: () => datetime2,
-  duration: () => duration2,
-  time: () => time2
-});
-var ZodISODateTime = /* @__PURE__ */ $constructor("ZodISODateTime", (inst, def) => {
-  $ZodISODateTime.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
-function datetime2(params) {
-  return _isoDateTime(ZodISODateTime, params);
-}
-var ZodISODate = /* @__PURE__ */ $constructor("ZodISODate", (inst, def) => {
-  $ZodISODate.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
-function date2(params) {
-  return _isoDate(ZodISODate, params);
-}
-var ZodISOTime = /* @__PURE__ */ $constructor("ZodISOTime", (inst, def) => {
-  $ZodISOTime.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
-function time2(params) {
-  return _isoTime(ZodISOTime, params);
-}
-var ZodISODuration = /* @__PURE__ */ $constructor("ZodISODuration", (inst, def) => {
-  $ZodISODuration.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
-function duration2(params) {
-  return _isoDuration(ZodISODuration, params);
-}
-
 // node_modules/zod/v4/classic/errors.js
+var _installedErrorProtos = /* @__PURE__ */ new WeakSet([Object.prototype, Error.prototype]);
+function _lazyMethod(proto, key, make) {
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    enumerable: false,
+    get() {
+      const value = make(this);
+      Object.defineProperty(this, key, { value, configurable: true, writable: true });
+      return value;
+    },
+    set(value) {
+      Object.defineProperty(this, key, { value, configurable: true, writable: true });
+    }
+  });
+}
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
-  Object.defineProperties(inst, {
-    format: {
-      value: (mapper) => formatError(inst, mapper)
-      // enumerable: false,
-    },
-    flatten: {
-      value: (mapper) => flattenError(inst, mapper)
-      // enumerable: false,
-    },
-    addIssue: {
-      value: (issue2) => {
-        inst.issues.push(issue2);
-        inst.message = JSON.stringify(inst.issues, jsonStringifyReplacer, 2);
-      }
-      // enumerable: false,
-    },
-    addIssues: {
-      value: (issues2) => {
-        inst.issues.push(...issues2);
-        inst.message = JSON.stringify(inst.issues, jsonStringifyReplacer, 2);
-      }
-      // enumerable: false,
-    },
-    isEmpty: {
-      get() {
-        return inst.issues.length === 0;
-      }
-      // enumerable: false,
+  const proto = Object.getPrototypeOf(inst);
+  if (_installedErrorProtos.has(proto))
+    return;
+  _installedErrorProtos.add(proto);
+  _lazyMethod(proto, "format", (self) => (mapper) => formatError(self, mapper));
+  _lazyMethod(proto, "flatten", (self) => (mapper) => flattenError(self, mapper));
+  _lazyMethod(proto, "addIssue", (self) => (issue2) => {
+    self.issues.push(issue2);
+    self.message = JSON.stringify(self.issues, jsonStringifyReplacer, 2);
+  });
+  _lazyMethod(proto, "addIssues", (self) => (issues2) => {
+    self.issues.push(...issues2);
+    self.message = JSON.stringify(self.issues, jsonStringifyReplacer, 2);
+  });
+  Object.defineProperty(proto, "isEmpty", {
+    configurable: true,
+    enumerable: false,
+    get() {
+      return this.issues.length === 0;
     }
   });
 };
-var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
+var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, void 0, {
   Parent: Error
 });
 
@@ -18760,171 +19852,182 @@ var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
 // node_modules/zod/v4/classic/schemas.js
-var _installedGroups = /* @__PURE__ */ new WeakMap();
-function _installLazyMethods(inst, group, methods) {
-  const proto = Object.getPrototypeOf(inst);
-  let installed = _installedGroups.get(proto);
-  if (!installed) {
-    installed = /* @__PURE__ */ new Set();
-    _installedGroups.set(proto, installed);
-  }
-  if (installed.has(group))
-    return;
-  installed.add(group);
-  for (const key in methods) {
-    const fn = methods[key];
-    Object.defineProperty(proto, key, {
-      configurable: true,
-      enumerable: false,
-      get() {
-        const bound = fn.bind(this);
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: bound
-        });
-        return bound;
-      },
-      set(v) {
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: v
-        });
-      }
-    });
-  }
+function _ensureDefaultLocale() {
+  if (!globalConfig.localeError)
+    config(en_default());
+}
+function _ensureDefaultMemoizer() {
+  if (!globalConfig.memoizer)
+    config({ memoizer: memoizer() });
 }
 var ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
+  _ensureDefaultLocale();
   $ZodType.init(inst, def);
-  Object.assign(inst["~standard"], {
-    jsonSchema: {
-      input: createStandardJSONSchemaMethod(inst, "input"),
-      output: createStandardJSONSchemaMethod(inst, "output")
-    }
-  });
-  inst.toJSONSchema = createToJSONSchemaMethod(inst, {});
   inst.def = def;
   inst.type = def.type;
-  Object.defineProperty(inst, "_def", { value: def });
-  inst.parse = (data, params) => parse2(inst, data, params, { callee: inst.parse });
-  inst.safeParse = (data, params) => safeParse3(inst, data, params);
-  inst.parseAsync = async (data, params) => parseAsync2(inst, data, params, { callee: inst.parseAsync });
-  inst.safeParseAsync = async (data, params) => safeParseAsync2(inst, data, params);
-  inst.spa = inst.safeParseAsync;
-  inst.encode = (data, params) => encode2(inst, data, params);
-  inst.decode = (data, params) => decode2(inst, data, params);
-  inst.encodeAsync = async (data, params) => encodeAsync2(inst, data, params);
-  inst.decodeAsync = async (data, params) => decodeAsync2(inst, data, params);
-  inst.safeEncode = (data, params) => safeEncode2(inst, data, params);
-  inst.safeDecode = (data, params) => safeDecode2(inst, data, params);
-  inst.safeEncodeAsync = async (data, params) => safeEncodeAsync2(inst, data, params);
-  inst.safeDecodeAsync = async (data, params) => safeDecodeAsync2(inst, data, params);
-  _installLazyMethods(inst, "ZodType", {
-    check(...chks) {
-      const def2 = this.def;
-      return this.clone(util_exports.mergeDefs(def2, {
-        checks: [
-          ...def2.checks ?? [],
-          ...chks.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
-        ]
-      }), { parent: true });
-    },
-    with(...chks) {
-      return this.check(...chks);
-    },
-    clone(def2, params) {
-      return clone(this, def2, params);
-    },
-    brand() {
-      return this;
-    },
-    register(reg, meta2) {
-      reg.add(this, meta2);
-      return this;
-    },
-    refine(check, params) {
-      return this.check(refine(check, params));
-    },
-    superRefine(refinement, params) {
-      return this.check(superRefine(refinement, params));
-    },
-    overwrite(fn) {
-      return this.check(_overwrite(fn));
-    },
-    optional() {
-      return optional(this);
-    },
-    exactOptional() {
-      return exactOptional(this);
-    },
-    nullable() {
-      return nullable(this);
-    },
-    nullish() {
-      return optional(nullable(this));
-    },
-    nonoptional(params) {
-      return nonoptional(this, params);
-    },
-    array() {
-      return array(this);
-    },
-    or(arg) {
-      return union([this, arg]);
-    },
-    and(arg) {
-      return intersection(this, arg);
-    },
-    transform(tx) {
-      return pipe(this, transform(tx));
-    },
-    default(d) {
-      return _default(this, d);
-    },
-    prefault(d) {
-      return prefault(this, d);
-    },
-    catch(params) {
-      return _catch(this, params);
-    },
-    pipe(target) {
-      return pipe(this, target);
-    },
-    readonly() {
-      return readonly(this);
-    },
-    describe(description) {
-      const cl = this.clone();
-      globalRegistry.add(cl, { description });
-      return cl;
-    },
-    meta(...args) {
-      if (args.length === 0)
-        return globalRegistry.get(this);
-      const cl = this.clone();
-      globalRegistry.add(cl, args[0]);
-      return cl;
-    },
-    isOptional() {
-      return this.safeParse(void 0).success;
-    },
-    isNullable() {
-      return this.safeParse(null).success;
-    },
-    apply(fn) {
-      return fn(this);
-    }
-  });
-  Object.defineProperty(inst, "description", {
-    get() {
-      return globalRegistry.get(inst)?.description;
-    },
-    configurable: true
-  });
   return inst;
+}, {
+  check(...chks) {
+    const def = this.def;
+    return this.clone(util_exports.mergeDefs(def, {
+      checks: [
+        ...def.checks ?? [],
+        ...chks.map((ch) => typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch)
+      ]
+    }), { parent: true });
+  },
+  with(...chks) {
+    return this.check(...chks);
+  },
+  clone(def, params) {
+    return clone(this, def, params);
+  },
+  brand() {
+    return this;
+  },
+  register(reg, meta2) {
+    reg.add(this, meta2);
+    return this;
+  },
+  refine(check, params) {
+    return this.check(refine(check, params));
+  },
+  superRefine(refinement, params) {
+    return this.check(superRefine(refinement, params));
+  },
+  overwrite(fn) {
+    return this.check(_overwrite(fn));
+  },
+  optional() {
+    return optional(this);
+  },
+  exactOptional() {
+    return exactOptional(this);
+  },
+  nullable() {
+    return nullable(this);
+  },
+  nullish() {
+    return optional(nullable(this));
+  },
+  nonoptional(params) {
+    return nonoptional(this, params);
+  },
+  array() {
+    return array(this);
+  },
+  or(arg) {
+    return union([this, arg]);
+  },
+  and(arg) {
+    return intersection(this, arg);
+  },
+  transform(tx) {
+    return pipe(this, transform(tx));
+  },
+  default(d) {
+    return _default(this, d);
+  },
+  prefault(d) {
+    return prefault(this, d);
+  },
+  catch(params) {
+    return _catch(this, params);
+  },
+  pipe(target) {
+    return pipe(this, target);
+  },
+  readonly() {
+    return readonly(this);
+  },
+  describe(description) {
+    const cl = this.clone();
+    globalRegistry.add(cl, { description });
+    return cl;
+  },
+  meta(...args) {
+    if (args.length === 0)
+      return globalRegistry.get(this);
+    const cl = this.clone();
+    globalRegistry.add(cl, args[0]);
+    return cl;
+  },
+  isOptional() {
+    return this.safeParse(void 0).success;
+  },
+  isNullable() {
+    return this.safeParse(null).success;
+  },
+  apply(fn, ...args) {
+    return args.length === 0 ? fn(this) : fn(this, ...args);
+  },
+  // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
+  get "~standard"() {
+    return util_exports.hide(this, "~standard", {
+      ...standardProps(this),
+      jsonSchema: {
+        input: createStandardJSONSchemaMethod(this, "input"),
+        output: createStandardJSONSchemaMethod(this, "output")
+      }
+    });
+  },
+  set "~standard"(value) {
+    util_exports.own(this, "~standard", value);
+  },
+  parse: function _parse2(data, params) {
+    return parse2(this, data, params, { callee: _parse2 });
+  },
+  parseAsync: async function _parseAsync2(data, params) {
+    return await parseAsync2(this, data, params, { callee: _parseAsync2 });
+  },
+  safeParse(data, params) {
+    return safeParse3(this, data, params);
+  },
+  async safeParseAsync(data, params) {
+    return safeParseAsync2(this, data, params);
+  },
+  // `spa` is an alias: same function object as `safeParseAsync`, as before.
+  get spa() {
+    return this?.safeParseAsync;
+  },
+  set spa(value) {
+    util_exports.own(this, "spa", value);
+  },
+  encode: function _encode2(data, params) {
+    return encode2(this, data, params, { callee: _encode2 });
+  },
+  decode: function _decode2(data, params) {
+    return decode2(this, data, params, { callee: _decode2 });
+  },
+  encodeAsync: async function _encodeAsync2(data, params) {
+    return await encodeAsync2(this, data, params, { callee: _encodeAsync2 });
+  },
+  decodeAsync: async function _decodeAsync2(data, params) {
+    return await decodeAsync2(this, data, params, { callee: _decodeAsync2 });
+  },
+  safeEncode(data, params) {
+    return safeEncode2(this, data, params);
+  },
+  safeDecode(data, params) {
+    return safeDecode2(this, data, params);
+  },
+  async safeEncodeAsync(data, params) {
+    return safeEncodeAsync2(this, data, params);
+  },
+  async safeDecodeAsync(data, params) {
+    return safeDecodeAsync2(this, data, params);
+  },
+  toJSONSchema(params) {
+    return createToJSONSchemaMethod(this, {})(params);
+  },
+  // Reads through to the registry on every access, so it must not cache.
+  get description() {
+    return globalRegistry.get(this)?.description;
+  },
+  // No setter: `schema._def = x` throws, as it did when `_def` was a non-writable own property.
+  get _def() {
+    return this._zod.def;
+  }
 });
 var _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
   $ZodString.init(inst, def);
@@ -18934,84 +20037,135 @@ var _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
   inst.format = bag.format ?? null;
   inst.minLength = bag.minimum ?? null;
   inst.maxLength = bag.maximum ?? null;
-  _installLazyMethods(inst, "_ZodString", {
-    regex(...args) {
-      return this.check(_regex(...args));
-    },
-    includes(...args) {
-      return this.check(_includes(...args));
-    },
-    startsWith(...args) {
-      return this.check(_startsWith(...args));
-    },
-    endsWith(...args) {
-      return this.check(_endsWith(...args));
-    },
-    min(...args) {
-      return this.check(_minLength(...args));
-    },
-    max(...args) {
-      return this.check(_maxLength(...args));
-    },
-    length(...args) {
-      return this.check(_length(...args));
-    },
-    nonempty(...args) {
-      return this.check(_minLength(1, ...args));
-    },
-    lowercase(params) {
-      return this.check(_lowercase(params));
-    },
-    uppercase(params) {
-      return this.check(_uppercase(params));
-    },
-    trim() {
-      return this.check(_trim());
-    },
-    normalize(...args) {
-      return this.check(_normalize(...args));
-    },
-    toLowerCase() {
-      return this.check(_toLowerCase());
-    },
-    toUpperCase() {
-      return this.check(_toUpperCase());
-    },
-    slugify() {
-      return this.check(_slugify());
-    }
-  });
+}, {
+  regex(...args) {
+    return this.check(_regex(...args));
+  },
+  includes(...args) {
+    return this.check(_includes(...args));
+  },
+  startsWith(...args) {
+    return this.check(_startsWith(...args));
+  },
+  endsWith(...args) {
+    return this.check(_endsWith(...args));
+  },
+  min(...args) {
+    return this.check(_minLength(...args));
+  },
+  max(...args) {
+    return this.check(_maxLength(...args));
+  },
+  length(...args) {
+    return this.check(_length(...args));
+  },
+  nonempty(...args) {
+    return this.check(_minLength(1, ...args));
+  },
+  lowercase(params) {
+    return this.check(_lowercase(params));
+  },
+  uppercase(params) {
+    return this.check(_uppercase(params));
+  },
+  trim() {
+    return this.check(_trim());
+  },
+  normalize(...args) {
+    return this.check(_normalize(...args));
+  },
+  toLowerCase() {
+    return this.check(_toLowerCase());
+  },
+  toUpperCase() {
+    return this.check(_toUpperCase());
+  },
+  slugify() {
+    return this.check(_slugify());
+  }
 });
 var ZodString = /* @__PURE__ */ $constructor("ZodString", (inst, def) => {
   $ZodString.init(inst, def);
   _ZodString.init(inst, def);
-  inst.email = (params) => inst.check(_email(ZodEmail, params));
-  inst.url = (params) => inst.check(_url(ZodURL, params));
-  inst.jwt = (params) => inst.check(_jwt(ZodJWT, params));
-  inst.emoji = (params) => inst.check(_emoji2(ZodEmoji, params));
-  inst.guid = (params) => inst.check(_guid(ZodGUID, params));
-  inst.uuid = (params) => inst.check(_uuid(ZodUUID, params));
-  inst.uuidv4 = (params) => inst.check(_uuidv4(ZodUUID, params));
-  inst.uuidv6 = (params) => inst.check(_uuidv6(ZodUUID, params));
-  inst.uuidv7 = (params) => inst.check(_uuidv7(ZodUUID, params));
-  inst.nanoid = (params) => inst.check(_nanoid(ZodNanoID, params));
-  inst.guid = (params) => inst.check(_guid(ZodGUID, params));
-  inst.cuid = (params) => inst.check(_cuid(ZodCUID, params));
-  inst.cuid2 = (params) => inst.check(_cuid2(ZodCUID2, params));
-  inst.ulid = (params) => inst.check(_ulid(ZodULID, params));
-  inst.base64 = (params) => inst.check(_base64(ZodBase64, params));
-  inst.base64url = (params) => inst.check(_base64url(ZodBase64URL, params));
-  inst.xid = (params) => inst.check(_xid(ZodXID, params));
-  inst.ksuid = (params) => inst.check(_ksuid(ZodKSUID, params));
-  inst.ipv4 = (params) => inst.check(_ipv4(ZodIPv4, params));
-  inst.ipv6 = (params) => inst.check(_ipv6(ZodIPv6, params));
-  inst.cidrv4 = (params) => inst.check(_cidrv4(ZodCIDRv4, params));
-  inst.cidrv6 = (params) => inst.check(_cidrv6(ZodCIDRv6, params));
-  inst.e164 = (params) => inst.check(_e164(ZodE164, params));
-  inst.datetime = (params) => inst.check(datetime2(params));
-  inst.date = (params) => inst.check(date2(params));
-  inst.time = (params) => inst.check(time2(params));
-  inst.duration = (params) => inst.check(duration2(params));
+}, {
+  email(params) {
+    return this.check(_email(ZodEmail, params));
+  },
+  url(params) {
+    return this.check(_url(ZodURL, params));
+  },
+  jwt(params) {
+    return this.check(_jwt(ZodJWT, params));
+  },
+  emoji(params) {
+    return this.check(_emoji2(ZodEmoji, params));
+  },
+  guid(params) {
+    return this.check(_guid(ZodGUID, params));
+  },
+  uuid(params) {
+    return this.check(_uuid(ZodUUID, params));
+  },
+  uuidv4(params) {
+    return this.check(_uuidv4(ZodUUID, params));
+  },
+  uuidv6(params) {
+    return this.check(_uuidv6(ZodUUID, params));
+  },
+  uuidv7(params) {
+    return this.check(_uuidv7(ZodUUID, params));
+  },
+  nanoid(params) {
+    return this.check(_nanoid(ZodNanoID, params));
+  },
+  cuid(params) {
+    return this.check(_cuid(ZodCUID, params));
+  },
+  cuid2(params) {
+    return this.check(_cuid2(ZodCUID2, params));
+  },
+  ulid(params) {
+    return this.check(_ulid(ZodULID, params));
+  },
+  base64(params) {
+    return this.check(_base64(ZodBase64, params));
+  },
+  base64url(params) {
+    return this.check(_base64url(ZodBase64URL, params));
+  },
+  xid(params) {
+    return this.check(_xid(ZodXID, params));
+  },
+  ksuid(params) {
+    return this.check(_ksuid(ZodKSUID, params));
+  },
+  ipv4(params) {
+    return this.check(_ipv4(ZodIPv4, params));
+  },
+  ipv6(params) {
+    return this.check(_ipv6(ZodIPv6, params));
+  },
+  cidrv4(params) {
+    return this.check(_cidrv4(ZodCIDRv4, params));
+  },
+  cidrv6(params) {
+    return this.check(_cidrv6(ZodCIDRv6, params));
+  },
+  e164(params) {
+    return this.check(_e164(ZodE164, params));
+  },
+  datetime(params) {
+    return this.check(_isoDateTime(ZodISODateTime, params));
+  },
+  date(params) {
+    return this.check(_isoDate(ZodISODate, params));
+  },
+  time(params) {
+    return this.check(_isoTime(ZodISOTime, params));
+  },
+  duration(params) {
+    return this.check(_isoDuration(ZodISODuration, params));
+  }
 });
 function string2(params) {
   return _string(ZodString, params);
@@ -19020,10 +20174,29 @@ var ZodStringFormat = /* @__PURE__ */ $constructor("ZodStringFormat", (inst, def
   $ZodStringFormat.init(inst, def);
   _ZodString.init(inst, def);
 });
+var ZodISODateTime = /* @__PURE__ */ $constructor("ZodISODateTime", (inst, def) => {
+  $ZodISODateTime.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+var ZodISODate = /* @__PURE__ */ $constructor("ZodISODate", (inst, def) => {
+  $ZodISODate.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+var ZodISOTime = /* @__PURE__ */ $constructor("ZodISOTime", (inst, def) => {
+  $ZodISOTime.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+var ZodISODuration = /* @__PURE__ */ $constructor("ZodISODuration", (inst, def) => {
+  $ZodISODuration.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
 var ZodEmail = /* @__PURE__ */ $constructor("ZodEmail", (inst, def) => {
   $ZodEmail.init(inst, def);
   ZodStringFormat.init(inst, def);
 });
+function email2(params) {
+  return _email(ZodEmail, params);
+}
 var ZodGUID = /* @__PURE__ */ $constructor("ZodGUID", (inst, def) => {
   $ZodGUID.init(inst, def);
   ZodStringFormat.init(inst, def);
@@ -19103,59 +20276,58 @@ var ZodNumber = /* @__PURE__ */ $constructor("ZodNumber", (inst, def) => {
   $ZodNumber.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => numberProcessor(inst, ctx, json, params);
-  _installLazyMethods(inst, "ZodNumber", {
-    gt(value, params) {
-      return this.check(_gt(value, params));
-    },
-    gte(value, params) {
-      return this.check(_gte(value, params));
-    },
-    min(value, params) {
-      return this.check(_gte(value, params));
-    },
-    lt(value, params) {
-      return this.check(_lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(_lte(value, params));
-    },
-    max(value, params) {
-      return this.check(_lte(value, params));
-    },
-    int(params) {
-      return this.check(int(params));
-    },
-    safe(params) {
-      return this.check(int(params));
-    },
-    positive(params) {
-      return this.check(_gt(0, params));
-    },
-    nonnegative(params) {
-      return this.check(_gte(0, params));
-    },
-    negative(params) {
-      return this.check(_lt(0, params));
-    },
-    nonpositive(params) {
-      return this.check(_lte(0, params));
-    },
-    multipleOf(value, params) {
-      return this.check(_multipleOf(value, params));
-    },
-    step(value, params) {
-      return this.check(_multipleOf(value, params));
-    },
-    finite() {
-      return this;
-    }
-  });
   const bag = inst._zod.bag;
   inst.minValue = Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
   inst.maxValue = Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
   inst.isInt = (bag.format ?? "").includes("int") || Number.isSafeInteger(bag.multipleOf ?? 0.5);
   inst.isFinite = true;
   inst.format = bag.format ?? null;
+}, {
+  gt(value, params) {
+    return this.check(_gt(value, params));
+  },
+  gte(value, params) {
+    return this.check(_gte(value, params));
+  },
+  min(value, params) {
+    return this.check(_gte(value, params));
+  },
+  lt(value, params) {
+    return this.check(_lt(value, params));
+  },
+  lte(value, params) {
+    return this.check(_lte(value, params));
+  },
+  max(value, params) {
+    return this.check(_lte(value, params));
+  },
+  int(params) {
+    return this.check(int(params));
+  },
+  safe(params) {
+    return this.check(int(params));
+  },
+  positive(params) {
+    return this.check(_gt(0, params));
+  },
+  nonnegative(params) {
+    return this.check(_gte(0, params));
+  },
+  negative(params) {
+    return this.check(_lt(0, params));
+  },
+  nonpositive(params) {
+    return this.check(_lte(0, params));
+  },
+  multipleOf(value, params) {
+    return this.check(_multipleOf(value, params));
+  },
+  step(value, params) {
+    return this.check(_multipleOf(value, params));
+  },
+  finite() {
+    return this;
+  }
 });
 function number2(params) {
   return _number(ZodNumber, params);
@@ -19179,23 +20351,44 @@ var ZodBigInt = /* @__PURE__ */ $constructor("ZodBigInt", (inst, def) => {
   $ZodBigInt.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => bigintProcessor(inst, ctx, json, params);
-  inst.gte = (value, params) => inst.check(_gte(value, params));
-  inst.min = (value, params) => inst.check(_gte(value, params));
-  inst.gt = (value, params) => inst.check(_gt(value, params));
-  inst.gte = (value, params) => inst.check(_gte(value, params));
-  inst.min = (value, params) => inst.check(_gte(value, params));
-  inst.lt = (value, params) => inst.check(_lt(value, params));
-  inst.lte = (value, params) => inst.check(_lte(value, params));
-  inst.max = (value, params) => inst.check(_lte(value, params));
-  inst.positive = (params) => inst.check(_gt(BigInt(0), params));
-  inst.negative = (params) => inst.check(_lt(BigInt(0), params));
-  inst.nonpositive = (params) => inst.check(_lte(BigInt(0), params));
-  inst.nonnegative = (params) => inst.check(_gte(BigInt(0), params));
-  inst.multipleOf = (value, params) => inst.check(_multipleOf(value, params));
   const bag = inst._zod.bag;
   inst.minValue = bag.minimum ?? null;
   inst.maxValue = bag.maximum ?? null;
   inst.format = bag.format ?? null;
+}, {
+  gte(value, params) {
+    return this.check(_gte(value, params));
+  },
+  min(value, params) {
+    return this.check(_gte(value, params));
+  },
+  gt(value, params) {
+    return this.check(_gt(value, params));
+  },
+  lt(value, params) {
+    return this.check(_lt(value, params));
+  },
+  lte(value, params) {
+    return this.check(_lte(value, params));
+  },
+  max(value, params) {
+    return this.check(_lte(value, params));
+  },
+  positive(params) {
+    return this.check(_gt(BigInt(0), params));
+  },
+  negative(params) {
+    return this.check(_lt(BigInt(0), params));
+  },
+  nonpositive(params) {
+    return this.check(_lte(BigInt(0), params));
+  },
+  nonnegative(params) {
+    return this.check(_gte(BigInt(0), params));
+  },
+  multipleOf(value, params) {
+    return this.check(_multipleOf(value, params));
+  }
 });
 var ZodNull = /* @__PURE__ */ $constructor("ZodNull", (inst, def) => {
   $ZodNull.init(inst, def);
@@ -19240,79 +20433,80 @@ var ZodDate = /* @__PURE__ */ $constructor("ZodDate", (inst, def) => {
   inst.maxDate = c.maximum ? new Date(c.maximum) : null;
 });
 var ZodArray = /* @__PURE__ */ $constructor("ZodArray", (inst, def) => {
+  _ensureDefaultMemoizer();
   $ZodArray.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => arrayProcessor(inst, ctx, json, params);
   inst.element = def.element;
-  _installLazyMethods(inst, "ZodArray", {
-    min(n, params) {
-      return this.check(_minLength(n, params));
-    },
-    nonempty(params) {
-      return this.check(_minLength(1, params));
-    },
-    max(n, params) {
-      return this.check(_maxLength(n, params));
-    },
-    length(n, params) {
-      return this.check(_length(n, params));
-    },
-    unwrap() {
-      return this.element;
-    }
-  });
+}, {
+  min(n, params) {
+    return this.check(_minLength(n, params));
+  },
+  nonempty(params) {
+    return this.check(_minLength(1, params));
+  },
+  max(n, params) {
+    return this.check(_maxLength(n, params));
+  },
+  length(n, params) {
+    return this.check(_length(n, params));
+  },
+  unwrap() {
+    return this.element;
+  }
 });
 function array(element, params) {
   return _array(ZodArray, element, params);
 }
 var ZodObject = /* @__PURE__ */ $constructor("ZodObject", (inst, def) => {
+  _ensureDefaultMemoizer();
   $ZodObjectJIT.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => objectProcessor(inst, ctx, json, params);
-  util_exports.defineLazy(inst, "shape", () => {
-    return def.shape;
-  });
-  _installLazyMethods(inst, "ZodObject", {
-    keyof() {
-      return _enum(Object.keys(this._zod.def.shape));
-    },
-    catchall(catchall) {
-      return this.clone({ ...this._zod.def, catchall });
-    },
-    passthrough() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    loose() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    strict() {
-      return this.clone({ ...this._zod.def, catchall: never() });
-    },
-    strip() {
-      return this.clone({ ...this._zod.def, catchall: void 0 });
-    },
-    extend(incoming) {
-      return util_exports.extend(this, incoming);
-    },
-    safeExtend(incoming) {
-      return util_exports.safeExtend(this, incoming);
-    },
-    merge(other) {
-      return util_exports.merge(this, other);
-    },
-    pick(mask) {
-      return util_exports.pick(this, mask);
-    },
-    omit(mask) {
-      return util_exports.omit(this, mask);
-    },
-    partial(...args) {
-      return util_exports.partial(ZodOptional, this, args[0]);
-    },
-    required(...args) {
-      return util_exports.required(ZodNonOptional, this, args[0]);
-    }
-  });
+  util_exports.installLazyProp(inst, "shape", (self) => self._zod.def.shape, false);
+}, {
+  keyof() {
+    return _enum(Object.keys(this._zod.def.shape));
+  },
+  catchall(catchall) {
+    return this.clone({ ...this._zod.def, catchall });
+  },
+  passthrough() {
+    return this.clone({ ...this._zod.def, catchall: unknown() });
+  },
+  loose() {
+    return this.clone({ ...this._zod.def, catchall: unknown() });
+  },
+  strict() {
+    return this.clone({ ...this._zod.def, catchall: never() });
+  },
+  strip() {
+    return this.clone({ ...this._zod.def, catchall: void 0 });
+  },
+  extend(incoming) {
+    return util_exports.extend(this, incoming);
+  },
+  safeExtend(incoming) {
+    return util_exports.safeExtend(this, incoming);
+  },
+  merge(other) {
+    return util_exports.merge(this, other);
+  },
+  pick(mask) {
+    return util_exports.pick(this, mask);
+  },
+  omit(mask) {
+    return util_exports.omit(this, mask);
+  },
+  partial(...args) {
+    return util_exports.partial(ZodOptional, this, args[0]);
+  },
+  exactPartial(...args) {
+    return util_exports.partial(ZodExactOptional, this, args[0], "exactPartial");
+  },
+  required(...args) {
+    return util_exports.required(ZodNonOptional, this, args[0]);
+  }
 });
 function object2(shape, params) {
   const def = {
@@ -19368,6 +20562,7 @@ function intersection(left, right) {
   });
 }
 var ZodRecord = /* @__PURE__ */ $constructor("ZodRecord", (inst, def) => {
+  _ensureDefaultMemoizer();
   $ZodRecord.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => recordProcessor(inst, ctx, json, params);
@@ -19458,6 +20653,7 @@ function literal(value, params) {
   });
 }
 var ZodTransform = /* @__PURE__ */ $constructor("ZodTransform", (inst, def) => {
+  _ensureDefaultMemoizer();
   $ZodTransform.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => transformProcessor(inst, ctx, json, params);
@@ -19473,7 +20669,8 @@ var ZodTransform = /* @__PURE__ */ $constructor("ZodTransform", (inst, def) => {
         if (_issue.fatal)
           _issue.continue = false;
         _issue.code ?? (_issue.code = "custom");
-        _issue.input ?? (_issue.input = payload.value);
+        if (!("input" in _issue))
+          _issue.input = payload.value;
         _issue.inst ?? (_issue.inst = inst);
         payload.issues.push(util_exports.issue(_issue));
       }
@@ -19482,12 +20679,10 @@ var ZodTransform = /* @__PURE__ */ $constructor("ZodTransform", (inst, def) => {
     if (output instanceof Promise) {
       return output.then((output2) => {
         payload.value = output2;
-        payload.fallback = true;
         return payload;
       });
     }
     payload.value = output;
-    payload.fallback = true;
     return payload;
   };
 });
@@ -19588,7 +20783,7 @@ function _catch(innerType, catchValue) {
   return new ZodCatch({
     type: "catch",
     innerType,
-    catchValue: typeof catchValue === "function" ? catchValue : () => catchValue
+    catchValue: typeof catchValue === "function" ? catchValue : util_exports.constantCatch(catchValue)
   });
 }
 var ZodPipe = /* @__PURE__ */ $constructor("ZodPipe", (inst, def) => {
@@ -19620,6 +20815,18 @@ function readonly(innerType) {
   return new ZodReadonly({
     type: "readonly",
     innerType
+  });
+}
+var ZodLazy = /* @__PURE__ */ $constructor("ZodLazy", (inst, def) => {
+  $ZodLazy.init(inst, def);
+  ZodType.init(inst, def);
+  inst._zod.processJSONSchema = (ctx, json, params) => lazyProcessor(inst, ctx, json, params);
+  inst.unwrap = () => inst._zod.def.getter();
+});
+function lazy(getter) {
+  return new ZodLazy({
+    type: "lazy",
+    getter
   });
 }
 var ZodCustom = /* @__PURE__ */ $constructor("ZodCustom", (inst, def) => {
@@ -19662,6 +20869,31 @@ var ZodFirstPartyTypeKind;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind2) {
 })(ZodFirstPartyTypeKind || (ZodFirstPartyTypeKind = {}));
 
+// node_modules/zod/v4/classic/iso.js
+var iso_exports = {};
+__export(iso_exports, {
+  ZodISODate: () => ZodISODate,
+  ZodISODateTime: () => ZodISODateTime,
+  ZodISODuration: () => ZodISODuration,
+  ZodISOTime: () => ZodISOTime,
+  date: () => date2,
+  datetime: () => datetime2,
+  duration: () => duration2,
+  time: () => time2
+});
+function datetime2(params) {
+  return _isoDateTime(ZodISODateTime, params);
+}
+function date2(params) {
+  return _isoDate(ZodISODate, params);
+}
+function time2(params) {
+  return _isoTime(ZodISOTime, params);
+}
+function duration2(params) {
+  return _isoDuration(ZodISODuration, params);
+}
+
 // node_modules/zod/v4/classic/coerce.js
 var coerce_exports = {};
 __export(coerce_exports, {
@@ -19686,9 +20918,6 @@ function bigint2(params) {
 function date3(params) {
   return _coercedDate(ZodDate, params);
 }
-
-// node_modules/zod/v4/classic/external.js
-config(en_default());
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
@@ -20091,7 +21320,6 @@ var InitializedNotificationSchema = NotificationSchema.extend({
   method: literal("notifications/initialized"),
   params: NotificationsParamsSchema.optional()
 });
-var isInitializedNotification = (value) => InitializedNotificationSchema.safeParse(value).success;
 var PingRequestSchema = RequestSchema.extend({
   method: literal("ping"),
   params: BaseRequestParamsSchema.optional()
@@ -22203,8 +23431,8 @@ function createDefaultAjvInstance() {
     validateSchema: false,
     allErrors: true
   });
-  const addFormats = import_ajv_formats.default;
-  addFormats(ajv);
+  const addFormats2 = import_ajv_formats.default;
+  addFormats2(ajv);
   return ajv;
 }
 var AjvJsonSchemaValidator = class {
@@ -22986,751 +24214,851 @@ import path11 from "node:path";
 import fs10 from "node:fs";
 import { tmpdir } from "node:os";
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/client.js
-var ExperimentalClientTasks = class {
-  constructor(_client) {
-    this._client = _client;
+// node_modules/@modelcontextprotocol/client/dist/chunk-Br0eD_fh.mjs
+var __create2 = Object.create;
+var __defProp2 = Object.defineProperty;
+var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames2 = Object.getOwnPropertyNames;
+var __getProtoOf2 = Object.getPrototypeOf;
+var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __exportAll = (all, symbols) => {
+  let target = {};
+  for (var name in all) {
+    __defProp2(target, name, {
+      get: all[name],
+      enumerable: true
+    });
   }
-  /**
-   * Calls a tool and returns an AsyncGenerator that yields response messages.
-   * The generator is guaranteed to end with either a 'result' or 'error' message.
-   *
-   * This method provides streaming access to tool execution, allowing you to
-   * observe intermediate task status updates for long-running tool calls.
-   * Automatically validates structured output if the tool has an outputSchema.
-   *
-   * @example
-   * ```typescript
-   * const stream = client.experimental.tasks.callToolStream({ name: 'myTool', arguments: {} });
-   * for await (const message of stream) {
-   *   switch (message.type) {
-   *     case 'taskCreated':
-   *       console.log('Tool execution started:', message.task.taskId);
-   *       break;
-   *     case 'taskStatus':
-   *       console.log('Tool status:', message.task.status);
-   *       break;
-   *     case 'result':
-   *       console.log('Tool result:', message.result);
-   *       break;
-   *     case 'error':
-   *       console.error('Tool error:', message.error);
-   *       break;
-   *   }
-   * }
-   * ```
-   *
-   * @param params - Tool call parameters (name and arguments)
-   * @param resultSchema - Zod schema for validating the result (defaults to CallToolResultSchema)
-   * @param options - Optional request options (timeout, signal, task creation params, etc.)
-   * @returns AsyncGenerator that yields ResponseMessage objects
-   *
-   * @experimental
-   */
-  async *callToolStream(params, resultSchema = CallToolResultSchema, options) {
-    const clientInternal = this._client;
-    const optionsWithTask = {
-      ...options,
-      // We check if the tool is known to be a task during auto-configuration, but assume
-      // the caller knows what they're doing if they pass this explicitly
-      task: options?.task ?? (clientInternal.isToolTask(params.name) ? {} : void 0)
-    };
-    const stream = clientInternal.requestStream({ method: "tools/call", params }, resultSchema, optionsWithTask);
-    const validator = clientInternal.getToolOutputValidator(params.name);
-    for await (const message of stream) {
-      if (message.type === "result" && validator) {
-        const result = message.result;
-        if (!result.structuredContent && !result.isError) {
-          yield {
-            type: "error",
-            error: new McpError(ErrorCode.InvalidRequest, `Tool ${params.name} has an output schema but did not return structured content`)
-          };
-          return;
-        }
-        if (result.structuredContent) {
-          try {
-            const validationResult = validator(result.structuredContent);
-            if (!validationResult.valid) {
-              yield {
-                type: "error",
-                error: new McpError(ErrorCode.InvalidParams, `Structured content does not match the tool's output schema: ${validationResult.errorMessage}`)
-              };
-              return;
-            }
-          } catch (error2) {
-            if (error2 instanceof McpError) {
-              yield { type: "error", error: error2 };
-              return;
-            }
-            yield {
-              type: "error",
-              error: new McpError(ErrorCode.InvalidParams, `Failed to validate structured content: ${error2 instanceof Error ? error2.message : String(error2)}`)
-            };
-            return;
-          }
-        }
-      }
-      yield message;
-    }
+  if (symbols) {
+    __defProp2(target, Symbol.toStringTag, { value: "Module" });
   }
-  /**
-   * Gets the current status of a task.
-   *
-   * @param taskId - The task identifier
-   * @param options - Optional request options
-   * @returns The task status
-   *
-   * @experimental
-   */
-  async getTask(taskId, options) {
-    return this._client.getTask({ taskId }, options);
-  }
-  /**
-   * Retrieves the result of a completed task.
-   *
-   * @param taskId - The task identifier
-   * @param resultSchema - Zod schema for validating the result
-   * @param options - Optional request options
-   * @returns The task result
-   *
-   * @experimental
-   */
-  async getTaskResult(taskId, resultSchema, options) {
-    return this._client.getTaskResult({ taskId }, resultSchema, options);
-  }
-  /**
-   * Lists tasks with optional pagination.
-   *
-   * @param cursor - Optional pagination cursor
-   * @param options - Optional request options
-   * @returns List of tasks with optional next cursor
-   *
-   * @experimental
-   */
-  async listTasks(cursor, options) {
-    return this._client.listTasks(cursor ? { cursor } : void 0, options);
-  }
-  /**
-   * Cancels a running task.
-   *
-   * @param taskId - The task identifier
-   * @param options - Optional request options
-   *
-   * @experimental
-   */
-  async cancelTask(taskId, options) {
-    return this._client.cancelTask({ taskId }, options);
-  }
-  /**
-   * Sends a request and returns an AsyncGenerator that yields response messages.
-   * The generator is guaranteed to end with either a 'result' or 'error' message.
-   *
-   * This method provides streaming access to request processing, allowing you to
-   * observe intermediate task status updates for task-augmented requests.
-   *
-   * @param request - The request to send
-   * @param resultSchema - Zod schema for validating the result
-   * @param options - Optional request options (timeout, signal, task creation params, etc.)
-   * @returns AsyncGenerator that yields ResponseMessage objects
-   *
-   * @experimental
-   */
-  requestStream(request, resultSchema, options) {
-    return this._client.requestStream(request, resultSchema, options);
-  }
+  return target;
 };
-
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js
-function applyElicitationDefaults(schema, data) {
-  if (!schema || data === null || typeof data !== "object")
-    return;
-  if (schema.type === "object" && schema.properties && typeof schema.properties === "object") {
-    const obj = data;
-    const props = schema.properties;
-    for (const key of Object.keys(props)) {
-      const propSchema = props[key];
-      if (obj[key] === void 0 && Object.prototype.hasOwnProperty.call(propSchema, "default")) {
-        obj[key] = propSchema.default;
-      }
-      if (obj[key] !== void 0) {
-        applyElicitationDefaults(propSchema, obj[key]);
+var __copyProps2 = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (var keys = __getOwnPropNames2(from), i = 0, n = keys.length, key; i < n; i++) {
+      key = keys[i];
+      if (!__hasOwnProp2.call(to, key) && key !== except) {
+        __defProp2(to, key, {
+          get: ((k) => from[k]).bind(null, key),
+          enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable
+        });
       }
     }
   }
-  if (Array.isArray(schema.anyOf)) {
-    for (const sub of schema.anyOf) {
-      if (typeof sub !== "boolean") {
-        applyElicitationDefaults(sub, data);
-      }
-    }
-  }
-  if (Array.isArray(schema.oneOf)) {
-    for (const sub of schema.oneOf) {
-      if (typeof sub !== "boolean") {
-        applyElicitationDefaults(sub, data);
-      }
-    }
-  }
-}
-function getSupportedElicitationModes(capabilities) {
-  if (!capabilities) {
-    return { supportsFormMode: false, supportsUrlMode: false };
-  }
-  const hasFormCapability = capabilities.form !== void 0;
-  const hasUrlCapability = capabilities.url !== void 0;
-  const supportsFormMode = hasFormCapability || !hasFormCapability && !hasUrlCapability;
-  const supportsUrlMode = hasUrlCapability;
-  return { supportsFormMode, supportsUrlMode };
-}
-var Client = class extends Protocol {
-  /**
-   * Initializes this client with the given name and version information.
-   */
-  constructor(_clientInfo, options) {
-    super(options);
-    this._clientInfo = _clientInfo;
-    this._cachedToolOutputValidators = /* @__PURE__ */ new Map();
-    this._cachedKnownTaskTools = /* @__PURE__ */ new Set();
-    this._cachedRequiredTaskTools = /* @__PURE__ */ new Set();
-    this._listChangedDebounceTimers = /* @__PURE__ */ new Map();
-    this._capabilities = options?.capabilities ?? {};
-    this._jsonSchemaValidator = options?.jsonSchemaValidator ?? new AjvJsonSchemaValidator();
-    if (options?.listChanged) {
-      this._pendingListChangedConfig = options.listChanged;
-    }
-  }
-  /**
-   * Set up handlers for list changed notifications based on config and server capabilities.
-   * This should only be called after initialization when server capabilities are known.
-   * Handlers are silently skipped if the server doesn't advertise the corresponding listChanged capability.
-   * @internal
-   */
-  _setupListChangedHandlers(config2) {
-    if (config2.tools && this._serverCapabilities?.tools?.listChanged) {
-      this._setupListChangedHandler("tools", ToolListChangedNotificationSchema, config2.tools, async () => {
-        const result = await this.listTools();
-        return result.tools;
-      });
-    }
-    if (config2.prompts && this._serverCapabilities?.prompts?.listChanged) {
-      this._setupListChangedHandler("prompts", PromptListChangedNotificationSchema, config2.prompts, async () => {
-        const result = await this.listPrompts();
-        return result.prompts;
-      });
-    }
-    if (config2.resources && this._serverCapabilities?.resources?.listChanged) {
-      this._setupListChangedHandler("resources", ResourceListChangedNotificationSchema, config2.resources, async () => {
-        const result = await this.listResources();
-        return result.resources;
-      });
-    }
-  }
-  /**
-   * Access experimental features.
-   *
-   * WARNING: These APIs are experimental and may change without notice.
-   *
-   * @experimental
-   */
-  get experimental() {
-    if (!this._experimental) {
-      this._experimental = {
-        tasks: new ExperimentalClientTasks(this)
-      };
-    }
-    return this._experimental;
-  }
-  /**
-   * Registers new capabilities. This can only be called before connecting to a transport.
-   *
-   * The new capabilities will be merged with any existing capabilities previously given (e.g., at initialization).
-   */
-  registerCapabilities(capabilities) {
-    if (this.transport) {
-      throw new Error("Cannot register capabilities after connecting to transport");
-    }
-    this._capabilities = mergeCapabilities(this._capabilities, capabilities);
-  }
-  /**
-   * Override request handler registration to enforce client-side validation for elicitation.
-   */
-  setRequestHandler(requestSchema, handler) {
-    const shape = getObjectShape(requestSchema);
-    const methodSchema = shape?.method;
-    if (!methodSchema) {
-      throw new Error("Schema is missing a method literal");
-    }
-    let methodValue;
-    if (isZ4Schema(methodSchema)) {
-      const v4Schema = methodSchema;
-      const v4Def = v4Schema._zod?.def;
-      methodValue = v4Def?.value ?? v4Schema.value;
-    } else {
-      const v3Schema = methodSchema;
-      const legacyDef = v3Schema._def;
-      methodValue = legacyDef?.value ?? v3Schema.value;
-    }
-    if (typeof methodValue !== "string") {
-      throw new Error("Schema method literal must be a string");
-    }
-    const method = methodValue;
-    if (method === "elicitation/create") {
-      const wrappedHandler = async (request, extra) => {
-        const validatedRequest = safeParse2(ElicitRequestSchema, request);
-        if (!validatedRequest.success) {
-          const errorMessage = validatedRequest.error instanceof Error ? validatedRequest.error.message : String(validatedRequest.error);
-          throw new McpError(ErrorCode.InvalidParams, `Invalid elicitation request: ${errorMessage}`);
-        }
-        const { params } = validatedRequest.data;
-        params.mode = params.mode ?? "form";
-        const { supportsFormMode, supportsUrlMode } = getSupportedElicitationModes(this._capabilities.elicitation);
-        if (params.mode === "form" && !supportsFormMode) {
-          throw new McpError(ErrorCode.InvalidParams, "Client does not support form-mode elicitation requests");
-        }
-        if (params.mode === "url" && !supportsUrlMode) {
-          throw new McpError(ErrorCode.InvalidParams, "Client does not support URL-mode elicitation requests");
-        }
-        const result = await Promise.resolve(handler(request, extra));
-        if (params.task) {
-          const taskValidationResult = safeParse2(CreateTaskResultSchema, result);
-          if (!taskValidationResult.success) {
-            const errorMessage = taskValidationResult.error instanceof Error ? taskValidationResult.error.message : String(taskValidationResult.error);
-            throw new McpError(ErrorCode.InvalidParams, `Invalid task creation result: ${errorMessage}`);
-          }
-          return taskValidationResult.data;
-        }
-        const validationResult = safeParse2(ElicitResultSchema, result);
-        if (!validationResult.success) {
-          const errorMessage = validationResult.error instanceof Error ? validationResult.error.message : String(validationResult.error);
-          throw new McpError(ErrorCode.InvalidParams, `Invalid elicitation result: ${errorMessage}`);
-        }
-        const validatedResult = validationResult.data;
-        const requestedSchema = params.mode === "form" ? params.requestedSchema : void 0;
-        if (params.mode === "form" && validatedResult.action === "accept" && validatedResult.content && requestedSchema) {
-          if (this._capabilities.elicitation?.form?.applyDefaults) {
-            try {
-              applyElicitationDefaults(requestedSchema, validatedResult.content);
-            } catch {
-            }
-          }
-        }
-        return validatedResult;
-      };
-      return super.setRequestHandler(requestSchema, wrappedHandler);
-    }
-    if (method === "sampling/createMessage") {
-      const wrappedHandler = async (request, extra) => {
-        const validatedRequest = safeParse2(CreateMessageRequestSchema, request);
-        if (!validatedRequest.success) {
-          const errorMessage = validatedRequest.error instanceof Error ? validatedRequest.error.message : String(validatedRequest.error);
-          throw new McpError(ErrorCode.InvalidParams, `Invalid sampling request: ${errorMessage}`);
-        }
-        const { params } = validatedRequest.data;
-        const result = await Promise.resolve(handler(request, extra));
-        if (params.task) {
-          const taskValidationResult = safeParse2(CreateTaskResultSchema, result);
-          if (!taskValidationResult.success) {
-            const errorMessage = taskValidationResult.error instanceof Error ? taskValidationResult.error.message : String(taskValidationResult.error);
-            throw new McpError(ErrorCode.InvalidParams, `Invalid task creation result: ${errorMessage}`);
-          }
-          return taskValidationResult.data;
-        }
-        const hasTools = params.tools || params.toolChoice;
-        const resultSchema = hasTools ? CreateMessageResultWithToolsSchema : CreateMessageResultSchema;
-        const validationResult = safeParse2(resultSchema, result);
-        if (!validationResult.success) {
-          const errorMessage = validationResult.error instanceof Error ? validationResult.error.message : String(validationResult.error);
-          throw new McpError(ErrorCode.InvalidParams, `Invalid sampling result: ${errorMessage}`);
-        }
-        return validationResult.data;
-      };
-      return super.setRequestHandler(requestSchema, wrappedHandler);
-    }
-    return super.setRequestHandler(requestSchema, handler);
-  }
-  assertCapability(capability, method) {
-    if (!this._serverCapabilities?.[capability]) {
-      throw new Error(`Server does not support ${capability} (required for ${method})`);
-    }
-  }
-  async connect(transport, options) {
-    await super.connect(transport);
-    if (transport.sessionId !== void 0) {
-      return;
-    }
-    try {
-      const result = await this.request({
-        method: "initialize",
-        params: {
-          protocolVersion: LATEST_PROTOCOL_VERSION,
-          capabilities: this._capabilities,
-          clientInfo: this._clientInfo
-        }
-      }, InitializeResultSchema, options);
-      if (result === void 0) {
-        throw new Error(`Server sent invalid initialize result: ${result}`);
-      }
-      if (!SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
-        throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
-      }
-      this._serverCapabilities = result.capabilities;
-      this._serverVersion = result.serverInfo;
-      if (transport.setProtocolVersion) {
-        transport.setProtocolVersion(result.protocolVersion);
-      }
-      this._instructions = result.instructions;
-      await this.notification({
-        method: "notifications/initialized"
-      });
-      if (this._pendingListChangedConfig) {
-        this._setupListChangedHandlers(this._pendingListChangedConfig);
-        this._pendingListChangedConfig = void 0;
-      }
-    } catch (error2) {
-      void this.close();
-      throw error2;
-    }
-  }
-  /**
-   * After initialization has completed, this will be populated with the server's reported capabilities.
-   */
-  getServerCapabilities() {
-    return this._serverCapabilities;
-  }
-  /**
-   * After initialization has completed, this will be populated with information about the server's name and version.
-   */
-  getServerVersion() {
-    return this._serverVersion;
-  }
-  /**
-   * After initialization has completed, this may be populated with information about the server's instructions.
-   */
-  getInstructions() {
-    return this._instructions;
-  }
-  assertCapabilityForMethod(method) {
-    switch (method) {
-      case "logging/setLevel":
-        if (!this._serverCapabilities?.logging) {
-          throw new Error(`Server does not support logging (required for ${method})`);
-        }
-        break;
-      case "prompts/get":
-      case "prompts/list":
-        if (!this._serverCapabilities?.prompts) {
-          throw new Error(`Server does not support prompts (required for ${method})`);
-        }
-        break;
-      case "resources/list":
-      case "resources/templates/list":
-      case "resources/read":
-      case "resources/subscribe":
-      case "resources/unsubscribe":
-        if (!this._serverCapabilities?.resources) {
-          throw new Error(`Server does not support resources (required for ${method})`);
-        }
-        if (method === "resources/subscribe" && !this._serverCapabilities.resources.subscribe) {
-          throw new Error(`Server does not support resource subscriptions (required for ${method})`);
-        }
-        break;
-      case "tools/call":
-      case "tools/list":
-        if (!this._serverCapabilities?.tools) {
-          throw new Error(`Server does not support tools (required for ${method})`);
-        }
-        break;
-      case "completion/complete":
-        if (!this._serverCapabilities?.completions) {
-          throw new Error(`Server does not support completions (required for ${method})`);
-        }
-        break;
-      case "initialize":
-        break;
-      case "ping":
-        break;
-    }
-  }
-  assertNotificationCapability(method) {
-    switch (method) {
-      case "notifications/roots/list_changed":
-        if (!this._capabilities.roots?.listChanged) {
-          throw new Error(`Client does not support roots list changed notifications (required for ${method})`);
-        }
-        break;
-      case "notifications/initialized":
-        break;
-      case "notifications/cancelled":
-        break;
-      case "notifications/progress":
-        break;
-    }
-  }
-  assertRequestHandlerCapability(method) {
-    if (!this._capabilities) {
-      return;
-    }
-    switch (method) {
-      case "sampling/createMessage":
-        if (!this._capabilities.sampling) {
-          throw new Error(`Client does not support sampling capability (required for ${method})`);
-        }
-        break;
-      case "elicitation/create":
-        if (!this._capabilities.elicitation) {
-          throw new Error(`Client does not support elicitation capability (required for ${method})`);
-        }
-        break;
-      case "roots/list":
-        if (!this._capabilities.roots) {
-          throw new Error(`Client does not support roots capability (required for ${method})`);
-        }
-        break;
-      case "tasks/get":
-      case "tasks/list":
-      case "tasks/result":
-      case "tasks/cancel":
-        if (!this._capabilities.tasks) {
-          throw new Error(`Client does not support tasks capability (required for ${method})`);
-        }
-        break;
-      case "ping":
-        break;
-    }
-  }
-  assertTaskCapability(method) {
-    assertToolsCallTaskCapability(this._serverCapabilities?.tasks?.requests, method, "Server");
-  }
-  assertTaskHandlerCapability(method) {
-    if (!this._capabilities) {
-      return;
-    }
-    assertClientRequestTaskCapability(this._capabilities.tasks?.requests, method, "Client");
-  }
-  async ping(options) {
-    return this.request({ method: "ping" }, EmptyResultSchema, options);
-  }
-  async complete(params, options) {
-    return this.request({ method: "completion/complete", params }, CompleteResultSchema, options);
-  }
-  async setLoggingLevel(level, options) {
-    return this.request({ method: "logging/setLevel", params: { level } }, EmptyResultSchema, options);
-  }
-  async getPrompt(params, options) {
-    return this.request({ method: "prompts/get", params }, GetPromptResultSchema, options);
-  }
-  async listPrompts(params, options) {
-    return this.request({ method: "prompts/list", params }, ListPromptsResultSchema, options);
-  }
-  async listResources(params, options) {
-    return this.request({ method: "resources/list", params }, ListResourcesResultSchema, options);
-  }
-  async listResourceTemplates(params, options) {
-    return this.request({ method: "resources/templates/list", params }, ListResourceTemplatesResultSchema, options);
-  }
-  async readResource(params, options) {
-    return this.request({ method: "resources/read", params }, ReadResourceResultSchema, options);
-  }
-  async subscribeResource(params, options) {
-    return this.request({ method: "resources/subscribe", params }, EmptyResultSchema, options);
-  }
-  async unsubscribeResource(params, options) {
-    return this.request({ method: "resources/unsubscribe", params }, EmptyResultSchema, options);
-  }
-  /**
-   * Calls a tool and waits for the result. Automatically validates structured output if the tool has an outputSchema.
-   *
-   * For task-based execution with streaming behavior, use client.experimental.tasks.callToolStream() instead.
-   */
-  async callTool(params, resultSchema = CallToolResultSchema, options) {
-    if (this.isToolTaskRequired(params.name)) {
-      throw new McpError(ErrorCode.InvalidRequest, `Tool "${params.name}" requires task-based execution. Use client.experimental.tasks.callToolStream() instead.`);
-    }
-    const result = await this.request({ method: "tools/call", params }, resultSchema, options);
-    const validator = this.getToolOutputValidator(params.name);
-    if (validator) {
-      if (!result.structuredContent && !result.isError) {
-        throw new McpError(ErrorCode.InvalidRequest, `Tool ${params.name} has an output schema but did not return structured content`);
-      }
-      if (result.structuredContent) {
-        try {
-          const validationResult = validator(result.structuredContent);
-          if (!validationResult.valid) {
-            throw new McpError(ErrorCode.InvalidParams, `Structured content does not match the tool's output schema: ${validationResult.errorMessage}`);
-          }
-        } catch (error2) {
-          if (error2 instanceof McpError) {
-            throw error2;
-          }
-          throw new McpError(ErrorCode.InvalidParams, `Failed to validate structured content: ${error2 instanceof Error ? error2.message : String(error2)}`);
-        }
-      }
-    }
-    return result;
-  }
-  isToolTask(toolName) {
-    if (!this._serverCapabilities?.tasks?.requests?.tools?.call) {
-      return false;
-    }
-    return this._cachedKnownTaskTools.has(toolName);
-  }
-  /**
-   * Check if a tool requires task-based execution.
-   * Unlike isToolTask which includes 'optional' tools, this only checks for 'required'.
-   */
-  isToolTaskRequired(toolName) {
-    return this._cachedRequiredTaskTools.has(toolName);
-  }
-  /**
-   * Cache validators for tool output schemas.
-   * Called after listTools() to pre-compile validators for better performance.
-   */
-  cacheToolMetadata(tools) {
-    this._cachedToolOutputValidators.clear();
-    this._cachedKnownTaskTools.clear();
-    this._cachedRequiredTaskTools.clear();
-    for (const tool of tools) {
-      if (tool.outputSchema) {
-        const toolValidator = this._jsonSchemaValidator.getValidator(tool.outputSchema);
-        this._cachedToolOutputValidators.set(tool.name, toolValidator);
-      }
-      const taskSupport = tool.execution?.taskSupport;
-      if (taskSupport === "required" || taskSupport === "optional") {
-        this._cachedKnownTaskTools.add(tool.name);
-      }
-      if (taskSupport === "required") {
-        this._cachedRequiredTaskTools.add(tool.name);
-      }
-    }
-  }
-  /**
-   * Get cached validator for a tool
-   */
-  getToolOutputValidator(toolName) {
-    return this._cachedToolOutputValidators.get(toolName);
-  }
-  async listTools(params, options) {
-    const result = await this.request({ method: "tools/list", params }, ListToolsResultSchema, options);
-    this.cacheToolMetadata(result.tools);
-    return result;
-  }
-  /**
-   * Set up a single list changed handler.
-   * @internal
-   */
-  _setupListChangedHandler(listType, notificationSchema, options, fetcher) {
-    const parseResult = ListChangedOptionsBaseSchema.safeParse(options);
-    if (!parseResult.success) {
-      throw new Error(`Invalid ${listType} listChanged options: ${parseResult.error.message}`);
-    }
-    if (typeof options.onChanged !== "function") {
-      throw new Error(`Invalid ${listType} listChanged options: onChanged must be a function`);
-    }
-    const { autoRefresh, debounceMs } = parseResult.data;
-    const { onChanged } = options;
-    const refresh = async () => {
-      if (!autoRefresh) {
-        onChanged(null, null);
-        return;
-      }
-      try {
-        const items = await fetcher();
-        onChanged(null, items);
-      } catch (e) {
-        const error2 = e instanceof Error ? e : new Error(String(e));
-        onChanged(error2, null);
-      }
-    };
-    const handler = () => {
-      if (debounceMs) {
-        const existingTimer = this._listChangedDebounceTimers.get(listType);
-        if (existingTimer) {
-          clearTimeout(existingTimer);
-        }
-        const timer = setTimeout(refresh, debounceMs);
-        this._listChangedDebounceTimers.set(listType, timer);
-      } else {
-        refresh();
-      }
-    };
-    this.setNotificationHandler(notificationSchema, handler);
-  }
-  async sendRootsListChanged() {
-    return this.notification({ method: "notifications/roots/list_changed" });
-  }
+  return to;
 };
+var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", {
+  value: mod,
+  enumerable: true
+}) : target, mod));
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/transport.js
-function normalizeHeaders(headers) {
-  if (!headers)
-    return {};
-  if (headers instanceof Headers) {
-    return Object.fromEntries(headers.entries());
-  }
-  if (Array.isArray(headers)) {
-    return Object.fromEntries(headers);
-  }
-  return { ...headers };
+// node_modules/@modelcontextprotocol/client/dist/dialects-BOhdv1Fc.mjs
+var DRAFT_2020_12_URIS = /* @__PURE__ */ new Set(["https://json-schema.org/draft/2020-12/schema", "http://json-schema.org/draft/2020-12/schema"]);
+var DRAFT_2019_09_URIS = /* @__PURE__ */ new Set(["https://json-schema.org/draft/2019-09/schema", "http://json-schema.org/draft/2019-09/schema"]);
+var DRAFT_07_URIS = /* @__PURE__ */ new Set(["https://json-schema.org/draft-07/schema", "http://json-schema.org/draft-07/schema"]);
+var DRAFT_06_URIS = /* @__PURE__ */ new Set(["https://json-schema.org/draft-06/schema", "http://json-schema.org/draft-06/schema"]);
+function declares2019Dialect($schema) {
+  return typeof $schema === "string" && DRAFT_2019_09_URIS.has($schema.replace(/#$/, ""));
 }
-function createFetchWithInit(baseFetch = fetch, baseInit) {
-  if (!baseInit) {
-    return baseFetch;
-  }
-  return async (url2, init) => {
-    const mergedInit = {
-      ...baseInit,
-      ...init,
-      // Headers need special handling - merge instead of replace
-      headers: init?.headers ? { ...normalizeHeaders(baseInit.headers), ...normalizeHeaders(init.headers) } : baseInit.headers
-    };
-    return baseFetch(url2, mergedInit);
-  };
+function declaredDialect(schema, remedy) {
+  if (!("$schema" in schema) || typeof schema.$schema !== "string") return "2020-12";
+  const declared = schema.$schema.replace(/#$/, "");
+  if (DRAFT_2020_12_URIS.has(declared)) return "2020-12";
+  if (DRAFT_2019_09_URIS.has(declared)) return "2019-09";
+  if (DRAFT_07_URIS.has(declared) || DRAFT_06_URIS.has(declared)) return "draft-7";
+  throw new Error(`JSON Schema declares an unsupported dialect ("$schema": "${schema.$schema.slice(0, 200)}"). The default validator supports JSON Schema 2020-12, 2019-09, draft-07, and draft-06; ${remedy}`);
 }
 
-// node_modules/pkce-challenge/dist/index.node.js
-var crypto;
-crypto = globalThis.crypto?.webcrypto ?? // Node.js [18-16] REPL
-globalThis.crypto ?? // Node.js >18
-import("node:crypto").then((m) => m.webcrypto);
-async function getRandomValues(size) {
-  return (await crypto).getRandomValues(new Uint8Array(size));
-}
-async function random(size) {
-  const mask = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
-  const evenDistCutoff = Math.pow(2, 8) - Math.pow(2, 8) % mask.length;
-  let result = "";
-  while (result.length < size) {
-    const randomBytes = await getRandomValues(size - result.length);
-    for (const randomByte of randomBytes) {
-      if (randomByte < evenDistCutoff) {
-        result += mask[randomByte % mask.length];
-      }
-    }
+// node_modules/@modelcontextprotocol/core/dist/auth-CUe6YdwF.mjs
+var LATEST_PROTOCOL_VERSION2 = "2025-11-25";
+var SUPPORTED_PROTOCOL_VERSIONS2 = [
+  LATEST_PROTOCOL_VERSION2,
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+  "2024-10-07"
+];
+var RELATED_TASK_META_KEY2 = "io.modelcontextprotocol/related-task";
+var PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
+var CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo";
+var SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+var CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities";
+var SUBSCRIPTION_ID_META_KEY = "io.modelcontextprotocol/subscriptionId";
+var LOG_LEVEL_META_KEY = "io.modelcontextprotocol/logLevel";
+var JSONRPC_VERSION2 = "2.0";
+var JSONValueSchema = lazy(() => union([
+  string2(),
+  number2(),
+  boolean2(),
+  _null3(),
+  record(string2(), JSONValueSchema),
+  array(JSONValueSchema)
+]));
+var JSONObjectSchema = record(string2(), JSONValueSchema);
+var JSONArraySchema = array(JSONValueSchema);
+var ProgressTokenSchema2 = union([string2(), number2().int()]);
+var CursorSchema2 = string2();
+var TaskMetadataSchema2 = object2({ ttl: number2().optional() });
+var RelatedTaskMetadataSchema2 = object2({ taskId: string2() });
+var RequestMetaSchema2 = looseObject({
+  progressToken: ProgressTokenSchema2.optional(),
+  [RELATED_TASK_META_KEY2]: RelatedTaskMetadataSchema2.optional()
+});
+var BaseRequestParamsSchema2 = object2({ _meta: RequestMetaSchema2.optional() });
+var TaskAugmentedRequestParamsSchema2 = BaseRequestParamsSchema2.extend({ task: TaskMetadataSchema2.optional() });
+var RequestSchema2 = object2({
+  method: string2(),
+  params: BaseRequestParamsSchema2.loose().optional()
+});
+var NotificationsParamsSchema2 = object2({ _meta: RequestMetaSchema2.optional() });
+var NotificationSchema2 = object2({
+  method: string2(),
+  params: NotificationsParamsSchema2.loose().optional()
+});
+var ResultMetaObjectSchema = looseObject({ get [SERVER_INFO_META_KEY]() {
+  return ImplementationSchema2.optional().catch(void 0);
+} });
+var ResultSchema2 = looseObject({ _meta: ResultMetaObjectSchema.optional() });
+var RequestIdSchema2 = union([string2(), number2().int()]);
+var JSONRPCRequestSchema2 = object2({
+  jsonrpc: literal(JSONRPC_VERSION2),
+  id: RequestIdSchema2,
+  ...RequestSchema2.shape
+}).strict();
+var JSONRPCNotificationSchema2 = object2({
+  jsonrpc: literal(JSONRPC_VERSION2),
+  ...NotificationSchema2.shape
+}).strict();
+var JSONRPCResultResponseSchema2 = object2({
+  jsonrpc: literal(JSONRPC_VERSION2),
+  id: RequestIdSchema2,
+  result: ResultSchema2
+}).strict();
+var JSONRPCErrorResponseSchema2 = object2({
+  jsonrpc: literal(JSONRPC_VERSION2),
+  id: RequestIdSchema2.optional(),
+  error: object2({
+    code: number2().int(),
+    message: string2(),
+    data: unknown().optional()
+  })
+}).strict();
+var JSONRPCMessageSchema2 = union([
+  JSONRPCRequestSchema2,
+  JSONRPCNotificationSchema2,
+  JSONRPCResultResponseSchema2,
+  JSONRPCErrorResponseSchema2
+]);
+var JSONRPCResponseSchema2 = union([JSONRPCResultResponseSchema2, JSONRPCErrorResponseSchema2]);
+var EmptyResultSchema2 = ResultSchema2.strict();
+var CancelledNotificationParamsSchema2 = NotificationsParamsSchema2.extend({
+  requestId: RequestIdSchema2.optional(),
+  reason: string2().optional()
+});
+var CancelledNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/cancelled"),
+  params: CancelledNotificationParamsSchema2
+});
+var IconSchema2 = object2({
+  src: string2(),
+  mimeType: string2().optional(),
+  sizes: array(string2()).optional(),
+  theme: _enum(["light", "dark"]).optional()
+});
+var IconsSchema2 = object2({ icons: array(IconSchema2).optional() });
+var BaseMetadataSchema2 = object2({
+  name: string2(),
+  title: string2().optional()
+});
+var ImplementationSchema2 = BaseMetadataSchema2.extend({
+  ...BaseMetadataSchema2.shape,
+  ...IconsSchema2.shape,
+  version: string2(),
+  websiteUrl: string2().optional(),
+  description: string2().optional()
+});
+var FormElicitationCapabilitySchema2 = intersection(object2({ applyDefaults: boolean2().optional() }), JSONObjectSchema);
+var ElicitationCapabilitySchema2 = preprocess((value) => {
+  if (value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0) return { form: {} };
+  return value;
+}, intersection(object2({
+  form: FormElicitationCapabilitySchema2.optional(),
+  url: JSONObjectSchema.optional()
+}), JSONObjectSchema.optional()));
+var ClientTasksCapabilitySchema2 = looseObject({
+  list: JSONObjectSchema.optional(),
+  cancel: JSONObjectSchema.optional(),
+  requests: looseObject({
+    sampling: looseObject({ createMessage: JSONObjectSchema.optional() }).optional(),
+    elicitation: looseObject({ create: JSONObjectSchema.optional() }).optional()
+  }).optional()
+});
+var ServerTasksCapabilitySchema2 = looseObject({
+  list: JSONObjectSchema.optional(),
+  cancel: JSONObjectSchema.optional(),
+  requests: looseObject({ tools: looseObject({ call: JSONObjectSchema.optional() }).optional() }).optional()
+});
+var ClientCapabilitiesSchema2 = object2({
+  experimental: record(string2(), JSONObjectSchema).optional(),
+  sampling: object2({
+    context: JSONObjectSchema.optional(),
+    tools: JSONObjectSchema.optional()
+  }).optional(),
+  elicitation: ElicitationCapabilitySchema2.optional(),
+  roots: object2({ listChanged: boolean2().optional() }).optional(),
+  tasks: ClientTasksCapabilitySchema2.optional(),
+  extensions: record(string2(), JSONObjectSchema).optional()
+});
+var InitializeRequestParamsSchema2 = BaseRequestParamsSchema2.extend({
+  protocolVersion: string2(),
+  capabilities: ClientCapabilitiesSchema2,
+  clientInfo: ImplementationSchema2
+});
+var InitializeRequestSchema2 = RequestSchema2.extend({
+  method: literal("initialize"),
+  params: InitializeRequestParamsSchema2
+});
+var ServerCapabilitiesSchema2 = object2({
+  experimental: record(string2(), JSONObjectSchema).optional(),
+  logging: JSONObjectSchema.optional(),
+  completions: JSONObjectSchema.optional(),
+  prompts: object2({ listChanged: boolean2().optional() }).optional(),
+  resources: object2({
+    subscribe: boolean2().optional(),
+    listChanged: boolean2().optional()
+  }).optional(),
+  tools: object2({ listChanged: boolean2().optional() }).optional(),
+  tasks: ServerTasksCapabilitySchema2.optional(),
+  extensions: record(string2(), JSONObjectSchema).optional()
+});
+var InitializeResultSchema2 = ResultSchema2.extend({
+  protocolVersion: string2(),
+  capabilities: ServerCapabilitiesSchema2,
+  serverInfo: ImplementationSchema2,
+  instructions: string2().optional()
+});
+var InitializedNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/initialized"),
+  params: NotificationsParamsSchema2.optional()
+});
+var DiscoverRequestSchema = RequestSchema2.extend({
+  method: literal("server/discover"),
+  params: BaseRequestParamsSchema2.optional()
+});
+var DiscoverResultSchema = ResultSchema2.extend({
+  supportedVersions: array(string2()),
+  capabilities: ServerCapabilitiesSchema2,
+  instructions: string2().optional()
+});
+var PingRequestSchema2 = RequestSchema2.extend({
+  method: literal("ping"),
+  params: BaseRequestParamsSchema2.optional()
+});
+var ProgressSchema2 = object2({
+  progress: number2(),
+  total: optional(number2()),
+  message: optional(string2())
+});
+var ProgressNotificationParamsSchema2 = object2({
+  ...NotificationsParamsSchema2.shape,
+  ...ProgressSchema2.shape,
+  progressToken: ProgressTokenSchema2
+});
+var ProgressNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/progress"),
+  params: ProgressNotificationParamsSchema2
+});
+var PaginatedRequestParamsSchema2 = BaseRequestParamsSchema2.extend({ cursor: CursorSchema2.optional() });
+var PaginatedRequestSchema2 = RequestSchema2.extend({ params: PaginatedRequestParamsSchema2.optional() });
+var PaginatedResultSchema2 = ResultSchema2.extend({ nextCursor: CursorSchema2.optional() });
+var ResourceContentsSchema2 = object2({
+  uri: string2(),
+  mimeType: optional(string2()),
+  _meta: record(string2(), unknown()).optional()
+});
+var TextResourceContentsSchema2 = ResourceContentsSchema2.extend({ text: string2() });
+var Base64Schema2 = string2().refine((val) => {
+  try {
+    atob(val);
+    return true;
+  } catch {
+    return false;
   }
-  return result;
-}
-async function generateVerifier(length) {
-  return await random(length);
-}
-async function generateChallenge(code_verifier) {
-  const buffer = await (await crypto).subtle.digest("SHA-256", new TextEncoder().encode(code_verifier));
-  return btoa(String.fromCharCode(...new Uint8Array(buffer))).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "");
-}
-async function pkceChallenge(length) {
-  if (!length)
-    length = 43;
-  if (length < 43 || length > 128) {
-    throw `Expected a length between 43 and 128. Received ${length}.`;
-  }
-  const verifier = await generateVerifier(length);
-  const challenge = await generateChallenge(verifier);
-  return {
-    code_verifier: verifier,
-    code_challenge: challenge
-  };
-}
-
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth.js
+}, { message: "Invalid Base64 string" });
+var BlobResourceContentsSchema2 = ResourceContentsSchema2.extend({ blob: Base64Schema2 });
+var RoleSchema2 = _enum(["user", "assistant"]);
+var AnnotationsSchema2 = object2({
+  audience: array(RoleSchema2).optional(),
+  priority: number2().min(0).max(1).optional(),
+  lastModified: iso_exports.datetime({ offset: true }).optional()
+});
+var ResourceSchema2 = object2({
+  ...BaseMetadataSchema2.shape,
+  ...IconsSchema2.shape,
+  uri: string2(),
+  description: optional(string2()),
+  mimeType: optional(string2()),
+  size: optional(number2()),
+  annotations: AnnotationsSchema2.optional(),
+  _meta: optional(looseObject({}))
+});
+var ResourceTemplateSchema2 = object2({
+  ...BaseMetadataSchema2.shape,
+  ...IconsSchema2.shape,
+  uriTemplate: string2(),
+  description: optional(string2()),
+  mimeType: optional(string2()),
+  annotations: AnnotationsSchema2.optional(),
+  _meta: optional(looseObject({}))
+});
+var ListResourcesRequestSchema2 = PaginatedRequestSchema2.extend({ method: literal("resources/list") });
+var ListResourcesResultSchema2 = PaginatedResultSchema2.extend({ resources: array(ResourceSchema2) });
+var ListResourceTemplatesRequestSchema2 = PaginatedRequestSchema2.extend({ method: literal("resources/templates/list") });
+var ListResourceTemplatesResultSchema2 = PaginatedResultSchema2.extend({ resourceTemplates: array(ResourceTemplateSchema2) });
+var ResourceRequestParamsSchema2 = BaseRequestParamsSchema2.extend({ uri: string2() });
+var ReadResourceRequestParamsSchema2 = ResourceRequestParamsSchema2;
+var ReadResourceRequestSchema2 = RequestSchema2.extend({
+  method: literal("resources/read"),
+  params: ReadResourceRequestParamsSchema2
+});
+var ReadResourceResultSchema2 = ResultSchema2.extend({ contents: array(union([TextResourceContentsSchema2, BlobResourceContentsSchema2])) });
+var ResourceListChangedNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/resources/list_changed"),
+  params: NotificationsParamsSchema2.optional()
+});
+var SubscribeRequestParamsSchema2 = ResourceRequestParamsSchema2;
+var SubscribeRequestSchema2 = RequestSchema2.extend({
+  method: literal("resources/subscribe"),
+  params: SubscribeRequestParamsSchema2
+});
+var UnsubscribeRequestParamsSchema2 = ResourceRequestParamsSchema2;
+var UnsubscribeRequestSchema2 = RequestSchema2.extend({
+  method: literal("resources/unsubscribe"),
+  params: UnsubscribeRequestParamsSchema2
+});
+var SubscriptionFilterSchema = object2({
+  toolsListChanged: boolean2().optional(),
+  promptsListChanged: boolean2().optional(),
+  resourcesListChanged: boolean2().optional(),
+  resourceSubscriptions: array(string2()).optional()
+});
+var SubscriptionsListenRequestParamsSchema = BaseRequestParamsSchema2.extend({ notifications: SubscriptionFilterSchema });
+var SubscriptionsListenRequestSchema = RequestSchema2.extend({
+  method: literal("subscriptions/listen"),
+  params: SubscriptionsListenRequestParamsSchema
+});
+var SubscriptionsAcknowledgedNotificationParamsSchema = NotificationsParamsSchema2.extend({ notifications: SubscriptionFilterSchema });
+var SubscriptionsAcknowledgedNotificationSchema = NotificationSchema2.extend({
+  method: literal("notifications/subscriptions/acknowledged"),
+  params: SubscriptionsAcknowledgedNotificationParamsSchema
+});
+var SubscriptionsListenResultMetaSchema = ResultMetaObjectSchema.extend({ [SUBSCRIPTION_ID_META_KEY]: RequestIdSchema2 });
+var SubscriptionsListenResultSchema = ResultSchema2.extend({ _meta: SubscriptionsListenResultMetaSchema });
+var ResourceUpdatedNotificationParamsSchema2 = NotificationsParamsSchema2.extend({ uri: string2() });
+var ResourceUpdatedNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/resources/updated"),
+  params: ResourceUpdatedNotificationParamsSchema2
+});
+var PromptArgumentSchema2 = object2({
+  name: string2(),
+  description: optional(string2()),
+  required: optional(boolean2())
+});
+var PromptSchema2 = object2({
+  ...BaseMetadataSchema2.shape,
+  ...IconsSchema2.shape,
+  description: optional(string2()),
+  arguments: optional(array(PromptArgumentSchema2)),
+  _meta: optional(looseObject({}))
+});
+var ListPromptsRequestSchema2 = PaginatedRequestSchema2.extend({ method: literal("prompts/list") });
+var ListPromptsResultSchema2 = PaginatedResultSchema2.extend({ prompts: array(PromptSchema2) });
+var GetPromptRequestParamsSchema2 = BaseRequestParamsSchema2.extend({
+  name: string2(),
+  arguments: record(string2(), string2()).optional()
+});
+var GetPromptRequestSchema2 = RequestSchema2.extend({
+  method: literal("prompts/get"),
+  params: GetPromptRequestParamsSchema2
+});
+var TextContentSchema2 = object2({
+  type: literal("text"),
+  text: string2(),
+  annotations: AnnotationsSchema2.optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var ImageContentSchema2 = object2({
+  type: literal("image"),
+  data: Base64Schema2,
+  mimeType: string2(),
+  annotations: AnnotationsSchema2.optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var AudioContentSchema2 = object2({
+  type: literal("audio"),
+  data: Base64Schema2,
+  mimeType: string2(),
+  annotations: AnnotationsSchema2.optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var ToolUseContentSchema2 = object2({
+  type: literal("tool_use"),
+  name: string2(),
+  id: string2(),
+  input: record(string2(), unknown()),
+  _meta: record(string2(), unknown()).optional()
+});
+var EmbeddedResourceSchema2 = object2({
+  type: literal("resource"),
+  resource: union([TextResourceContentsSchema2, BlobResourceContentsSchema2]),
+  annotations: AnnotationsSchema2.optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var ResourceLinkSchema2 = ResourceSchema2.extend({ type: literal("resource_link") });
+var ContentBlockSchema2 = union([
+  TextContentSchema2,
+  ImageContentSchema2,
+  AudioContentSchema2,
+  ResourceLinkSchema2,
+  EmbeddedResourceSchema2
+]);
+var PromptMessageSchema2 = object2({
+  role: RoleSchema2,
+  content: ContentBlockSchema2
+});
+var GetPromptResultSchema2 = ResultSchema2.extend({
+  description: string2().optional(),
+  messages: array(PromptMessageSchema2)
+});
+var PromptListChangedNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/prompts/list_changed"),
+  params: NotificationsParamsSchema2.optional()
+});
+var ToolAnnotationsSchema2 = object2({
+  title: string2().optional(),
+  readOnlyHint: boolean2().optional(),
+  destructiveHint: boolean2().optional(),
+  idempotentHint: boolean2().optional(),
+  openWorldHint: boolean2().optional()
+});
+var ToolExecutionSchema2 = object2({ taskSupport: _enum([
+  "required",
+  "optional",
+  "forbidden"
+]).optional() });
+var ToolSchema2 = object2({
+  ...BaseMetadataSchema2.shape,
+  ...IconsSchema2.shape,
+  description: string2().optional(),
+  inputSchema: object2({
+    type: literal("object"),
+    properties: record(string2(), JSONValueSchema).optional(),
+    required: array(string2()).optional()
+  }).catchall(unknown()),
+  outputSchema: looseObject({ $schema: string2().optional() }).optional(),
+  annotations: ToolAnnotationsSchema2.optional(),
+  execution: ToolExecutionSchema2.optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var ListToolsRequestSchema2 = PaginatedRequestSchema2.extend({ method: literal("tools/list") });
+var ListToolsResultSchema2 = PaginatedResultSchema2.extend({ tools: array(ToolSchema2) });
+var CallToolResultSchema2 = ResultSchema2.extend({
+  content: array(ContentBlockSchema2).default([]),
+  structuredContent: unknown().optional(),
+  isError: boolean2().optional()
+});
+var CompatibilityCallToolResultSchema2 = CallToolResultSchema2.or(ResultSchema2.extend({ toolResult: unknown() }));
+var CallToolRequestParamsSchema2 = TaskAugmentedRequestParamsSchema2.extend({
+  name: string2(),
+  arguments: record(string2(), unknown()).optional()
+});
+var CallToolRequestSchema2 = RequestSchema2.extend({
+  method: literal("tools/call"),
+  params: CallToolRequestParamsSchema2
+});
+var ToolListChangedNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/tools/list_changed"),
+  params: NotificationsParamsSchema2.optional()
+});
+var ListChangedOptionsBaseSchema2 = object2({
+  autoRefresh: boolean2().default(true),
+  debounceMs: number2().int().nonnegative().default(300)
+});
+var LoggingLevelSchema2 = _enum([
+  "debug",
+  "info",
+  "notice",
+  "warning",
+  "error",
+  "critical",
+  "alert",
+  "emergency"
+]);
+var SetLevelRequestParamsSchema2 = BaseRequestParamsSchema2.extend({ level: LoggingLevelSchema2 });
+var SetLevelRequestSchema2 = RequestSchema2.extend({
+  method: literal("logging/setLevel"),
+  params: SetLevelRequestParamsSchema2
+});
+var LoggingMessageNotificationParamsSchema2 = NotificationsParamsSchema2.extend({
+  level: LoggingLevelSchema2,
+  logger: string2().optional(),
+  data: unknown()
+});
+var LoggingMessageNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/message"),
+  params: LoggingMessageNotificationParamsSchema2
+});
+var ModelHintSchema2 = object2({ name: string2().optional() });
+var ModelPreferencesSchema2 = object2({
+  hints: array(ModelHintSchema2).optional(),
+  costPriority: number2().min(0).max(1).optional(),
+  speedPriority: number2().min(0).max(1).optional(),
+  intelligencePriority: number2().min(0).max(1).optional()
+});
+var ToolChoiceSchema2 = object2({ mode: _enum([
+  "auto",
+  "required",
+  "none"
+]).optional() });
+var ToolResultContentSchema2 = object2({
+  type: literal("tool_result"),
+  toolUseId: string2().describe("The unique identifier for the corresponding tool call."),
+  content: array(ContentBlockSchema2),
+  structuredContent: unknown().optional(),
+  isError: boolean2().optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var SamplingContentSchema2 = discriminatedUnion("type", [
+  TextContentSchema2,
+  ImageContentSchema2,
+  AudioContentSchema2
+]);
+var SamplingMessageContentBlockSchema2 = discriminatedUnion("type", [
+  TextContentSchema2,
+  ImageContentSchema2,
+  AudioContentSchema2,
+  ToolUseContentSchema2,
+  ToolResultContentSchema2
+]);
+var SamplingMessageSchema2 = object2({
+  role: RoleSchema2,
+  content: union([SamplingMessageContentBlockSchema2, array(SamplingMessageContentBlockSchema2)]),
+  _meta: record(string2(), unknown()).optional()
+});
+var CreateMessageRequestParamsSchema2 = TaskAugmentedRequestParamsSchema2.extend({
+  messages: array(SamplingMessageSchema2),
+  modelPreferences: ModelPreferencesSchema2.optional(),
+  systemPrompt: string2().optional(),
+  includeContext: _enum([
+    "none",
+    "thisServer",
+    "allServers"
+  ]).optional(),
+  temperature: number2().optional(),
+  maxTokens: number2().int(),
+  stopSequences: array(string2()).optional(),
+  metadata: JSONObjectSchema.optional(),
+  tools: array(ToolSchema2).optional(),
+  toolChoice: ToolChoiceSchema2.optional()
+});
+var CreateMessageRequestSchema2 = RequestSchema2.extend({
+  method: literal("sampling/createMessage"),
+  params: CreateMessageRequestParamsSchema2
+});
+var CreateMessageResultSchema2 = ResultSchema2.extend({
+  model: string2(),
+  stopReason: optional(_enum([
+    "endTurn",
+    "stopSequence",
+    "maxTokens"
+  ]).or(string2())),
+  role: RoleSchema2,
+  content: SamplingContentSchema2
+});
+var CreateMessageResultWithToolsSchema2 = ResultSchema2.extend({
+  model: string2(),
+  stopReason: optional(_enum([
+    "endTurn",
+    "stopSequence",
+    "maxTokens",
+    "toolUse"
+  ]).or(string2())),
+  role: RoleSchema2,
+  content: union([SamplingMessageContentBlockSchema2, array(SamplingMessageContentBlockSchema2)])
+});
+var BooleanSchemaSchema2 = object2({
+  type: literal("boolean"),
+  title: string2().optional(),
+  description: string2().optional(),
+  default: boolean2().optional()
+});
+var StringSchemaSchema2 = object2({
+  type: literal("string"),
+  title: string2().optional(),
+  description: string2().optional(),
+  minLength: number2().optional(),
+  maxLength: number2().optional(),
+  format: _enum([
+    "email",
+    "uri",
+    "date",
+    "date-time"
+  ]).optional(),
+  default: string2().optional()
+});
+var NumberSchemaSchema2 = object2({
+  type: _enum(["number", "integer"]),
+  title: string2().optional(),
+  description: string2().optional(),
+  minimum: number2().optional(),
+  maximum: number2().optional(),
+  default: number2().optional()
+});
+var UntitledSingleSelectEnumSchemaSchema2 = object2({
+  type: literal("string"),
+  title: string2().optional(),
+  description: string2().optional(),
+  enum: array(string2()),
+  default: string2().optional()
+});
+var TitledSingleSelectEnumSchemaSchema2 = object2({
+  type: literal("string"),
+  title: string2().optional(),
+  description: string2().optional(),
+  oneOf: array(object2({
+    const: string2(),
+    title: string2()
+  })),
+  default: string2().optional()
+});
+var LegacyTitledEnumSchemaSchema2 = object2({
+  type: literal("string"),
+  title: string2().optional(),
+  description: string2().optional(),
+  enum: array(string2()),
+  enumNames: array(string2()).optional(),
+  default: string2().optional()
+});
+var SingleSelectEnumSchemaSchema2 = union([UntitledSingleSelectEnumSchemaSchema2, TitledSingleSelectEnumSchemaSchema2]);
+var UntitledMultiSelectEnumSchemaSchema2 = object2({
+  type: literal("array"),
+  title: string2().optional(),
+  description: string2().optional(),
+  minItems: number2().optional(),
+  maxItems: number2().optional(),
+  items: object2({
+    type: literal("string"),
+    enum: array(string2())
+  }),
+  default: array(string2()).optional()
+});
+var TitledMultiSelectEnumSchemaSchema2 = object2({
+  type: literal("array"),
+  title: string2().optional(),
+  description: string2().optional(),
+  minItems: number2().optional(),
+  maxItems: number2().optional(),
+  items: object2({ anyOf: array(object2({
+    const: string2(),
+    title: string2()
+  })) }),
+  default: array(string2()).optional()
+});
+var MultiSelectEnumSchemaSchema2 = union([UntitledMultiSelectEnumSchemaSchema2, TitledMultiSelectEnumSchemaSchema2]);
+var EnumSchemaSchema2 = union([
+  LegacyTitledEnumSchemaSchema2,
+  SingleSelectEnumSchemaSchema2,
+  MultiSelectEnumSchemaSchema2
+]);
+var PrimitiveSchemaDefinitionSchema2 = union([
+  EnumSchemaSchema2,
+  BooleanSchemaSchema2,
+  StringSchemaSchema2,
+  NumberSchemaSchema2
+]);
+var ElicitRequestFormParamsSchema2 = TaskAugmentedRequestParamsSchema2.extend({
+  mode: literal("form").optional(),
+  message: string2(),
+  requestedSchema: object2({
+    type: literal("object"),
+    properties: record(string2(), PrimitiveSchemaDefinitionSchema2),
+    required: array(string2()).optional()
+  }).catchall(unknown())
+});
+var ElicitRequestURLParamsSchema2 = TaskAugmentedRequestParamsSchema2.extend({
+  mode: literal("url"),
+  message: string2(),
+  elicitationId: string2(),
+  url: string2().url()
+});
+var ElicitRequestParamsSchema2 = union([ElicitRequestFormParamsSchema2, ElicitRequestURLParamsSchema2]);
+var ElicitRequestSchema2 = RequestSchema2.extend({
+  method: literal("elicitation/create"),
+  params: ElicitRequestParamsSchema2
+});
+var ElicitationCompleteNotificationParamsSchema2 = NotificationsParamsSchema2.extend({ elicitationId: string2() });
+var ElicitationCompleteNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/elicitation/complete"),
+  params: ElicitationCompleteNotificationParamsSchema2
+});
+var ElicitResultSchema2 = ResultSchema2.extend({
+  action: _enum([
+    "accept",
+    "decline",
+    "cancel"
+  ]),
+  content: preprocess((val) => val === null ? void 0 : val, record(string2(), union([
+    string2(),
+    number2(),
+    boolean2(),
+    array(string2())
+  ])).optional())
+});
+var ResourceTemplateReferenceSchema2 = object2({
+  type: literal("ref/resource"),
+  uri: string2()
+});
+var PromptReferenceSchema2 = object2({
+  type: literal("ref/prompt"),
+  name: string2()
+});
+var CompleteRequestParamsSchema2 = BaseRequestParamsSchema2.extend({
+  ref: union([PromptReferenceSchema2, ResourceTemplateReferenceSchema2]),
+  argument: object2({
+    name: string2(),
+    value: string2()
+  }),
+  context: object2({ arguments: record(string2(), string2()).optional() }).optional()
+});
+var CompleteRequestSchema2 = RequestSchema2.extend({
+  method: literal("completion/complete"),
+  params: CompleteRequestParamsSchema2
+});
+var CompleteResultSchema2 = ResultSchema2.extend({ completion: looseObject({
+  values: array(string2()).max(100),
+  total: optional(number2().int()),
+  hasMore: optional(boolean2())
+}) });
+var RootSchema2 = object2({
+  uri: string2().startsWith("file://"),
+  name: string2().optional(),
+  _meta: record(string2(), unknown()).optional()
+});
+var ListRootsRequestSchema2 = RequestSchema2.extend({
+  method: literal("roots/list"),
+  params: BaseRequestParamsSchema2.optional()
+});
+var ListRootsResultSchema2 = ResultSchema2.extend({ roots: array(RootSchema2) });
+var RootsListChangedNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/roots/list_changed"),
+  params: NotificationsParamsSchema2.optional()
+});
+var TaskCreationParamsSchema2 = looseObject({
+  ttl: number2().optional(),
+  pollInterval: number2().optional()
+});
+var TaskStatusSchema2 = _enum([
+  "working",
+  "input_required",
+  "completed",
+  "failed",
+  "cancelled"
+]);
+var TaskSchema2 = object2({
+  taskId: string2(),
+  status: TaskStatusSchema2,
+  ttl: union([number2(), _null3()]),
+  createdAt: string2(),
+  lastUpdatedAt: string2(),
+  pollInterval: optional(number2()),
+  statusMessage: optional(string2())
+});
+var CreateTaskResultSchema2 = ResultSchema2.extend({ task: TaskSchema2 });
+var TaskStatusNotificationParamsSchema2 = NotificationsParamsSchema2.merge(TaskSchema2);
+var TaskStatusNotificationSchema2 = NotificationSchema2.extend({
+  method: literal("notifications/tasks/status"),
+  params: TaskStatusNotificationParamsSchema2
+});
+var GetTaskRequestSchema2 = RequestSchema2.extend({
+  method: literal("tasks/get"),
+  params: BaseRequestParamsSchema2.extend({ taskId: string2() })
+});
+var GetTaskResultSchema2 = ResultSchema2.merge(TaskSchema2);
+var GetTaskPayloadRequestSchema2 = RequestSchema2.extend({
+  method: literal("tasks/result"),
+  params: BaseRequestParamsSchema2.extend({ taskId: string2() })
+});
+var GetTaskPayloadResultSchema2 = ResultSchema2.loose();
+var ListTasksRequestSchema2 = PaginatedRequestSchema2.extend({ method: literal("tasks/list") });
+var ListTasksResultSchema2 = PaginatedResultSchema2.extend({ tasks: array(TaskSchema2) });
+var CancelTaskRequestSchema2 = RequestSchema2.extend({
+  method: literal("tasks/cancel"),
+  params: BaseRequestParamsSchema2.extend({ taskId: string2() })
+});
+var CancelTaskResultSchema2 = ResultSchema2.merge(TaskSchema2);
+var ClientRequestSchema2 = union([
+  PingRequestSchema2,
+  InitializeRequestSchema2,
+  DiscoverRequestSchema,
+  CompleteRequestSchema2,
+  SetLevelRequestSchema2,
+  GetPromptRequestSchema2,
+  ListPromptsRequestSchema2,
+  ListResourcesRequestSchema2,
+  ListResourceTemplatesRequestSchema2,
+  ReadResourceRequestSchema2,
+  SubscribeRequestSchema2,
+  UnsubscribeRequestSchema2,
+  SubscriptionsListenRequestSchema,
+  CallToolRequestSchema2,
+  ListToolsRequestSchema2
+]);
+var ClientNotificationSchema2 = union([
+  CancelledNotificationSchema2,
+  ProgressNotificationSchema2,
+  InitializedNotificationSchema2,
+  RootsListChangedNotificationSchema2
+]);
+var ClientResultSchema2 = union([
+  EmptyResultSchema2,
+  CreateMessageResultSchema2,
+  CreateMessageResultWithToolsSchema2,
+  ElicitResultSchema2,
+  ListRootsResultSchema2
+]);
+var ServerRequestSchema2 = union([
+  PingRequestSchema2,
+  CreateMessageRequestSchema2,
+  ElicitRequestSchema2,
+  ListRootsRequestSchema2
+]);
+var ServerNotificationSchema2 = union([
+  CancelledNotificationSchema2,
+  ProgressNotificationSchema2,
+  LoggingMessageNotificationSchema2,
+  ResourceUpdatedNotificationSchema2,
+  ResourceListChangedNotificationSchema2,
+  ToolListChangedNotificationSchema2,
+  PromptListChangedNotificationSchema2,
+  SubscriptionsAcknowledgedNotificationSchema,
+  ElicitationCompleteNotificationSchema2
+]);
+var ServerResultSchema2 = union([
+  EmptyResultSchema2,
+  InitializeResultSchema2,
+  DiscoverResultSchema,
+  CompleteResultSchema2,
+  GetPromptResultSchema2,
+  ListPromptsResultSchema2,
+  ListResourcesResultSchema2,
+  ListResourceTemplatesResultSchema2,
+  ReadResourceResultSchema2,
+  CallToolResultSchema2,
+  ListToolsResultSchema2,
+  SubscriptionsListenResultSchema
+]);
 var SafeUrlSchema = url().superRefine((val, ctx) => {
   if (!URL.canParse(val)) {
     ctx.addIssue({
@@ -23779,7 +25107,8 @@ var OAuthMetadataSchema = looseObject({
   introspection_endpoint_auth_methods_supported: array(string2()).optional(),
   introspection_endpoint_auth_signing_alg_values_supported: array(string2()).optional(),
   code_challenge_methods_supported: array(string2()).optional(),
-  client_id_metadata_document_supported: boolean2().optional()
+  client_id_metadata_document_supported: boolean2().optional(),
+  authorization_response_iss_parameter_supported: boolean2().optional().catch(void 0)
 });
 var OpenIdProviderMetadataSchema = looseObject({
   issuer: string2(),
@@ -23817,22 +25146,27 @@ var OpenIdProviderMetadataSchema = looseObject({
   require_request_uri_registration: boolean2().optional(),
   op_policy_uri: SafeUrlSchema.optional(),
   op_tos_uri: SafeUrlSchema.optional(),
-  client_id_metadata_document_supported: boolean2().optional()
+  client_id_metadata_document_supported: boolean2().optional(),
+  authorization_response_iss_parameter_supported: boolean2().optional().catch(void 0)
 });
 var OpenIdProviderDiscoveryMetadataSchema = object2({
   ...OpenIdProviderMetadataSchema.shape,
-  ...OAuthMetadataSchema.pick({
-    code_challenge_methods_supported: true
-  }).shape
+  ...OAuthMetadataSchema.pick({ code_challenge_methods_supported: true }).shape
 });
 var OAuthTokensSchema = object2({
   access_token: string2(),
   id_token: string2().optional(),
-  // Optional for OAuth 2.1, but necessary in OpenID Connect
   token_type: string2(),
   expires_in: coerce_exports.number().optional(),
   scope: string2().optional(),
   refresh_token: string2().optional()
+}).strip();
+var IdJagTokenExchangeResponseSchema = object2({
+  issued_token_type: literal("urn:ietf:params:oauth:token-type:id-jag"),
+  access_token: string2(),
+  token_type: string2().optional(),
+  expires_in: number2().optional(),
+  scope: string2().optional()
 }).strip();
 var OAuthErrorResponseSchema = object2({
   error: string2(),
@@ -23845,6 +25179,7 @@ var OAuthClientMetadataSchema = object2({
   token_endpoint_auth_method: string2().optional(),
   grant_types: array(string2()).optional(),
   response_types: array(string2()).optional(),
+  application_type: string2().optional(),
   client_name: string2().optional(),
   client_uri: SafeUrlSchema.optional(),
   logo_uri: OptionalSafeUrlSchema,
@@ -23874,7 +25209,164 @@ var OAuthTokenRevocationRequestSchema = object2({
   token_type_hint: string2().optional()
 }).strip();
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/auth-utils.js
+// node_modules/@modelcontextprotocol/client/dist/src-D_zzAWoS.mjs
+var BRANDS = /* @__PURE__ */ Symbol.for("mcp.sdk.errorBrands");
+function stampErrorBrands(instance, ctor) {
+  const brands = /* @__PURE__ */ new Set();
+  let current = ctor;
+  while (typeof current === "function") {
+    const brand = current.mcpBrand;
+    if (Object.prototype.hasOwnProperty.call(current, "mcpBrand") && typeof brand === "string") brands.add(brand);
+    current = Object.getPrototypeOf(current);
+  }
+  if (brands.size === 0) return;
+  Object.defineProperty(instance, BRANDS, {
+    value: brands,
+    enumerable: false,
+    configurable: true
+  });
+}
+function brandedHasInstance(cls, value) {
+  try {
+    if (typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(cls, "mcpBrand") && typeof cls.mcpBrand === "string" && Object.prototype.hasOwnProperty.call(value, BRANDS)) {
+      const carried = value[BRANDS];
+      if (carried && typeof carried.has === "function" && carried.has(cls.mcpBrand)) return true;
+    }
+  } catch {
+  }
+  return Function.prototype[Symbol.hasInstance].call(cls, value);
+}
+var OAuthErrorCode = /* @__PURE__ */ (function(OAuthErrorCode$1) {
+  OAuthErrorCode$1["InvalidRequest"] = "invalid_request";
+  OAuthErrorCode$1["InvalidClient"] = "invalid_client";
+  OAuthErrorCode$1["InvalidGrant"] = "invalid_grant";
+  OAuthErrorCode$1["UnauthorizedClient"] = "unauthorized_client";
+  OAuthErrorCode$1["UnsupportedGrantType"] = "unsupported_grant_type";
+  OAuthErrorCode$1["InvalidScope"] = "invalid_scope";
+  OAuthErrorCode$1["AccessDenied"] = "access_denied";
+  OAuthErrorCode$1["ServerError"] = "server_error";
+  OAuthErrorCode$1["TemporarilyUnavailable"] = "temporarily_unavailable";
+  OAuthErrorCode$1["UnsupportedResponseType"] = "unsupported_response_type";
+  OAuthErrorCode$1["UnsupportedTokenType"] = "unsupported_token_type";
+  OAuthErrorCode$1["InvalidToken"] = "invalid_token";
+  OAuthErrorCode$1["MethodNotAllowed"] = "method_not_allowed";
+  OAuthErrorCode$1["TooManyRequests"] = "too_many_requests";
+  OAuthErrorCode$1["InvalidClientMetadata"] = "invalid_client_metadata";
+  OAuthErrorCode$1["InvalidRedirectUri"] = "invalid_redirect_uri";
+  OAuthErrorCode$1["InsufficientScope"] = "insufficient_scope";
+  OAuthErrorCode$1["InvalidTarget"] = "invalid_target";
+  return OAuthErrorCode$1;
+})({});
+var OAuthError = class OAuthError2 extends Error {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.OAuthError" });
+  }
+  static [Symbol.hasInstance](value) {
+    return brandedHasInstance(this, value);
+  }
+  /**
+  * Brand-based type guard: equivalent to `value instanceof this`, as an
+  * explicit static predicate (the axios/AWS-SDK `isInstance` style). Reads
+  * the caller's own brand via `this`, so every branded subclass gets a
+  * correctly-scoped guard by inheritance. Must be invoked on the class —
+  * in callback position write `v => SdkError.isInstance(v)`, not
+  * `.filter(SdkError.isInstance)` (detached calls throw rather than
+  * silently matching nothing).
+  */
+  static isInstance(value) {
+    if (typeof this !== "function") throw new TypeError("isInstance must be called on the class (e.g. `SdkError.isInstance(value)`); for callbacks use `v => SdkError.isInstance(v)`");
+    return brandedHasInstance(this, value);
+  }
+  constructor(code, message, errorUri) {
+    super(message);
+    this.code = code;
+    this.errorUri = errorUri;
+    this.name = "OAuthError";
+    stampErrorBrands(this, new.target);
+  }
+  /**
+  * Converts the error to a standard OAuth error response object.
+  */
+  toResponseObject() {
+    const response = {
+      error: this.code,
+      error_description: this.message
+    };
+    if (this.errorUri) response.error_uri = this.errorUri;
+    return response;
+  }
+  /**
+  * Creates an {@linkcode OAuthError} from an OAuth error response.
+  */
+  static fromResponse(response) {
+    return new OAuthError2(response.error, response.error_description ?? response.error, response.error_uri);
+  }
+};
+var SdkErrorCode = /* @__PURE__ */ (function(SdkErrorCode$1) {
+  SdkErrorCode$1["NotConnected"] = "NOT_CONNECTED";
+  SdkErrorCode$1["AlreadyConnected"] = "ALREADY_CONNECTED";
+  SdkErrorCode$1["NotInitialized"] = "NOT_INITIALIZED";
+  SdkErrorCode$1["CapabilityNotSupported"] = "CAPABILITY_NOT_SUPPORTED";
+  SdkErrorCode$1["RequestTimeout"] = "REQUEST_TIMEOUT";
+  SdkErrorCode$1["ConnectionClosed"] = "CONNECTION_CLOSED";
+  SdkErrorCode$1["SendFailed"] = "SEND_FAILED";
+  SdkErrorCode$1["InvalidResult"] = "INVALID_RESULT";
+  SdkErrorCode$1["UnsupportedResultType"] = "UNSUPPORTED_RESULT_TYPE";
+  SdkErrorCode$1["InputRequiredRoundsExceeded"] = "INPUT_REQUIRED_ROUNDS_EXCEEDED";
+  SdkErrorCode$1["ListPaginationExceeded"] = "LIST_PAGINATION_EXCEEDED";
+  SdkErrorCode$1["MethodNotSupportedByProtocolVersion"] = "METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION";
+  SdkErrorCode$1["EraNegotiationFailed"] = "ERA_NEGOTIATION_FAILED";
+  SdkErrorCode$1["ClientHttpNotImplemented"] = "CLIENT_HTTP_NOT_IMPLEMENTED";
+  SdkErrorCode$1["ClientHttpAuthentication"] = "CLIENT_HTTP_AUTHENTICATION";
+  SdkErrorCode$1["ClientHttpForbidden"] = "CLIENT_HTTP_FORBIDDEN";
+  SdkErrorCode$1["ClientHttpUnexpectedContent"] = "CLIENT_HTTP_UNEXPECTED_CONTENT";
+  SdkErrorCode$1["ClientHttpFailedToOpenStream"] = "CLIENT_HTTP_FAILED_TO_OPEN_STREAM";
+  SdkErrorCode$1["ClientHttpFailedToTerminateSession"] = "CLIENT_HTTP_FAILED_TO_TERMINATE_SESSION";
+  return SdkErrorCode$1;
+})({});
+var SdkError = class extends Error {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.SdkError" });
+  }
+  static [Symbol.hasInstance](value) {
+    return brandedHasInstance(this, value);
+  }
+  /**
+  * Brand-based type guard: equivalent to `value instanceof this`, as an
+  * explicit static predicate (the axios/AWS-SDK `isInstance` style). Reads
+  * the caller's own brand via `this`, so every branded subclass gets a
+  * correctly-scoped guard by inheritance. Must be invoked on the class —
+  * in callback position write `v => SdkError.isInstance(v)`, not
+  * `.filter(SdkError.isInstance)` (detached calls throw rather than
+  * silently matching nothing).
+  */
+  static isInstance(value) {
+    if (typeof this !== "function") throw new TypeError("isInstance must be called on the class (e.g. `SdkError.isInstance(value)`); for callbacks use `v => SdkError.isInstance(v)`");
+    return brandedHasInstance(this, value);
+  }
+  constructor(code, message, data) {
+    super(message);
+    this.code = code;
+    this.data = data;
+    this.name = "SdkError";
+    stampErrorBrands(this, new.target);
+  }
+};
+var SdkHttpError = class extends SdkError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.SdkHttpError" });
+  }
+  constructor(code, message, data) {
+    super(code, message, data);
+    this.name = "SdkHttpError";
+  }
+  get status() {
+    return this.data.status;
+  }
+  get statusText() {
+    return this.data.statusText;
+  }
+};
 function resourceUrlFromServerUrl(url2) {
   const resourceURL = typeof url2 === "string" ? new URL(url2) : new URL(url2.href);
   resourceURL.hash = "";
@@ -23883,651 +25375,11541 @@ function resourceUrlFromServerUrl(url2) {
 function checkResourceAllowed({ requestedResource, configuredResource }) {
   const requested = typeof requestedResource === "string" ? new URL(requestedResource) : new URL(requestedResource.href);
   const configured = typeof configuredResource === "string" ? new URL(configuredResource) : new URL(configuredResource.href);
-  if (requested.origin !== configured.origin) {
-    return false;
-  }
-  if (requested.pathname.length < configured.pathname.length) {
-    return false;
-  }
+  if (requested.origin !== configured.origin) return false;
+  if (requested.pathname.length < configured.pathname.length) return false;
   const requestedPath = requested.pathname.endsWith("/") ? requested.pathname : requested.pathname + "/";
   const configuredPath = configured.pathname.endsWith("/") ? configured.pathname : configured.pathname + "/";
   return requestedPath.startsWith(configuredPath);
 }
-
-// node_modules/@modelcontextprotocol/sdk/dist/esm/server/auth/errors.js
-var OAuthError = class extends Error {
-  constructor(message, errorUri) {
-    super(message);
-    this.errorUri = errorUri;
-    this.name = this.constructor.name;
-  }
-  /**
-   * Converts the error to a standard OAuth error response object
-   */
-  toResponseObject() {
-    const response = {
-      error: this.errorCode,
-      error_description: this.message
-    };
-    if (this.errorUri) {
-      response.error_uri = this.errorUri;
-    }
-    return response;
-  }
-  get errorCode() {
-    return this.constructor.errorCode;
-  }
-};
-var InvalidRequestError = class extends OAuthError {
-};
-InvalidRequestError.errorCode = "invalid_request";
-var InvalidClientError = class extends OAuthError {
-};
-InvalidClientError.errorCode = "invalid_client";
-var InvalidGrantError = class extends OAuthError {
-};
-InvalidGrantError.errorCode = "invalid_grant";
-var UnauthorizedClientError = class extends OAuthError {
-};
-UnauthorizedClientError.errorCode = "unauthorized_client";
-var UnsupportedGrantTypeError = class extends OAuthError {
-};
-UnsupportedGrantTypeError.errorCode = "unsupported_grant_type";
-var InvalidScopeError = class extends OAuthError {
-};
-InvalidScopeError.errorCode = "invalid_scope";
-var AccessDeniedError = class extends OAuthError {
-};
-AccessDeniedError.errorCode = "access_denied";
-var ServerError = class extends OAuthError {
-};
-ServerError.errorCode = "server_error";
-var TemporarilyUnavailableError = class extends OAuthError {
-};
-TemporarilyUnavailableError.errorCode = "temporarily_unavailable";
-var UnsupportedResponseTypeError = class extends OAuthError {
-};
-UnsupportedResponseTypeError.errorCode = "unsupported_response_type";
-var UnsupportedTokenTypeError = class extends OAuthError {
-};
-UnsupportedTokenTypeError.errorCode = "unsupported_token_type";
-var InvalidTokenError = class extends OAuthError {
-};
-InvalidTokenError.errorCode = "invalid_token";
-var MethodNotAllowedError = class extends OAuthError {
-};
-MethodNotAllowedError.errorCode = "method_not_allowed";
-var TooManyRequestsError = class extends OAuthError {
-};
-TooManyRequestsError.errorCode = "too_many_requests";
-var InvalidClientMetadataError = class extends OAuthError {
-};
-InvalidClientMetadataError.errorCode = "invalid_client_metadata";
-var InsufficientScopeError = class extends OAuthError {
-};
-InsufficientScopeError.errorCode = "insufficient_scope";
-var InvalidTargetError = class extends OAuthError {
-};
-InvalidTargetError.errorCode = "invalid_target";
-var OAUTH_ERRORS = {
-  [InvalidRequestError.errorCode]: InvalidRequestError,
-  [InvalidClientError.errorCode]: InvalidClientError,
-  [InvalidGrantError.errorCode]: InvalidGrantError,
-  [UnauthorizedClientError.errorCode]: UnauthorizedClientError,
-  [UnsupportedGrantTypeError.errorCode]: UnsupportedGrantTypeError,
-  [InvalidScopeError.errorCode]: InvalidScopeError,
-  [AccessDeniedError.errorCode]: AccessDeniedError,
-  [ServerError.errorCode]: ServerError,
-  [TemporarilyUnavailableError.errorCode]: TemporarilyUnavailableError,
-  [UnsupportedResponseTypeError.errorCode]: UnsupportedResponseTypeError,
-  [UnsupportedTokenTypeError.errorCode]: UnsupportedTokenTypeError,
-  [InvalidTokenError.errorCode]: InvalidTokenError,
-  [MethodNotAllowedError.errorCode]: MethodNotAllowedError,
-  [TooManyRequestsError.errorCode]: TooManyRequestsError,
-  [InvalidClientMetadataError.errorCode]: InvalidClientMetadataError,
-  [InsufficientScopeError.errorCode]: InsufficientScopeError,
-  [InvalidTargetError.errorCode]: InvalidTargetError
-};
-
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/auth.js
-var UnauthorizedError = class extends Error {
-  constructor(message) {
-    super(message ?? "Unauthorized");
-  }
-};
-function isClientAuthMethod(method) {
-  return ["client_secret_basic", "client_secret_post", "none"].includes(method);
+var FIRST_MODERN_PROTOCOL_VERSION = "2026-07-28";
+var SUPPORTED_MODERN_PROTOCOL_VERSIONS = [FIRST_MODERN_PROTOCOL_VERSION];
+function isModernProtocolVersion(version2) {
+  return version2 >= FIRST_MODERN_PROTOCOL_VERSION;
 }
-var AUTHORIZATION_CODE_RESPONSE_TYPE = "code";
-var AUTHORIZATION_CODE_CHALLENGE_METHOD = "S256";
-function selectClientAuthMethod(clientInformation, supportedMethods) {
-  const hasClientSecret = clientInformation.client_secret !== void 0;
-  if ("token_endpoint_auth_method" in clientInformation && clientInformation.token_endpoint_auth_method && isClientAuthMethod(clientInformation.token_endpoint_auth_method) && (supportedMethods.length === 0 || supportedMethods.includes(clientInformation.token_endpoint_auth_method))) {
-    return clientInformation.token_endpoint_auth_method;
-  }
-  if (supportedMethods.length === 0) {
-    return hasClientSecret ? "client_secret_basic" : "none";
-  }
-  if (hasClientSecret && supportedMethods.includes("client_secret_basic")) {
-    return "client_secret_basic";
-  }
-  if (hasClientSecret && supportedMethods.includes("client_secret_post")) {
-    return "client_secret_post";
-  }
-  if (supportedMethods.includes("none")) {
-    return "none";
-  }
-  return hasClientSecret ? "client_secret_post" : "none";
+function legacyProtocolVersions(versions) {
+  return versions.filter((version2) => !isModernProtocolVersion(version2));
 }
-function applyClientAuthentication(method, clientInformation, headers, params) {
-  const { client_id, client_secret } = clientInformation;
-  switch (method) {
-    case "client_secret_basic":
-      applyBasicAuth(client_id, client_secret, headers);
-      return;
-    case "client_secret_post":
-      applyPostAuth(client_id, client_secret, params);
-      return;
-    case "none":
-      applyPublicAuth(client_id, params);
-      return;
-    default:
-      throw new Error(`Unsupported client authentication method: ${method}`);
-  }
+function modernProtocolVersions(versions) {
+  return versions.filter((version2) => isModernProtocolVersion(version2));
 }
-function applyBasicAuth(clientId, clientSecret, headers) {
-  if (!clientSecret) {
-    throw new Error("client_secret_basic authentication requires a client_secret");
-  }
-  const credentials = btoa(`${clientId}:${clientSecret}`);
-  headers.set("Authorization", `Basic ${credentials}`);
+function appendTextFallbackForNonObject(result) {
+  const sc = result.structuredContent;
+  if (sc === void 0) return result;
+  if (!(typeof sc !== "object" || sc === null || Array.isArray(sc))) return result;
+  if (result.content?.some((c) => c.type === "text") ?? false) return result;
+  return {
+    ...result,
+    content: [...result.content ?? [], {
+      type: "text",
+      text: JSON.stringify(sc)
+    }]
+  };
 }
-function applyPostAuth(clientId, clientSecret, params) {
-  params.set("client_id", clientId);
-  if (clientSecret) {
-    params.set("client_secret", clientSecret);
-  }
+var TOOL_RESULT_FOREIGN_FAMILY_KEYS = [
+  "task",
+  "inputRequests",
+  "requestState"
+];
+function normalizeContentlessToolResult(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value) || value.content !== void 0 || TOOL_RESULT_FOREIGN_FAMILY_KEYS.some((key) => key in value)) return value;
+  return {
+    ...value,
+    content: []
+  };
 }
-function applyPublicAuth(clientId, params) {
-  params.set("client_id", clientId);
-}
-async function parseErrorResponse(input) {
-  const statusCode = input instanceof Response ? input.status : void 0;
-  const body = input instanceof Response ? await input.text() : input;
-  try {
-    const result = OAuthErrorResponseSchema.parse(JSON.parse(body));
-    const { error: error2, error_description, error_uri } = result;
-    const errorClass = OAUTH_ERRORS[error2] || ServerError;
-    return new errorClass(error_description || "", error_uri);
-  } catch (error2) {
-    const errorMessage = `${statusCode ? `HTTP ${statusCode}: ` : ""}Invalid OAuth error response: ${error2}. Raw body: ${body}`;
-    return new ServerError(errorMessage);
-  }
-}
-async function auth(provider, options) {
-  try {
-    return await authInternal(provider, options);
-  } catch (error2) {
-    if (error2 instanceof InvalidClientError || error2 instanceof UnauthorizedClientError) {
-      await provider.invalidateCredentials?.("all");
-      return await authInternal(provider, options);
-    } else if (error2 instanceof InvalidGrantError) {
-      await provider.invalidateCredentials?.("tokens");
-      return await authInternal(provider, options);
-    }
-    throw error2;
-  }
-}
-async function authInternal(provider, { serverUrl, authorizationCode, scope, resourceMetadataUrl, fetchFn }) {
-  const cachedState = await provider.discoveryState?.();
-  let resourceMetadata;
-  let authorizationServerUrl;
-  let metadata;
-  let effectiveResourceMetadataUrl = resourceMetadataUrl;
-  if (!effectiveResourceMetadataUrl && cachedState?.resourceMetadataUrl) {
-    effectiveResourceMetadataUrl = new URL(cachedState.resourceMetadataUrl);
-  }
-  if (cachedState?.authorizationServerUrl) {
-    authorizationServerUrl = cachedState.authorizationServerUrl;
-    resourceMetadata = cachedState.resourceMetadata;
-    metadata = cachedState.authorizationServerMetadata ?? await discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn });
-    if (!resourceMetadata) {
-      try {
-        resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl: effectiveResourceMetadataUrl }, fetchFn);
-      } catch {
-      }
-    }
-    if (metadata !== cachedState.authorizationServerMetadata || resourceMetadata !== cachedState.resourceMetadata) {
-      await provider.saveDiscoveryState?.({
-        authorizationServerUrl: String(authorizationServerUrl),
-        resourceMetadataUrl: effectiveResourceMetadataUrl?.toString(),
-        resourceMetadata,
-        authorizationServerMetadata: metadata
-      });
-    }
-  } else {
-    const serverInfo = await discoverOAuthServerInfo(serverUrl, { resourceMetadataUrl: effectiveResourceMetadataUrl, fetchFn });
-    authorizationServerUrl = serverInfo.authorizationServerUrl;
-    metadata = serverInfo.authorizationServerMetadata;
-    resourceMetadata = serverInfo.resourceMetadata;
-    await provider.saveDiscoveryState?.({
-      authorizationServerUrl: String(authorizationServerUrl),
-      resourceMetadataUrl: effectiveResourceMetadataUrl?.toString(),
-      resourceMetadata,
-      authorizationServerMetadata: metadata
-    });
-  }
-  const resource = await selectResourceURL(serverUrl, provider, resourceMetadata);
-  const resolvedScope = scope || resourceMetadata?.scopes_supported?.join(" ") || provider.clientMetadata.scope;
-  let clientInformation = await Promise.resolve(provider.clientInformation());
-  if (!clientInformation) {
-    if (authorizationCode !== void 0) {
-      throw new Error("Existing OAuth client information is required when exchanging an authorization code");
-    }
-    const supportsUrlBasedClientId = metadata?.client_id_metadata_document_supported === true;
-    const clientMetadataUrl = provider.clientMetadataUrl;
-    if (clientMetadataUrl && !isHttpsUrl(clientMetadataUrl)) {
-      throw new InvalidClientMetadataError(`clientMetadataUrl must be a valid HTTPS URL with a non-root pathname, got: ${clientMetadataUrl}`);
-    }
-    const shouldUseUrlBasedClientId = supportsUrlBasedClientId && clientMetadataUrl;
-    if (shouldUseUrlBasedClientId) {
-      clientInformation = {
-        client_id: clientMetadataUrl
-      };
-      await provider.saveClientInformation?.(clientInformation);
-    } else {
-      if (!provider.saveClientInformation) {
-        throw new Error("OAuth client information must be saveable for dynamic registration");
-      }
-      const fullInformation = await registerClient(authorizationServerUrl, {
-        metadata,
-        clientMetadata: provider.clientMetadata,
-        scope: resolvedScope,
-        fetchFn
-      });
-      await provider.saveClientInformation(fullInformation);
-      clientInformation = fullInformation;
-    }
-  }
-  const nonInteractiveFlow = !provider.redirectUrl;
-  if (authorizationCode !== void 0 || nonInteractiveFlow) {
-    const tokens2 = await fetchToken(provider, authorizationServerUrl, {
-      metadata,
-      resource,
-      authorizationCode,
-      fetchFn
-    });
-    await provider.saveTokens(tokens2);
-    return "AUTHORIZED";
-  }
-  const tokens = await provider.tokens();
-  if (tokens?.refresh_token) {
-    try {
-      const newTokens = await refreshAuthorization(authorizationServerUrl, {
-        metadata,
-        clientInformation,
-        refreshToken: tokens.refresh_token,
-        resource,
-        addClientAuthentication: provider.addClientAuthentication,
-        fetchFn
-      });
-      await provider.saveTokens(newTokens);
-      return "AUTHORIZED";
-    } catch (error2) {
-      if (!(error2 instanceof OAuthError) || error2 instanceof ServerError) {
-      } else {
-        throw error2;
-      }
-    }
-  }
-  const state = provider.state ? await provider.state() : void 0;
-  const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
-    metadata,
-    clientInformation,
-    state,
-    redirectUrl: provider.redirectUrl,
-    scope: resolvedScope,
-    resource
+function build$1() {
+  const JSONValueSchema$1 = lazy(() => union([
+    string2(),
+    number2(),
+    boolean2(),
+    _null3(),
+    record(string2(), JSONValueSchema$1),
+    array(JSONValueSchema$1)
+  ]));
+  const JSONObjectSchema$1 = record(string2(), JSONValueSchema$1);
+  const ProgressTokenSchema$1 = union([string2(), number2().int()]);
+  const CursorSchema$1 = string2();
+  const TaskMetadataSchema$1 = object2({ ttl: number2().optional() });
+  const RelatedTaskMetadataSchema$1 = object2({ taskId: string2() });
+  const RequestMetaSchema$1 = looseObject({
+    progressToken: ProgressTokenSchema$1.optional(),
+    "io.modelcontextprotocol/related-task": RelatedTaskMetadataSchema$1.optional()
   });
-  await provider.saveCodeVerifier(codeVerifier);
-  await provider.redirectToAuthorization(authorizationUrl);
-  return "REDIRECT";
-}
-function isHttpsUrl(value) {
-  if (!value)
-    return false;
-  try {
-    const url2 = new URL(value);
-    return url2.protocol === "https:" && url2.pathname !== "/";
-  } catch {
-    return false;
-  }
-}
-async function selectResourceURL(serverUrl, provider, resourceMetadata) {
-  const defaultResource = resourceUrlFromServerUrl(serverUrl);
-  if (provider.validateResourceURL) {
-    return await provider.validateResourceURL(defaultResource, resourceMetadata?.resource);
-  }
-  if (!resourceMetadata) {
-    return void 0;
-  }
-  if (!checkResourceAllowed({ requestedResource: defaultResource, configuredResource: resourceMetadata.resource })) {
-    throw new Error(`Protected resource ${resourceMetadata.resource} does not match expected ${defaultResource} (or origin)`);
-  }
-  return new URL(resourceMetadata.resource);
-}
-function extractWWWAuthenticateParams(res) {
-  const authenticateHeader = res.headers.get("WWW-Authenticate");
-  if (!authenticateHeader) {
-    return {};
-  }
-  const [type, scheme] = authenticateHeader.split(" ");
-  if (type.toLowerCase() !== "bearer" || !scheme) {
-    return {};
-  }
-  const resourceMetadataMatch = extractFieldFromWwwAuth(res, "resource_metadata") || void 0;
-  let resourceMetadataUrl;
-  if (resourceMetadataMatch) {
+  const BaseRequestParamsSchema$1 = object2({ _meta: RequestMetaSchema$1.optional() });
+  const TaskAugmentedRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({ task: TaskMetadataSchema$1.optional() });
+  const RequestSchema$1 = object2({
+    method: string2(),
+    params: BaseRequestParamsSchema$1.loose().optional()
+  });
+  const NotificationsParamsSchema$1 = object2({ _meta: RequestMetaSchema$1.optional() });
+  const NotificationSchema$1 = object2({
+    method: string2(),
+    params: NotificationsParamsSchema$1.loose().optional()
+  });
+  const ResultSchema$1 = looseObject({ _meta: RequestMetaSchema$1.optional() });
+  const RequestIdSchema$1 = union([string2(), number2().int()]);
+  const EmptyResultSchema$1 = ResultSchema$1.strict();
+  const CancelledNotificationParamsSchema$1 = NotificationsParamsSchema$1.extend({
+    requestId: RequestIdSchema$1.optional(),
+    reason: string2().optional()
+  });
+  const CancelledNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/cancelled"),
+    params: CancelledNotificationParamsSchema$1
+  });
+  const IconSchema$1 = object2({
+    src: string2(),
+    mimeType: string2().optional(),
+    sizes: array(string2()).optional(),
+    theme: _enum(["light", "dark"]).optional()
+  });
+  const IconsSchema$1 = object2({ icons: array(IconSchema$1).optional() });
+  const BaseMetadataSchema$1 = object2({
+    name: string2(),
+    title: string2().optional()
+  });
+  const ImplementationSchema$1 = BaseMetadataSchema$1.extend({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    version: string2(),
+    websiteUrl: string2().optional(),
+    description: string2().optional()
+  });
+  const FormElicitationCapabilitySchema3 = intersection(object2({ applyDefaults: boolean2().optional() }), JSONObjectSchema$1);
+  const ElicitationCapabilitySchema3 = preprocess((value) => {
+    if (value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0) return { form: {} };
+    return value;
+  }, intersection(object2({
+    form: FormElicitationCapabilitySchema3.optional(),
+    url: JSONObjectSchema$1.optional()
+  }), JSONObjectSchema$1.optional()));
+  const ClientTasksCapabilitySchema$1 = looseObject({
+    list: JSONObjectSchema$1.optional(),
+    cancel: JSONObjectSchema$1.optional(),
+    requests: looseObject({
+      sampling: looseObject({ createMessage: JSONObjectSchema$1.optional() }).optional(),
+      elicitation: looseObject({ create: JSONObjectSchema$1.optional() }).optional()
+    }).optional()
+  });
+  const ServerTasksCapabilitySchema$1 = looseObject({
+    list: JSONObjectSchema$1.optional(),
+    cancel: JSONObjectSchema$1.optional(),
+    requests: looseObject({ tools: looseObject({ call: JSONObjectSchema$1.optional() }).optional() }).optional()
+  });
+  const ClientCapabilitiesSchema$1 = object2({
+    experimental: record(string2(), JSONObjectSchema$1).optional(),
+    sampling: object2({
+      context: JSONObjectSchema$1.optional(),
+      tools: JSONObjectSchema$1.optional()
+    }).optional(),
+    elicitation: ElicitationCapabilitySchema3.optional(),
+    roots: object2({ listChanged: boolean2().optional() }).optional(),
+    tasks: ClientTasksCapabilitySchema$1.optional(),
+    extensions: record(string2(), JSONObjectSchema$1).optional()
+  });
+  const InitializeRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({
+    protocolVersion: string2(),
+    capabilities: ClientCapabilitiesSchema$1,
+    clientInfo: ImplementationSchema$1
+  });
+  const InitializeRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("initialize"),
+    params: InitializeRequestParamsSchema$1
+  });
+  const ServerCapabilitiesSchema$1 = object2({
+    experimental: record(string2(), JSONObjectSchema$1).optional(),
+    logging: JSONObjectSchema$1.optional(),
+    completions: JSONObjectSchema$1.optional(),
+    prompts: object2({ listChanged: boolean2().optional() }).optional(),
+    resources: object2({
+      subscribe: boolean2().optional(),
+      listChanged: boolean2().optional()
+    }).optional(),
+    tools: object2({ listChanged: boolean2().optional() }).optional(),
+    tasks: ServerTasksCapabilitySchema$1.optional(),
+    extensions: record(string2(), JSONObjectSchema$1).optional()
+  });
+  const InitializeResultSchema$1 = ResultSchema$1.extend({
+    protocolVersion: string2(),
+    capabilities: ServerCapabilitiesSchema$1,
+    serverInfo: ImplementationSchema$1,
+    instructions: string2().optional()
+  });
+  const InitializedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/initialized"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const PingRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("ping"),
+    params: BaseRequestParamsSchema$1.optional()
+  });
+  const ProgressSchema$1 = object2({
+    progress: number2(),
+    total: optional(number2()),
+    message: optional(string2())
+  });
+  const ProgressNotificationParamsSchema$1 = object2({
+    ...NotificationsParamsSchema$1.shape,
+    ...ProgressSchema$1.shape,
+    progressToken: ProgressTokenSchema$1
+  });
+  const ProgressNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/progress"),
+    params: ProgressNotificationParamsSchema$1
+  });
+  const PaginatedRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({ cursor: CursorSchema$1.optional() });
+  const PaginatedRequestSchema$1 = RequestSchema$1.extend({ params: PaginatedRequestParamsSchema$1.optional() });
+  const PaginatedResultSchema$1 = ResultSchema$1.extend({ nextCursor: CursorSchema$1.optional() });
+  const ResourceContentsSchema$1 = object2({
+    uri: string2(),
+    mimeType: optional(string2()),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const TextResourceContentsSchema$1 = ResourceContentsSchema$1.extend({ text: string2() });
+  const Base64Schema3 = string2().refine((val) => {
     try {
-      resourceMetadataUrl = new URL(resourceMetadataMatch);
+      atob(val);
+      return true;
     } catch {
+      return false;
     }
-  }
-  const scope = extractFieldFromWwwAuth(res, "scope") || void 0;
-  const error2 = extractFieldFromWwwAuth(res, "error") || void 0;
+  }, { message: "Invalid Base64 string" });
+  const BlobResourceContentsSchema$1 = ResourceContentsSchema$1.extend({ blob: Base64Schema3 });
+  const RoleSchema$1 = _enum(["user", "assistant"]);
+  const AnnotationsSchema$1 = object2({
+    audience: array(RoleSchema$1).optional(),
+    priority: number2().min(0).max(1).optional(),
+    lastModified: iso_exports.datetime({ offset: true }).optional()
+  });
+  const ResourceSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    uri: string2(),
+    description: optional(string2()),
+    mimeType: optional(string2()),
+    size: optional(number2()),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: optional(looseObject({}))
+  });
+  const ResourceTemplateSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    uriTemplate: string2(),
+    description: optional(string2()),
+    mimeType: optional(string2()),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: optional(looseObject({}))
+  });
+  const ListResourcesRequestSchema$1 = PaginatedRequestSchema$1.extend({ method: literal("resources/list") });
+  const ListResourcesResultSchema$1 = PaginatedResultSchema$1.extend({ resources: array(ResourceSchema$1) });
+  const ListResourceTemplatesRequestSchema$1 = PaginatedRequestSchema$1.extend({ method: literal("resources/templates/list") });
+  const ListResourceTemplatesResultSchema$1 = PaginatedResultSchema$1.extend({ resourceTemplates: array(ResourceTemplateSchema$1) });
+  const ResourceRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({ uri: string2() });
+  const ReadResourceRequestParamsSchema$1 = ResourceRequestParamsSchema$1;
+  const ReadResourceRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("resources/read"),
+    params: ReadResourceRequestParamsSchema$1
+  });
+  const ReadResourceResultSchema$1 = ResultSchema$1.extend({ contents: array(union([TextResourceContentsSchema$1, BlobResourceContentsSchema$1])) });
+  const ResourceListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/resources/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const SubscribeRequestParamsSchema$1 = ResourceRequestParamsSchema$1;
+  const SubscribeRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("resources/subscribe"),
+    params: SubscribeRequestParamsSchema$1
+  });
+  const UnsubscribeRequestParamsSchema$1 = ResourceRequestParamsSchema$1;
+  const UnsubscribeRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("resources/unsubscribe"),
+    params: UnsubscribeRequestParamsSchema$1
+  });
+  const ResourceUpdatedNotificationParamsSchema$1 = NotificationsParamsSchema$1.extend({ uri: string2() });
+  const ResourceUpdatedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/resources/updated"),
+    params: ResourceUpdatedNotificationParamsSchema$1
+  });
+  const PromptArgumentSchema$1 = object2({
+    name: string2(),
+    description: optional(string2()),
+    required: optional(boolean2())
+  });
+  const PromptSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    description: optional(string2()),
+    arguments: optional(array(PromptArgumentSchema$1)),
+    _meta: optional(looseObject({}))
+  });
+  const ListPromptsRequestSchema$1 = PaginatedRequestSchema$1.extend({ method: literal("prompts/list") });
+  const ListPromptsResultSchema$1 = PaginatedResultSchema$1.extend({ prompts: array(PromptSchema$1) });
+  const GetPromptRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({
+    name: string2(),
+    arguments: record(string2(), string2()).optional()
+  });
+  const GetPromptRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("prompts/get"),
+    params: GetPromptRequestParamsSchema$1
+  });
+  const TextContentSchema$1 = object2({
+    type: literal("text"),
+    text: string2(),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ImageContentSchema$1 = object2({
+    type: literal("image"),
+    data: Base64Schema3,
+    mimeType: string2(),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const AudioContentSchema$1 = object2({
+    type: literal("audio"),
+    data: Base64Schema3,
+    mimeType: string2(),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ToolUseContentSchema$1 = object2({
+    type: literal("tool_use"),
+    name: string2(),
+    id: string2(),
+    input: record(string2(), unknown()),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const EmbeddedResourceSchema$1 = object2({
+    type: literal("resource"),
+    resource: union([TextResourceContentsSchema$1, BlobResourceContentsSchema$1]),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ResourceLinkSchema$1 = ResourceSchema$1.extend({ type: literal("resource_link") });
+  const ContentBlockSchema$1 = union([
+    TextContentSchema$1,
+    ImageContentSchema$1,
+    AudioContentSchema$1,
+    ResourceLinkSchema$1,
+    EmbeddedResourceSchema$1
+  ]);
+  const PromptMessageSchema$1 = object2({
+    role: RoleSchema$1,
+    content: ContentBlockSchema$1
+  });
+  const GetPromptResultSchema$1 = ResultSchema$1.extend({
+    description: string2().optional(),
+    messages: array(PromptMessageSchema$1)
+  });
+  const PromptListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/prompts/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const ToolAnnotationsSchema$1 = object2({
+    title: string2().optional(),
+    readOnlyHint: boolean2().optional(),
+    destructiveHint: boolean2().optional(),
+    idempotentHint: boolean2().optional(),
+    openWorldHint: boolean2().optional()
+  });
+  const ToolExecutionSchema$1 = object2({ taskSupport: _enum([
+    "required",
+    "optional",
+    "forbidden"
+  ]).optional() });
+  const ToolSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    description: string2().optional(),
+    inputSchema: object2({
+      type: literal("object"),
+      properties: record(string2(), JSONValueSchema$1).optional(),
+      required: array(string2()).optional()
+    }).catchall(unknown()),
+    outputSchema: object2({
+      type: literal("object"),
+      properties: record(string2(), JSONValueSchema$1).optional(),
+      required: array(string2()).optional()
+    }).catchall(unknown()).optional(),
+    annotations: ToolAnnotationsSchema$1.optional(),
+    execution: ToolExecutionSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ListToolsRequestSchema$1 = PaginatedRequestSchema$1.extend({ method: literal("tools/list") });
+  const ListToolsResultSchema$1 = PaginatedResultSchema$1.extend({ tools: array(ToolSchema$1) });
+  const CallToolResultSchema$1 = ResultSchema$1.extend({
+    content: array(ContentBlockSchema$1),
+    structuredContent: record(string2(), unknown()).optional(),
+    isError: boolean2().optional()
+  });
+  const CallToolRequestParamsSchema$1 = TaskAugmentedRequestParamsSchema$1.extend({
+    name: string2(),
+    arguments: record(string2(), unknown()).optional()
+  });
+  const CallToolRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("tools/call"),
+    params: CallToolRequestParamsSchema$1
+  });
+  const ToolListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/tools/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const LoggingLevelSchema$1 = _enum([
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+    "alert",
+    "emergency"
+  ]);
+  const SetLevelRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({ level: LoggingLevelSchema$1 });
+  const SetLevelRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("logging/setLevel"),
+    params: SetLevelRequestParamsSchema$1
+  });
+  const LoggingMessageNotificationParamsSchema$1 = NotificationsParamsSchema$1.extend({
+    level: LoggingLevelSchema$1,
+    logger: string2().optional(),
+    data: unknown()
+  });
+  const LoggingMessageNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/message"),
+    params: LoggingMessageNotificationParamsSchema$1
+  });
+  const ModelHintSchema$1 = object2({ name: string2().optional() });
+  const ModelPreferencesSchema$1 = object2({
+    hints: array(ModelHintSchema$1).optional(),
+    costPriority: number2().min(0).max(1).optional(),
+    speedPriority: number2().min(0).max(1).optional(),
+    intelligencePriority: number2().min(0).max(1).optional()
+  });
+  const ToolChoiceSchema$1 = object2({ mode: _enum([
+    "auto",
+    "required",
+    "none"
+  ]).optional() });
+  const ToolResultContentSchema$1 = object2({
+    type: literal("tool_result"),
+    toolUseId: string2().describe("The unique identifier for the corresponding tool call."),
+    content: array(ContentBlockSchema$1),
+    structuredContent: object2({}).loose().optional(),
+    isError: boolean2().optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const SamplingContentSchema$1 = discriminatedUnion("type", [
+    TextContentSchema$1,
+    ImageContentSchema$1,
+    AudioContentSchema$1
+  ]);
+  const SamplingMessageContentBlockSchema$1 = discriminatedUnion("type", [
+    TextContentSchema$1,
+    ImageContentSchema$1,
+    AudioContentSchema$1,
+    ToolUseContentSchema$1,
+    ToolResultContentSchema$1
+  ]);
+  const SamplingMessageSchema$1 = object2({
+    role: RoleSchema$1,
+    content: union([SamplingMessageContentBlockSchema$1, array(SamplingMessageContentBlockSchema$1)]),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const CreateMessageRequestParamsSchema$1 = TaskAugmentedRequestParamsSchema$1.extend({
+    messages: array(SamplingMessageSchema$1),
+    modelPreferences: ModelPreferencesSchema$1.optional(),
+    systemPrompt: string2().optional(),
+    includeContext: _enum([
+      "none",
+      "thisServer",
+      "allServers"
+    ]).optional(),
+    temperature: number2().optional(),
+    maxTokens: number2().int(),
+    stopSequences: array(string2()).optional(),
+    metadata: JSONObjectSchema$1.optional(),
+    tools: array(ToolSchema$1).optional(),
+    toolChoice: ToolChoiceSchema$1.optional()
+  });
+  const CreateMessageRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("sampling/createMessage"),
+    params: CreateMessageRequestParamsSchema$1
+  });
+  const CreateMessageResultSchema$1 = ResultSchema$1.extend({
+    model: string2(),
+    stopReason: optional(_enum([
+      "endTurn",
+      "stopSequence",
+      "maxTokens"
+    ]).or(string2())),
+    role: RoleSchema$1,
+    content: SamplingContentSchema$1
+  });
+  const CreateMessageResultWithToolsSchema$1 = ResultSchema$1.extend({
+    model: string2(),
+    stopReason: optional(_enum([
+      "endTurn",
+      "stopSequence",
+      "maxTokens",
+      "toolUse"
+    ]).or(string2())),
+    role: RoleSchema$1,
+    content: union([SamplingMessageContentBlockSchema$1, array(SamplingMessageContentBlockSchema$1)])
+  });
+  const BooleanSchemaSchema$1 = object2({
+    type: literal("boolean"),
+    title: string2().optional(),
+    description: string2().optional(),
+    default: boolean2().optional()
+  });
+  const StringSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    minLength: number2().optional(),
+    maxLength: number2().optional(),
+    format: _enum([
+      "email",
+      "uri",
+      "date",
+      "date-time"
+    ]).optional(),
+    default: string2().optional()
+  });
+  const NumberSchemaSchema$1 = object2({
+    type: _enum(["number", "integer"]),
+    title: string2().optional(),
+    description: string2().optional(),
+    minimum: number2().optional(),
+    maximum: number2().optional(),
+    default: number2().optional()
+  });
+  const UntitledSingleSelectEnumSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    enum: array(string2()),
+    default: string2().optional()
+  });
+  const TitledSingleSelectEnumSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    oneOf: array(object2({
+      const: string2(),
+      title: string2()
+    })),
+    default: string2().optional()
+  });
+  const LegacyTitledEnumSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    enum: array(string2()),
+    enumNames: array(string2()).optional(),
+    default: string2().optional()
+  });
+  const SingleSelectEnumSchemaSchema$1 = union([UntitledSingleSelectEnumSchemaSchema$1, TitledSingleSelectEnumSchemaSchema$1]);
+  const UntitledMultiSelectEnumSchemaSchema$1 = object2({
+    type: literal("array"),
+    title: string2().optional(),
+    description: string2().optional(),
+    minItems: number2().optional(),
+    maxItems: number2().optional(),
+    items: object2({
+      type: literal("string"),
+      enum: array(string2())
+    }),
+    default: array(string2()).optional()
+  });
+  const TitledMultiSelectEnumSchemaSchema$1 = object2({
+    type: literal("array"),
+    title: string2().optional(),
+    description: string2().optional(),
+    minItems: number2().optional(),
+    maxItems: number2().optional(),
+    items: object2({ anyOf: array(object2({
+      const: string2(),
+      title: string2()
+    })) }),
+    default: array(string2()).optional()
+  });
+  const MultiSelectEnumSchemaSchema$1 = union([UntitledMultiSelectEnumSchemaSchema$1, TitledMultiSelectEnumSchemaSchema$1]);
+  const EnumSchemaSchema$1 = union([
+    LegacyTitledEnumSchemaSchema$1,
+    SingleSelectEnumSchemaSchema$1,
+    MultiSelectEnumSchemaSchema$1
+  ]);
+  const PrimitiveSchemaDefinitionSchema$1 = union([
+    EnumSchemaSchema$1,
+    BooleanSchemaSchema$1,
+    StringSchemaSchema$1,
+    NumberSchemaSchema$1
+  ]);
+  const ElicitRequestFormParamsSchema$1 = TaskAugmentedRequestParamsSchema$1.extend({
+    mode: literal("form").optional(),
+    message: string2(),
+    requestedSchema: object2({
+      type: literal("object"),
+      properties: record(string2(), PrimitiveSchemaDefinitionSchema$1),
+      required: array(string2()).optional()
+    }).catchall(unknown())
+  });
+  const ElicitRequestURLParamsSchema$1 = TaskAugmentedRequestParamsSchema$1.extend({
+    mode: literal("url"),
+    message: string2(),
+    elicitationId: string2(),
+    url: string2().url()
+  });
+  const ElicitRequestParamsSchema$1 = union([ElicitRequestFormParamsSchema$1, ElicitRequestURLParamsSchema$1]);
+  const ElicitRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("elicitation/create"),
+    params: ElicitRequestParamsSchema$1
+  });
+  const ElicitationCompleteNotificationParamsSchema$1 = NotificationsParamsSchema$1.extend({ elicitationId: string2() });
+  const ElicitationCompleteNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/elicitation/complete"),
+    params: ElicitationCompleteNotificationParamsSchema$1
+  });
+  const ElicitResultSchema$1 = ResultSchema$1.extend({
+    action: _enum([
+      "accept",
+      "decline",
+      "cancel"
+    ]),
+    content: preprocess((val) => val === null ? void 0 : val, record(string2(), union([
+      string2(),
+      number2(),
+      boolean2(),
+      array(string2())
+    ])).optional())
+  });
+  const ResourceTemplateReferenceSchema$1 = object2({
+    type: literal("ref/resource"),
+    uri: string2()
+  });
+  const PromptReferenceSchema$1 = object2({
+    type: literal("ref/prompt"),
+    name: string2()
+  });
+  const CompleteRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({
+    ref: union([PromptReferenceSchema$1, ResourceTemplateReferenceSchema$1]),
+    argument: object2({
+      name: string2(),
+      value: string2()
+    }),
+    context: object2({ arguments: record(string2(), string2()).optional() }).optional()
+  });
+  const CompleteRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("completion/complete"),
+    params: CompleteRequestParamsSchema$1
+  });
+  const CompleteResultSchema$1 = ResultSchema$1.extend({ completion: looseObject({
+    values: array(string2()).max(100),
+    total: optional(number2().int()),
+    hasMore: optional(boolean2())
+  }) });
+  const RootSchema$1 = object2({
+    uri: string2().startsWith("file://"),
+    name: string2().optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ListRootsRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("roots/list"),
+    params: BaseRequestParamsSchema$1.optional()
+  });
+  const ListRootsResultSchema$1 = ResultSchema$1.extend({ roots: array(RootSchema$1) });
+  const RootsListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/roots/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const TaskCreationParamsSchema$1 = looseObject({
+    ttl: number2().optional(),
+    pollInterval: number2().optional()
+  });
+  const TaskStatusSchema$1 = _enum([
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "cancelled"
+  ]);
+  const TaskSchema$1 = object2({
+    taskId: string2(),
+    status: TaskStatusSchema$1,
+    ttl: union([number2(), _null3()]),
+    createdAt: string2(),
+    lastUpdatedAt: string2(),
+    pollInterval: optional(number2()),
+    statusMessage: optional(string2())
+  });
+  const CreateTaskResultSchema$1 = ResultSchema$1.extend({ task: TaskSchema$1 });
+  const TaskStatusNotificationParamsSchema$1 = NotificationsParamsSchema$1.merge(TaskSchema$1);
+  const TaskStatusNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/tasks/status"),
+    params: TaskStatusNotificationParamsSchema$1
+  });
+  const GetTaskRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("tasks/get"),
+    params: BaseRequestParamsSchema$1.extend({ taskId: string2() })
+  });
+  const GetTaskResultSchema$1 = ResultSchema$1.merge(TaskSchema$1);
+  const GetTaskPayloadRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("tasks/result"),
+    params: BaseRequestParamsSchema$1.extend({ taskId: string2() })
+  });
+  const GetTaskPayloadResultSchema$1 = ResultSchema$1.loose();
+  const ListTasksRequestSchema$1 = PaginatedRequestSchema$1.extend({ method: literal("tasks/list") });
+  const ListTasksResultSchema$1 = PaginatedResultSchema$1.extend({ tasks: array(TaskSchema$1) });
+  const CancelTaskRequestSchema$1 = RequestSchema$1.extend({
+    method: literal("tasks/cancel"),
+    params: BaseRequestParamsSchema$1.extend({ taskId: string2() })
+  });
   return {
-    resourceMetadataUrl,
-    scope,
-    error: error2
-  };
-}
-function extractFieldFromWwwAuth(response, fieldName) {
-  const wwwAuthHeader = response.headers.get("WWW-Authenticate");
-  if (!wwwAuthHeader) {
-    return null;
-  }
-  const pattern = new RegExp(`${fieldName}=(?:"([^"]+)"|([^\\s,]+))`);
-  const match = wwwAuthHeader.match(pattern);
-  if (match) {
-    return match[1] || match[2];
-  }
-  return null;
-}
-async function discoverOAuthProtectedResourceMetadata(serverUrl, opts, fetchFn = fetch) {
-  const response = await discoverMetadataWithFallback(serverUrl, "oauth-protected-resource", fetchFn, {
-    protocolVersion: opts?.protocolVersion,
-    metadataUrl: opts?.resourceMetadataUrl
-  });
-  if (!response || response.status === 404) {
-    await response?.body?.cancel();
-    throw new Error(`Resource server does not implement OAuth 2.0 Protected Resource Metadata.`);
-  }
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new Error(`HTTP ${response.status} trying to load well-known OAuth protected resource metadata.`);
-  }
-  return OAuthProtectedResourceMetadataSchema.parse(await response.json());
-}
-async function fetchWithCorsRetry(url2, headers, fetchFn = fetch) {
-  try {
-    return await fetchFn(url2, { headers });
-  } catch (error2) {
-    if (error2 instanceof TypeError) {
-      if (headers) {
-        return fetchWithCorsRetry(url2, void 0, fetchFn);
-      } else {
-        return void 0;
+    JSONValueSchema: JSONValueSchema$1,
+    JSONObjectSchema: JSONObjectSchema$1,
+    ProgressTokenSchema: ProgressTokenSchema$1,
+    CursorSchema: CursorSchema$1,
+    TaskMetadataSchema: TaskMetadataSchema$1,
+    RelatedTaskMetadataSchema: RelatedTaskMetadataSchema$1,
+    RequestMetaSchema: RequestMetaSchema$1,
+    BaseRequestParamsSchema: BaseRequestParamsSchema$1,
+    TaskAugmentedRequestParamsSchema: TaskAugmentedRequestParamsSchema$1,
+    RequestSchema: RequestSchema$1,
+    NotificationsParamsSchema: NotificationsParamsSchema$1,
+    NotificationSchema: NotificationSchema$1,
+    ResultSchema: ResultSchema$1,
+    RequestIdSchema: RequestIdSchema$1,
+    EmptyResultSchema: EmptyResultSchema$1,
+    CancelledNotificationParamsSchema: CancelledNotificationParamsSchema$1,
+    CancelledNotificationSchema: CancelledNotificationSchema$1,
+    IconSchema: IconSchema$1,
+    IconsSchema: IconsSchema$1,
+    BaseMetadataSchema: BaseMetadataSchema$1,
+    ImplementationSchema: ImplementationSchema$1,
+    ClientTasksCapabilitySchema: ClientTasksCapabilitySchema$1,
+    ServerTasksCapabilitySchema: ServerTasksCapabilitySchema$1,
+    ClientCapabilitiesSchema: ClientCapabilitiesSchema$1,
+    InitializeRequestParamsSchema: InitializeRequestParamsSchema$1,
+    InitializeRequestSchema: InitializeRequestSchema$1,
+    ServerCapabilitiesSchema: ServerCapabilitiesSchema$1,
+    InitializeResultSchema: InitializeResultSchema$1,
+    InitializedNotificationSchema: InitializedNotificationSchema$1,
+    PingRequestSchema: PingRequestSchema$1,
+    ProgressSchema: ProgressSchema$1,
+    ProgressNotificationParamsSchema: ProgressNotificationParamsSchema$1,
+    ProgressNotificationSchema: ProgressNotificationSchema$1,
+    PaginatedRequestParamsSchema: PaginatedRequestParamsSchema$1,
+    PaginatedRequestSchema: PaginatedRequestSchema$1,
+    PaginatedResultSchema: PaginatedResultSchema$1,
+    ResourceContentsSchema: ResourceContentsSchema$1,
+    TextResourceContentsSchema: TextResourceContentsSchema$1,
+    BlobResourceContentsSchema: BlobResourceContentsSchema$1,
+    RoleSchema: RoleSchema$1,
+    AnnotationsSchema: AnnotationsSchema$1,
+    ResourceSchema: ResourceSchema$1,
+    ResourceTemplateSchema: ResourceTemplateSchema$1,
+    ListResourcesRequestSchema: ListResourcesRequestSchema$1,
+    ListResourcesResultSchema: ListResourcesResultSchema$1,
+    ListResourceTemplatesRequestSchema: ListResourceTemplatesRequestSchema$1,
+    ListResourceTemplatesResultSchema: ListResourceTemplatesResultSchema$1,
+    ResourceRequestParamsSchema: ResourceRequestParamsSchema$1,
+    ReadResourceRequestParamsSchema: ReadResourceRequestParamsSchema$1,
+    ReadResourceRequestSchema: ReadResourceRequestSchema$1,
+    ReadResourceResultSchema: ReadResourceResultSchema$1,
+    ResourceListChangedNotificationSchema: ResourceListChangedNotificationSchema$1,
+    SubscribeRequestParamsSchema: SubscribeRequestParamsSchema$1,
+    SubscribeRequestSchema: SubscribeRequestSchema$1,
+    UnsubscribeRequestParamsSchema: UnsubscribeRequestParamsSchema$1,
+    UnsubscribeRequestSchema: UnsubscribeRequestSchema$1,
+    ResourceUpdatedNotificationParamsSchema: ResourceUpdatedNotificationParamsSchema$1,
+    ResourceUpdatedNotificationSchema: ResourceUpdatedNotificationSchema$1,
+    PromptArgumentSchema: PromptArgumentSchema$1,
+    PromptSchema: PromptSchema$1,
+    ListPromptsRequestSchema: ListPromptsRequestSchema$1,
+    ListPromptsResultSchema: ListPromptsResultSchema$1,
+    GetPromptRequestParamsSchema: GetPromptRequestParamsSchema$1,
+    GetPromptRequestSchema: GetPromptRequestSchema$1,
+    TextContentSchema: TextContentSchema$1,
+    ImageContentSchema: ImageContentSchema$1,
+    AudioContentSchema: AudioContentSchema$1,
+    ToolUseContentSchema: ToolUseContentSchema$1,
+    EmbeddedResourceSchema: EmbeddedResourceSchema$1,
+    ResourceLinkSchema: ResourceLinkSchema$1,
+    ContentBlockSchema: ContentBlockSchema$1,
+    PromptMessageSchema: PromptMessageSchema$1,
+    GetPromptResultSchema: GetPromptResultSchema$1,
+    PromptListChangedNotificationSchema: PromptListChangedNotificationSchema$1,
+    ToolAnnotationsSchema: ToolAnnotationsSchema$1,
+    ToolExecutionSchema: ToolExecutionSchema$1,
+    ToolSchema: ToolSchema$1,
+    ListToolsRequestSchema: ListToolsRequestSchema$1,
+    ListToolsResultSchema: ListToolsResultSchema$1,
+    CallToolResultSchema: CallToolResultSchema$1,
+    CallToolRequestParamsSchema: CallToolRequestParamsSchema$1,
+    CallToolRequestSchema: CallToolRequestSchema$1,
+    ToolListChangedNotificationSchema: ToolListChangedNotificationSchema$1,
+    LoggingLevelSchema: LoggingLevelSchema$1,
+    SetLevelRequestParamsSchema: SetLevelRequestParamsSchema$1,
+    SetLevelRequestSchema: SetLevelRequestSchema$1,
+    LoggingMessageNotificationParamsSchema: LoggingMessageNotificationParamsSchema$1,
+    LoggingMessageNotificationSchema: LoggingMessageNotificationSchema$1,
+    ModelHintSchema: ModelHintSchema$1,
+    ModelPreferencesSchema: ModelPreferencesSchema$1,
+    ToolChoiceSchema: ToolChoiceSchema$1,
+    ToolResultContentSchema: ToolResultContentSchema$1,
+    SamplingContentSchema: SamplingContentSchema$1,
+    SamplingMessageContentBlockSchema: SamplingMessageContentBlockSchema$1,
+    SamplingMessageSchema: SamplingMessageSchema$1,
+    CreateMessageRequestParamsSchema: CreateMessageRequestParamsSchema$1,
+    CreateMessageRequestSchema: CreateMessageRequestSchema$1,
+    CreateMessageResultSchema: CreateMessageResultSchema$1,
+    CreateMessageResultWithToolsSchema: CreateMessageResultWithToolsSchema$1,
+    BooleanSchemaSchema: BooleanSchemaSchema$1,
+    StringSchemaSchema: StringSchemaSchema$1,
+    NumberSchemaSchema: NumberSchemaSchema$1,
+    UntitledSingleSelectEnumSchemaSchema: UntitledSingleSelectEnumSchemaSchema$1,
+    TitledSingleSelectEnumSchemaSchema: TitledSingleSelectEnumSchemaSchema$1,
+    LegacyTitledEnumSchemaSchema: LegacyTitledEnumSchemaSchema$1,
+    SingleSelectEnumSchemaSchema: SingleSelectEnumSchemaSchema$1,
+    UntitledMultiSelectEnumSchemaSchema: UntitledMultiSelectEnumSchemaSchema$1,
+    TitledMultiSelectEnumSchemaSchema: TitledMultiSelectEnumSchemaSchema$1,
+    MultiSelectEnumSchemaSchema: MultiSelectEnumSchemaSchema$1,
+    EnumSchemaSchema: EnumSchemaSchema$1,
+    PrimitiveSchemaDefinitionSchema: PrimitiveSchemaDefinitionSchema$1,
+    ElicitRequestFormParamsSchema: ElicitRequestFormParamsSchema$1,
+    ElicitRequestURLParamsSchema: ElicitRequestURLParamsSchema$1,
+    ElicitRequestParamsSchema: ElicitRequestParamsSchema$1,
+    ElicitRequestSchema: ElicitRequestSchema$1,
+    ElicitationCompleteNotificationParamsSchema: ElicitationCompleteNotificationParamsSchema$1,
+    ElicitationCompleteNotificationSchema: ElicitationCompleteNotificationSchema$1,
+    ElicitResultSchema: ElicitResultSchema$1,
+    ResourceTemplateReferenceSchema: ResourceTemplateReferenceSchema$1,
+    PromptReferenceSchema: PromptReferenceSchema$1,
+    CompleteRequestParamsSchema: CompleteRequestParamsSchema$1,
+    CompleteRequestSchema: CompleteRequestSchema$1,
+    CompleteResultSchema: CompleteResultSchema$1,
+    RootSchema: RootSchema$1,
+    ListRootsRequestSchema: ListRootsRequestSchema$1,
+    ListRootsResultSchema: ListRootsResultSchema$1,
+    RootsListChangedNotificationSchema: RootsListChangedNotificationSchema$1,
+    TaskCreationParamsSchema: TaskCreationParamsSchema$1,
+    TaskStatusSchema: TaskStatusSchema$1,
+    TaskSchema: TaskSchema$1,
+    CreateTaskResultSchema: CreateTaskResultSchema$1,
+    TaskStatusNotificationParamsSchema: TaskStatusNotificationParamsSchema$1,
+    TaskStatusNotificationSchema: TaskStatusNotificationSchema$1,
+    GetTaskRequestSchema: GetTaskRequestSchema$1,
+    GetTaskResultSchema: GetTaskResultSchema$1,
+    GetTaskPayloadRequestSchema: GetTaskPayloadRequestSchema$1,
+    GetTaskPayloadResultSchema: GetTaskPayloadResultSchema$1,
+    ListTasksRequestSchema: ListTasksRequestSchema$1,
+    ListTasksResultSchema: ListTasksResultSchema$1,
+    CancelTaskRequestSchema: CancelTaskRequestSchema$1,
+    CancelTaskResultSchema: ResultSchema$1.merge(TaskSchema$1),
+    ClientRequestSchema: union([
+      PingRequestSchema$1,
+      InitializeRequestSchema$1,
+      CompleteRequestSchema$1,
+      SetLevelRequestSchema$1,
+      GetPromptRequestSchema$1,
+      ListPromptsRequestSchema$1,
+      ListResourcesRequestSchema$1,
+      ListResourceTemplatesRequestSchema$1,
+      ReadResourceRequestSchema$1,
+      SubscribeRequestSchema$1,
+      UnsubscribeRequestSchema$1,
+      CallToolRequestSchema$1,
+      ListToolsRequestSchema$1,
+      GetTaskRequestSchema$1,
+      GetTaskPayloadRequestSchema$1,
+      ListTasksRequestSchema$1,
+      CancelTaskRequestSchema$1
+    ]),
+    ClientNotificationSchema: union([
+      CancelledNotificationSchema$1,
+      ProgressNotificationSchema$1,
+      InitializedNotificationSchema$1,
+      RootsListChangedNotificationSchema$1,
+      TaskStatusNotificationSchema$1
+    ]),
+    ClientResultSchema: union([
+      EmptyResultSchema$1,
+      CreateMessageResultSchema$1,
+      CreateMessageResultWithToolsSchema$1,
+      ElicitResultSchema$1,
+      ListRootsResultSchema$1,
+      GetTaskResultSchema$1,
+      ListTasksResultSchema$1,
+      CreateTaskResultSchema$1
+    ]),
+    ServerRequestSchema: union([
+      PingRequestSchema$1,
+      CreateMessageRequestSchema$1,
+      ElicitRequestSchema$1,
+      ListRootsRequestSchema$1,
+      GetTaskRequestSchema$1,
+      GetTaskPayloadRequestSchema$1,
+      ListTasksRequestSchema$1,
+      CancelTaskRequestSchema$1
+    ]),
+    ServerNotificationSchema: union([
+      CancelledNotificationSchema$1,
+      ProgressNotificationSchema$1,
+      LoggingMessageNotificationSchema$1,
+      ResourceUpdatedNotificationSchema$1,
+      ResourceListChangedNotificationSchema$1,
+      ToolListChangedNotificationSchema$1,
+      PromptListChangedNotificationSchema$1,
+      TaskStatusNotificationSchema$1,
+      ElicitationCompleteNotificationSchema$1
+    ]),
+    ServerResultSchema: union([
+      EmptyResultSchema$1,
+      InitializeResultSchema$1,
+      CompleteResultSchema$1,
+      GetPromptResultSchema$1,
+      ListPromptsResultSchema$1,
+      ListResourcesResultSchema$1,
+      ListResourceTemplatesResultSchema$1,
+      ReadResourceResultSchema$1,
+      CallToolResultSchema$1,
+      ListToolsResultSchema$1,
+      GetTaskResultSchema$1,
+      ListTasksResultSchema$1,
+      CreateTaskResultSchema$1
+    ]),
+    CallToolResultWireSchema: unknown().superRefine((value, ctx) => {
+      if (typeof value !== "object" || value === null || Array.isArray(value) || value.content !== void 0) return;
+      for (const key of TOOL_RESULT_FOREIGN_FAMILY_KEYS) if (key in value) {
+        ctx.addIssue({
+          code: "custom",
+          message: `content is required when the body carries '${key}' \u2014 another result family cannot default into an empty tools/call success`
+        });
+        return;
       }
-    }
-    throw error2;
-  }
-}
-function buildWellKnownPath(wellKnownPrefix, pathname = "", options = {}) {
-  if (pathname.endsWith("/")) {
-    pathname = pathname.slice(0, -1);
-  }
-  return options.prependPathname ? `${pathname}/.well-known/${wellKnownPrefix}` : `/.well-known/${wellKnownPrefix}${pathname}`;
-}
-async function tryMetadataDiscovery(url2, protocolVersion2, fetchFn = fetch) {
-  const headers = {
-    "MCP-Protocol-Version": protocolVersion2
+    }).transform(normalizeContentlessToolResult).pipe(CallToolResultSchema$1)
   };
-  return await fetchWithCorsRetry(url2, headers, fetchFn);
 }
-function shouldAttemptFallback(response, pathname) {
-  return !response || response.status >= 400 && response.status < 500 && pathname !== "/";
+var memo$1;
+function buildSchemas2025() {
+  return memo$1 ??= build$1();
 }
-async function discoverMetadataWithFallback(serverUrl, wellKnownType, fetchFn, opts) {
-  const issuer = new URL(serverUrl);
-  const protocolVersion2 = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
-  let url2;
-  if (opts?.metadataUrl) {
-    url2 = new URL(opts.metadataUrl);
-  } else {
-    const wellKnownPath = buildWellKnownPath(wellKnownType, issuer.pathname);
-    url2 = new URL(wellKnownPath, opts?.metadataServerUrl ?? issuer);
-    url2.search = issuer.search;
-  }
-  let response = await tryMetadataDiscovery(url2, protocolVersion2, fetchFn);
-  if (!opts?.metadataUrl && shouldAttemptFallback(response, issuer.pathname)) {
-    const rootUrl = new URL(`/.well-known/${wellKnownType}`, issuer);
-    response = await tryMetadataDiscovery(rootUrl, protocolVersion2, fetchFn);
-  }
-  return response;
+function isNonObjectJsonSchemaRoot(json) {
+  return json["type"] !== "object";
 }
-function buildDiscoveryUrls(authorizationServerUrl) {
-  const url2 = typeof authorizationServerUrl === "string" ? new URL(authorizationServerUrl) : authorizationServerUrl;
-  const hasPath = url2.pathname !== "/";
-  const urlsToTry = [];
-  if (!hasPath) {
-    urlsToTry.push({
-      url: new URL("/.well-known/oauth-authorization-server", url2.origin),
-      type: "oauth"
-    });
-    urlsToTry.push({
-      url: new URL(`/.well-known/openid-configuration`, url2.origin),
-      type: "oidc"
-    });
-    return urlsToTry;
-  }
-  let pathname = url2.pathname;
-  if (pathname.endsWith("/")) {
-    pathname = pathname.slice(0, -1);
-  }
-  urlsToTry.push({
-    url: new URL(`/.well-known/oauth-authorization-server${pathname}`, url2.origin),
-    type: "oauth"
-  });
-  urlsToTry.push({
-    url: new URL(`/.well-known/openid-configuration${pathname}`, url2.origin),
-    type: "oidc"
-  });
-  urlsToTry.push({
-    url: new URL(`${pathname}/.well-known/openid-configuration`, url2.origin),
-    type: "oidc"
-  });
-  return urlsToTry;
+var REF_REWRITE_DATA_POSITION_KEYS = /* @__PURE__ */ new Set([
+  "const",
+  "enum",
+  "default",
+  "examples"
+]);
+var REF_REWRITE_NAME_MAP_KEYS = /* @__PURE__ */ new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  "dependencies"
+]);
+function establishesNewBase(id) {
+  return id !== void 0 && !(typeof id === "string" && id.startsWith("#"));
 }
-async function discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn = fetch, protocolVersion: protocolVersion2 = LATEST_PROTOCOL_VERSION } = {}) {
-  const headers = {
-    "MCP-Protocol-Version": protocolVersion2,
-    Accept: "application/json"
+function wrapOutputSchemaForLegacy(natural) {
+  const $schema = typeof natural["$schema"] === "string" ? natural["$schema"] : void 0;
+  if (establishesNewBase(natural["$id"])) return {
+    ...$schema !== void 0 && { $schema },
+    type: "object",
+    properties: { result: natural },
+    required: ["result"]
   };
-  const urlsToTry = buildDiscoveryUrls(authorizationServerUrl);
-  for (const { url: endpointUrl, type } of urlsToTry) {
-    const response = await fetchWithCorsRetry(endpointUrl, headers, fetchFn);
-    if (!response) {
-      continue;
-    }
-    if (!response.ok) {
-      await response.body?.cancel();
-      if (response.status >= 400 && response.status < 500) {
-        continue;
-      }
-      throw new Error(`HTTP ${response.status} trying to load ${type === "oauth" ? "OAuth" : "OpenID provider"} metadata from ${endpointUrl}`);
-    }
-    if (type === "oauth") {
-      return OAuthMetadataSchema.parse(await response.json());
-    } else {
-      return OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
-    }
-  }
-  return void 0;
-}
-async function discoverOAuthServerInfo(serverUrl, opts) {
-  let resourceMetadata;
-  let authorizationServerUrl;
-  try {
-    resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl: opts?.resourceMetadataUrl }, opts?.fetchFn);
-    if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) {
-      authorizationServerUrl = resourceMetadata.authorization_servers[0];
-    }
-  } catch {
-  }
-  if (!authorizationServerUrl) {
-    authorizationServerUrl = String(new URL("/", serverUrl));
-  }
-  const authorizationServerMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn: opts?.fetchFn });
+  const convertRecursiveRefs = declares2019Dialect(natural["$schema"]) && natural["$recursiveAnchor"] !== true;
+  const rewriteRefs = (node2, parentIsNameMap) => {
+    if (Array.isArray(node2)) return node2.map((item) => rewriteRefs(item, false));
+    if (node2 === null || typeof node2 !== "object") return node2;
+    if (!parentIsNameMap && establishesNewBase(node2["$id"])) return node2;
+    const out = {};
+    let convertedRecursion = false;
+    for (const [k, v] of Object.entries(node2)) if (parentIsNameMap) out[k] = rewriteRefs(v, false);
+    else if ((k === "$ref" || k === "$dynamicRef") && typeof v === "string") out[k] = v === "#" ? "#/properties/result" : v.startsWith("#/") ? `#/properties/result${v.slice(1)}` : v;
+    else if (k === "$recursiveRef" && v === "#" && convertRecursiveRefs) convertedRecursion = true;
+    else if (REF_REWRITE_DATA_POSITION_KEYS.has(k)) out[k] = v;
+    else if (REF_REWRITE_NAME_MAP_KEYS.has(k)) out[k] = rewriteRefs(v, true);
+    else out[k] = rewriteRefs(v, false);
+    if (convertedRecursion) if ("$ref" in out) out["allOf"] = [...Array.isArray(out["allOf"]) ? out["allOf"] : [], { $ref: "#/properties/result" }];
+    else out["$ref"] = "#/properties/result";
+    return out;
+  };
   return {
-    authorizationServerUrl,
-    authorizationServerMetadata,
-    resourceMetadata
+    ...$schema !== void 0 && { $schema },
+    type: "object",
+    properties: { result: rewriteRefs(natural, false) },
+    required: ["result"]
   };
 }
-async function startAuthorization(authorizationServerUrl, { metadata, clientInformation, redirectUrl, scope, state, resource }) {
-  let authorizationUrl;
-  if (metadata) {
-    authorizationUrl = new URL(metadata.authorization_endpoint);
-    if (!metadata.response_types_supported.includes(AUTHORIZATION_CODE_RESPONSE_TYPE)) {
-      throw new Error(`Incompatible auth server: does not support response type ${AUTHORIZATION_CODE_RESPONSE_TYPE}`);
-    }
-    if (metadata.code_challenge_methods_supported && !metadata.code_challenge_methods_supported.includes(AUTHORIZATION_CODE_CHALLENGE_METHOD)) {
-      throw new Error(`Incompatible auth server: does not support code challenge method ${AUTHORIZATION_CODE_CHALLENGE_METHOD}`);
-    }
-  } else {
-    authorizationUrl = new URL("/authorize", authorizationServerUrl);
-  }
-  const challenge = await pkceChallenge();
-  const codeVerifier = challenge.code_verifier;
-  const codeChallenge = challenge.code_challenge;
-  authorizationUrl.searchParams.set("response_type", AUTHORIZATION_CODE_RESPONSE_TYPE);
-  authorizationUrl.searchParams.set("client_id", clientInformation.client_id);
-  authorizationUrl.searchParams.set("code_challenge", codeChallenge);
-  authorizationUrl.searchParams.set("code_challenge_method", AUTHORIZATION_CODE_CHALLENGE_METHOD);
-  authorizationUrl.searchParams.set("redirect_uri", String(redirectUrl));
-  if (state) {
-    authorizationUrl.searchParams.set("state", state);
-  }
-  if (scope) {
-    authorizationUrl.searchParams.set("scope", scope);
-  }
-  if (scope?.includes("offline_access")) {
-    authorizationUrl.searchParams.append("prompt", "consent");
-  }
-  if (resource) {
-    authorizationUrl.searchParams.set("resource", resource.href);
-  }
-  return { authorizationUrl, codeVerifier };
-}
-function prepareAuthorizationCodeRequest(authorizationCode, codeVerifier, redirectUri) {
-  return new URLSearchParams({
-    grant_type: "authorization_code",
-    code: authorizationCode,
-    code_verifier: codeVerifier,
-    redirect_uri: String(redirectUri)
-  });
-}
-async function executeTokenRequest(authorizationServerUrl, { metadata, tokenRequestParams, clientInformation, addClientAuthentication, resource, fetchFn }) {
-  const tokenUrl = metadata?.token_endpoint ? new URL(metadata.token_endpoint) : new URL("/token", authorizationServerUrl);
-  const headers = new Headers({
-    "Content-Type": "application/x-www-form-urlencoded",
-    Accept: "application/json"
-  });
-  if (resource) {
-    tokenRequestParams.set("resource", resource.href);
-  }
-  if (addClientAuthentication) {
-    await addClientAuthentication(headers, tokenRequestParams, tokenUrl, metadata);
-  } else if (clientInformation) {
-    const supportedMethods = metadata?.token_endpoint_auth_methods_supported ?? [];
-    const authMethod = selectClientAuthMethod(clientInformation, supportedMethods);
-    applyClientAuthentication(authMethod, clientInformation, headers, tokenRequestParams);
-  }
-  const response = await (fetchFn ?? fetch)(tokenUrl, {
-    method: "POST",
-    headers,
-    body: tokenRequestParams
-  });
-  if (!response.ok) {
-    throw await parseErrorResponse(response);
-  }
-  return OAuthTokensSchema.parse(await response.json());
-}
-async function refreshAuthorization(authorizationServerUrl, { metadata, clientInformation, refreshToken, resource, addClientAuthentication, fetchFn }) {
-  const tokenRequestParams = new URLSearchParams({
-    grant_type: "refresh_token",
-    refresh_token: refreshToken
-  });
-  const tokens = await executeTokenRequest(authorizationServerUrl, {
-    metadata,
-    tokenRequestParams,
-    clientInformation,
-    addClientAuthentication,
-    resource,
-    fetchFn
-  });
-  return { refresh_token: refreshToken, ...tokens };
-}
-async function fetchToken(provider, authorizationServerUrl, { metadata, resource, authorizationCode, fetchFn } = {}) {
-  const scope = provider.clientMetadata.scope;
-  let tokenRequestParams;
-  if (provider.prepareTokenRequest) {
-    tokenRequestParams = await provider.prepareTokenRequest(scope);
-  }
-  if (!tokenRequestParams) {
-    if (!authorizationCode) {
-      throw new Error("Either provider.prepareTokenRequest() or authorizationCode is required");
-    }
-    if (!provider.redirectUrl) {
-      throw new Error("redirectUrl is required for authorization_code flow");
-    }
-    const codeVerifier = await provider.codeVerifier();
-    tokenRequestParams = prepareAuthorizationCodeRequest(authorizationCode, codeVerifier, provider.redirectUrl);
-  }
-  const clientInformation = await provider.clientInformation();
-  return executeTokenRequest(authorizationServerUrl, {
-    metadata,
-    tokenRequestParams,
-    clientInformation: clientInformation ?? void 0,
-    addClientAuthentication: provider.addClientAuthentication,
-    resource,
-    fetchFn
-  });
-}
-async function registerClient(authorizationServerUrl, { metadata, clientMetadata, scope, fetchFn }) {
-  let registrationUrl;
-  if (metadata) {
-    if (!metadata.registration_endpoint) {
-      throw new Error("Incompatible auth server: does not support dynamic client registration");
-    }
-    registrationUrl = new URL(metadata.registration_endpoint);
-  } else {
-    registrationUrl = new URL("/register", authorizationServerUrl);
-  }
-  const response = await (fetchFn ?? fetch)(registrationUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json"
+var requestMethodKeys$1 = {
+  ping: null,
+  initialize: null,
+  "completion/complete": null,
+  "logging/setLevel": null,
+  "prompts/get": null,
+  "prompts/list": null,
+  "resources/list": null,
+  "resources/templates/list": null,
+  "resources/read": null,
+  "resources/subscribe": null,
+  "resources/unsubscribe": null,
+  "tools/call": null,
+  "tools/list": null,
+  "tasks/get": null,
+  "tasks/result": null,
+  "tasks/list": null,
+  "tasks/cancel": null,
+  "sampling/createMessage": null,
+  "elicitation/create": null,
+  "roots/list": null
+};
+var notificationMethodKeys$1 = {
+  "notifications/cancelled": null,
+  "notifications/progress": null,
+  "notifications/initialized": null,
+  "notifications/roots/list_changed": null,
+  "notifications/tasks/status": null,
+  "notifications/message": null,
+  "notifications/resources/updated": null,
+  "notifications/resources/list_changed": null,
+  "notifications/tools/list_changed": null,
+  "notifications/prompts/list_changed": null,
+  "notifications/elicitation/complete": null
+};
+var resultMethodKeys = {
+  ping: null,
+  initialize: null,
+  "completion/complete": null,
+  "logging/setLevel": null,
+  "prompts/get": null,
+  "prompts/list": null,
+  "resources/list": null,
+  "resources/templates/list": null,
+  "resources/read": null,
+  "resources/subscribe": null,
+  "resources/unsubscribe": null,
+  "tools/call": null,
+  "tools/list": null,
+  "sampling/createMessage": null,
+  "elicitation/create": null,
+  "roots/list": null
+};
+var maps$1;
+function registryMaps() {
+  if (maps$1) return maps$1;
+  const s = buildSchemas2025();
+  maps$1 = {
+    requestSchemas: {
+      ping: s.PingRequestSchema,
+      initialize: s.InitializeRequestSchema,
+      "completion/complete": s.CompleteRequestSchema,
+      "logging/setLevel": s.SetLevelRequestSchema,
+      "prompts/get": s.GetPromptRequestSchema,
+      "prompts/list": s.ListPromptsRequestSchema,
+      "resources/list": s.ListResourcesRequestSchema,
+      "resources/templates/list": s.ListResourceTemplatesRequestSchema,
+      "resources/read": s.ReadResourceRequestSchema,
+      "resources/subscribe": s.SubscribeRequestSchema,
+      "resources/unsubscribe": s.UnsubscribeRequestSchema,
+      "tools/call": s.CallToolRequestSchema,
+      "tools/list": s.ListToolsRequestSchema,
+      "tasks/get": s.GetTaskRequestSchema,
+      "tasks/result": s.GetTaskPayloadRequestSchema,
+      "tasks/list": s.ListTasksRequestSchema,
+      "tasks/cancel": s.CancelTaskRequestSchema,
+      "sampling/createMessage": s.CreateMessageRequestSchema,
+      "elicitation/create": s.ElicitRequestSchema,
+      "roots/list": s.ListRootsRequestSchema
     },
-    body: JSON.stringify({
-      ...clientMetadata,
-      ...scope !== void 0 ? { scope } : {}
+    notificationSchemas: {
+      "notifications/cancelled": s.CancelledNotificationSchema,
+      "notifications/progress": s.ProgressNotificationSchema,
+      "notifications/initialized": s.InitializedNotificationSchema,
+      "notifications/roots/list_changed": s.RootsListChangedNotificationSchema,
+      "notifications/tasks/status": s.TaskStatusNotificationSchema,
+      "notifications/message": s.LoggingMessageNotificationSchema,
+      "notifications/resources/updated": s.ResourceUpdatedNotificationSchema,
+      "notifications/resources/list_changed": s.ResourceListChangedNotificationSchema,
+      "notifications/tools/list_changed": s.ToolListChangedNotificationSchema,
+      "notifications/prompts/list_changed": s.PromptListChangedNotificationSchema,
+      "notifications/elicitation/complete": s.ElicitationCompleteNotificationSchema
+    },
+    resultSchemas: {
+      ping: s.EmptyResultSchema,
+      initialize: s.InitializeResultSchema,
+      "completion/complete": s.CompleteResultSchema,
+      "logging/setLevel": s.EmptyResultSchema,
+      "prompts/get": s.GetPromptResultSchema,
+      "prompts/list": s.ListPromptsResultSchema,
+      "resources/list": s.ListResourcesResultSchema,
+      "resources/templates/list": s.ListResourceTemplatesResultSchema,
+      "resources/read": s.ReadResourceResultSchema,
+      "resources/subscribe": s.EmptyResultSchema,
+      "resources/unsubscribe": s.EmptyResultSchema,
+      "tools/call": s.CallToolResultWireSchema,
+      "tools/list": s.ListToolsResultSchema,
+      "sampling/createMessage": s.CreateMessageResultWithToolsSchema,
+      "elicitation/create": s.ElicitResultSchema,
+      "roots/list": s.ListRootsResultSchema
+    }
+  };
+  return maps$1;
+}
+function hasRequestMethod2025(method) {
+  return Object.prototype.hasOwnProperty.call(requestMethodKeys$1, method);
+}
+function hasNotificationMethod2025(method) {
+  return Object.prototype.hasOwnProperty.call(notificationMethodKeys$1, method);
+}
+function hasResultMethod(method) {
+  return Object.prototype.hasOwnProperty.call(resultMethodKeys, method);
+}
+function getResultSchema(method) {
+  return hasResultMethod(method) ? registryMaps().resultSchemas[method] : void 0;
+}
+function getRequestSchema(method) {
+  return hasRequestMethod2025(method) ? registryMaps().requestSchemas[method] : void 0;
+}
+function getNotificationSchema(method) {
+  return hasNotificationMethod2025(method) ? registryMaps().notificationSchemas[method] : void 0;
+}
+var rev2025RequestMethods = Object.keys(requestMethodKeys$1);
+var rev2025NotificationMethods = Object.keys(notificationMethodKeys$1);
+function isPlainObject$4(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function triState$1(schema, raw) {
+  if (schema === void 0) return {
+    ok: false,
+    reason: "not-in-era"
+  };
+  const parsed = schema.safeParse(raw);
+  return parsed.success ? {
+    ok: true,
+    value: parsed.data
+  } : {
+    ok: false,
+    reason: "invalid",
+    message: String(parsed.error)
+  };
+}
+var NOT_IN_ERA$1 = {
+  ok: false,
+  reason: "not-in-era"
+};
+function toolNeedsLegacyWrap(t) {
+  return isPlainObject$4(t) && isPlainObject$4(t["outputSchema"]) && isNonObjectJsonSchemaRoot(t["outputSchema"]);
+}
+function toNeutralResult(value) {
+  return value;
+}
+var rev2025Codec = {
+  era: "2025-11-25",
+  hasRequestMethod: hasRequestMethod2025,
+  hasNotificationMethod: hasNotificationMethod2025,
+  validateRequest: (method, raw) => triState$1(getRequestSchema(method), raw),
+  validateResult: (method, raw) => triState$1(getResultSchema(method), raw),
+  validateNotification: (method, raw) => triState$1(getNotificationSchema(method), raw),
+  hasInputRequestMethod: () => false,
+  validateInputRequest: () => NOT_IN_ERA$1,
+  validateInputResponse: () => NOT_IN_ERA$1,
+  samplingResultVariant: ((hasTools, raw) => {
+    const s = buildSchemas2025();
+    return triState$1(hasTools ? s.CreateMessageResultWithToolsSchema : s.CreateMessageResultSchema, raw);
+  }),
+  outboundEnvelope: (_material) => void 0,
+  validateEnvelopeMeta: (_meta) => [],
+  projectCallToolResult(result, advertisedOutputSchema) {
+    const withText = appendTextFallbackForNonObject(result);
+    const sc = withText.structuredContent;
+    if (sc === void 0) return withText;
+    const valueIsNonObject = typeof sc !== "object" || sc === null || Array.isArray(sc);
+    const schemaWrapped = advertisedOutputSchema !== void 0 && isNonObjectJsonSchemaRoot(advertisedOutputSchema);
+    if (!valueIsNonObject && !schemaWrapped) return withText;
+    return {
+      ...withText,
+      structuredContent: { result: sc }
+    };
+  },
+  decodeResult(_method, raw) {
+    if (isPlainObject$4(raw) && "resultType" in raw) {
+      const stripped = { ...raw };
+      delete stripped["resultType"];
+      return {
+        kind: "complete",
+        result: toNeutralResult(stripped)
+      };
+    }
+    return {
+      kind: "complete",
+      result: toNeutralResult(raw)
+    };
+  },
+  encodeResult(method, result) {
+    if (method !== "tools/list") return result;
+    const tools = result.tools;
+    if (!Array.isArray(tools) || !tools.some((t) => toolNeedsLegacyWrap(t))) return result;
+    return {
+      ...result,
+      tools: tools.map((t) => toolNeedsLegacyWrap(t) ? {
+        ...t,
+        outputSchema: wrapOutputSchemaForLegacy(t.outputSchema)
+      } : t)
+    };
+  },
+  encodeErrorCode: (code) => code === -32002 ? -32602 : code,
+  checkInboundEnvelope: (_material) => void 0
+};
+function build() {
+  const JSONValueSchema$1 = lazy(() => union([
+    string2(),
+    number2(),
+    boolean2(),
+    _null3(),
+    record(string2(), JSONValueSchema$1),
+    array(JSONValueSchema$1)
+  ]));
+  const JSONObjectSchema$1 = record(string2(), JSONValueSchema$1);
+  const ProgressTokenSchema$1 = union([string2(), number2().int()]);
+  const CursorSchema$1 = string2();
+  const RequestIdSchema$1 = union([string2(), number2().int()]);
+  const RoleSchema$1 = _enum(["user", "assistant"]);
+  const LoggingLevelSchema$1 = _enum([
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+    "alert",
+    "emergency"
+  ]);
+  const Base64Schema3 = string2().refine((val) => {
+    try {
+      atob(val);
+      return true;
+    } catch {
+      return false;
+    }
+  }, { message: "Invalid Base64 string" });
+  const TaskMetadataSchema$1 = object2({ ttl: number2().optional() });
+  const RelatedTaskMetadataSchema$1 = object2({ taskId: string2() });
+  const RequestMetaSchema$1 = looseObject({
+    progressToken: ProgressTokenSchema$1.optional(),
+    "io.modelcontextprotocol/related-task": RelatedTaskMetadataSchema$1.optional()
+  });
+  const BaseRequestParamsSchema$1 = object2({ _meta: RequestMetaSchema$1.optional() });
+  const TaskAugmentedRequestParamsSchema$1 = BaseRequestParamsSchema$1.extend({ task: TaskMetadataSchema$1.optional() });
+  const NotificationsParamsSchema$1 = object2({ _meta: RequestMetaSchema$1.optional() });
+  const NotificationSchema$1 = object2({
+    method: string2(),
+    params: NotificationsParamsSchema$1.loose().optional()
+  });
+  const IconSchema$1 = object2({
+    src: string2(),
+    mimeType: string2().optional(),
+    sizes: array(string2()).optional(),
+    theme: _enum(["light", "dark"]).optional()
+  });
+  const IconsSchema$1 = object2({ icons: array(IconSchema$1).optional() });
+  const BaseMetadataSchema$1 = object2({
+    name: string2(),
+    title: string2().optional()
+  });
+  const ImplementationSchema$1 = BaseMetadataSchema$1.extend({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    version: string2(),
+    websiteUrl: string2().optional(),
+    description: string2().optional()
+  });
+  const FormElicitationCapabilitySchema3 = intersection(object2({ applyDefaults: boolean2().optional() }), JSONObjectSchema$1);
+  const ElicitationCapabilitySchema3 = preprocess((value) => {
+    if (value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0) return { form: {} };
+    return value;
+  }, intersection(object2({
+    form: FormElicitationCapabilitySchema3.optional(),
+    url: JSONObjectSchema$1.optional()
+  }), JSONObjectSchema$1.optional()));
+  const ClientTasksCapabilitySchema$1 = looseObject({
+    list: JSONObjectSchema$1.optional(),
+    cancel: JSONObjectSchema$1.optional(),
+    requests: looseObject({
+      sampling: looseObject({ createMessage: JSONObjectSchema$1.optional() }).optional(),
+      elicitation: looseObject({ create: JSONObjectSchema$1.optional() }).optional()
+    }).optional()
+  });
+  const ServerTasksCapabilitySchema$1 = looseObject({
+    list: JSONObjectSchema$1.optional(),
+    cancel: JSONObjectSchema$1.optional(),
+    requests: looseObject({ tools: looseObject({ call: JSONObjectSchema$1.optional() }).optional() }).optional()
+  });
+  const ClientCapabilitiesSchema$1 = object2({
+    experimental: record(string2(), JSONObjectSchema$1).optional(),
+    sampling: object2({
+      context: JSONObjectSchema$1.optional(),
+      tools: JSONObjectSchema$1.optional()
+    }).optional(),
+    elicitation: ElicitationCapabilitySchema3.optional(),
+    roots: object2({ listChanged: boolean2().optional() }).optional(),
+    tasks: ClientTasksCapabilitySchema$1.optional(),
+    extensions: record(string2(), JSONObjectSchema$1).optional()
+  });
+  const ServerCapabilitiesSchema$1 = object2({
+    experimental: record(string2(), JSONObjectSchema$1).optional(),
+    logging: JSONObjectSchema$1.optional(),
+    completions: JSONObjectSchema$1.optional(),
+    prompts: object2({ listChanged: boolean2().optional() }).optional(),
+    resources: object2({
+      subscribe: boolean2().optional(),
+      listChanged: boolean2().optional()
+    }).optional(),
+    tools: object2({ listChanged: boolean2().optional() }).optional(),
+    tasks: ServerTasksCapabilitySchema$1.optional(),
+    extensions: record(string2(), JSONObjectSchema$1).optional()
+  });
+  const ProgressSchema$1 = object2({
+    progress: number2(),
+    total: optional(number2()),
+    message: optional(string2())
+  });
+  const ProgressNotificationParamsSchema$1 = object2({
+    ...NotificationsParamsSchema$1.shape,
+    ...ProgressSchema$1.shape,
+    progressToken: ProgressTokenSchema$1
+  });
+  const ProgressNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/progress"),
+    params: ProgressNotificationParamsSchema$1
+  });
+  const LoggingMessageNotificationParamsSchema$1 = NotificationsParamsSchema$1.extend({
+    level: LoggingLevelSchema$1,
+    logger: string2().optional(),
+    data: unknown()
+  });
+  const LoggingMessageNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/message"),
+    params: LoggingMessageNotificationParamsSchema$1
+  });
+  const ResourceContentsSchema$1 = object2({
+    uri: string2(),
+    mimeType: optional(string2()),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const TextResourceContentsSchema$1 = ResourceContentsSchema$1.extend({ text: string2() });
+  const BlobResourceContentsSchema$1 = ResourceContentsSchema$1.extend({ blob: Base64Schema3 });
+  const AnnotationsSchema$1 = object2({
+    audience: array(RoleSchema$1).optional(),
+    priority: number2().min(0).max(1).optional(),
+    lastModified: iso_exports.datetime({ offset: true }).optional()
+  });
+  const ResourceSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    uri: string2(),
+    description: optional(string2()),
+    mimeType: optional(string2()),
+    size: optional(number2()),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: optional(looseObject({}))
+  });
+  const ResourceTemplateSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    uriTemplate: string2(),
+    description: optional(string2()),
+    mimeType: optional(string2()),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: optional(looseObject({}))
+  });
+  const ResourceListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/resources/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const ResourceUpdatedNotificationParamsSchema$1 = NotificationsParamsSchema$1.extend({ uri: string2() });
+  const ResourceUpdatedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/resources/updated"),
+    params: ResourceUpdatedNotificationParamsSchema$1
+  });
+  const PromptArgumentSchema$1 = object2({
+    name: string2(),
+    description: optional(string2()),
+    required: optional(boolean2())
+  });
+  const PromptSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    description: optional(string2()),
+    arguments: optional(array(PromptArgumentSchema$1)),
+    _meta: optional(looseObject({}))
+  });
+  const PromptListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/prompts/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const TextContentSchema$1 = object2({
+    type: literal("text"),
+    text: string2(),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ImageContentSchema$1 = object2({
+    type: literal("image"),
+    data: Base64Schema3,
+    mimeType: string2(),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const AudioContentSchema$1 = object2({
+    type: literal("audio"),
+    data: Base64Schema3,
+    mimeType: string2(),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ToolUseContentSchema$1 = object2({
+    type: literal("tool_use"),
+    name: string2(),
+    id: string2(),
+    input: record(string2(), unknown()),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const EmbeddedResourceSchema$1 = object2({
+    type: literal("resource"),
+    resource: union([TextResourceContentsSchema$1, BlobResourceContentsSchema$1]),
+    annotations: AnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ResourceLinkSchema$1 = ResourceSchema$1.extend({ type: literal("resource_link") });
+  const ContentBlockSchema$1 = union([
+    TextContentSchema$1,
+    ImageContentSchema$1,
+    AudioContentSchema$1,
+    ResourceLinkSchema$1,
+    EmbeddedResourceSchema$1
+  ]);
+  const PromptMessageSchema$1 = object2({
+    role: RoleSchema$1,
+    content: ContentBlockSchema$1
+  });
+  const ToolAnnotationsSchema$1 = object2({
+    title: string2().optional(),
+    readOnlyHint: boolean2().optional(),
+    destructiveHint: boolean2().optional(),
+    idempotentHint: boolean2().optional(),
+    openWorldHint: boolean2().optional()
+  });
+  const ToolListChangedNotificationSchema$1 = NotificationSchema$1.extend({
+    method: literal("notifications/tools/list_changed"),
+    params: NotificationsParamsSchema$1.optional()
+  });
+  const ModelHintSchema$1 = object2({ name: string2().optional() });
+  const ModelPreferencesSchema$1 = object2({
+    hints: array(ModelHintSchema$1).optional(),
+    costPriority: number2().min(0).max(1).optional(),
+    speedPriority: number2().min(0).max(1).optional(),
+    intelligencePriority: number2().min(0).max(1).optional()
+  });
+  const ToolChoiceSchema$1 = object2({ mode: _enum([
+    "auto",
+    "required",
+    "none"
+  ]).optional() });
+  const BooleanSchemaSchema$1 = object2({
+    type: literal("boolean"),
+    title: string2().optional(),
+    description: string2().optional(),
+    default: boolean2().optional()
+  });
+  const StringSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    minLength: number2().optional(),
+    maxLength: number2().optional(),
+    format: _enum([
+      "email",
+      "uri",
+      "date",
+      "date-time"
+    ]).optional(),
+    default: string2().optional()
+  });
+  const NumberSchemaSchema$1 = object2({
+    type: _enum(["number", "integer"]),
+    title: string2().optional(),
+    description: string2().optional(),
+    minimum: number2().optional(),
+    maximum: number2().optional(),
+    default: number2().optional()
+  });
+  const UntitledSingleSelectEnumSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    enum: array(string2()),
+    default: string2().optional()
+  });
+  const TitledSingleSelectEnumSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    oneOf: array(object2({
+      const: string2(),
+      title: string2()
+    })),
+    default: string2().optional()
+  });
+  const LegacyTitledEnumSchemaSchema$1 = object2({
+    type: literal("string"),
+    title: string2().optional(),
+    description: string2().optional(),
+    enum: array(string2()),
+    enumNames: array(string2()).optional(),
+    default: string2().optional()
+  });
+  const SingleSelectEnumSchemaSchema$1 = union([UntitledSingleSelectEnumSchemaSchema$1, TitledSingleSelectEnumSchemaSchema$1]);
+  const UntitledMultiSelectEnumSchemaSchema$1 = object2({
+    type: literal("array"),
+    title: string2().optional(),
+    description: string2().optional(),
+    minItems: number2().optional(),
+    maxItems: number2().optional(),
+    items: object2({
+      type: literal("string"),
+      enum: array(string2())
+    }),
+    default: array(string2()).optional()
+  });
+  const TitledMultiSelectEnumSchemaSchema$1 = object2({
+    type: literal("array"),
+    title: string2().optional(),
+    description: string2().optional(),
+    minItems: number2().optional(),
+    maxItems: number2().optional(),
+    items: object2({ anyOf: array(object2({
+      const: string2(),
+      title: string2()
+    })) }),
+    default: array(string2()).optional()
+  });
+  const MultiSelectEnumSchemaSchema$1 = union([UntitledMultiSelectEnumSchemaSchema$1, TitledMultiSelectEnumSchemaSchema$1]);
+  const EnumSchemaSchema$1 = union([
+    LegacyTitledEnumSchemaSchema$1,
+    SingleSelectEnumSchemaSchema$1,
+    MultiSelectEnumSchemaSchema$1
+  ]);
+  const PrimitiveSchemaDefinitionSchema$1 = union([
+    EnumSchemaSchema$1,
+    BooleanSchemaSchema$1,
+    StringSchemaSchema$1,
+    NumberSchemaSchema$1
+  ]);
+  const ElicitRequestFormParamsSchema$1 = TaskAugmentedRequestParamsSchema$1.extend({
+    mode: literal("form").optional(),
+    message: string2(),
+    requestedSchema: object2({
+      type: literal("object"),
+      properties: record(string2(), PrimitiveSchemaDefinitionSchema$1),
+      required: array(string2()).optional()
+    }).catchall(unknown())
+  });
+  const ResourceTemplateReferenceSchema$1 = object2({
+    type: literal("ref/resource"),
+    uri: string2()
+  });
+  const PromptReferenceSchema$1 = object2({
+    type: literal("ref/prompt"),
+    name: string2()
+  });
+  const RootSchema$1 = object2({
+    uri: string2().startsWith("file://"),
+    name: string2().optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const sharedClientCapabilityShape = ClientCapabilitiesSchema$1.shape;
+  const ClientCapabilities2026Schema = object2({
+    experimental: sharedClientCapabilityShape.experimental,
+    sampling: sharedClientCapabilityShape.sampling,
+    elicitation: sharedClientCapabilityShape.elicitation,
+    roots: sharedClientCapabilityShape.roots,
+    extensions: sharedClientCapabilityShape.extensions
+  });
+  const sharedServerCapabilityShape = ServerCapabilitiesSchema$1.shape;
+  const ServerCapabilities2026Schema = object2({
+    experimental: sharedServerCapabilityShape.experimental,
+    logging: sharedServerCapabilityShape.logging,
+    completions: sharedServerCapabilityShape.completions,
+    prompts: sharedServerCapabilityShape.prompts,
+    resources: sharedServerCapabilityShape.resources,
+    tools: sharedServerCapabilityShape.tools,
+    extensions: sharedServerCapabilityShape.extensions
+  });
+  const RequestMetaEnvelopeSchema = looseObject({
+    progressToken: ProgressTokenSchema$1.optional(),
+    [PROTOCOL_VERSION_META_KEY]: string2(),
+    [CLIENT_INFO_META_KEY]: ImplementationSchema$1.optional(),
+    [CLIENT_CAPABILITIES_META_KEY]: ClientCapabilities2026Schema,
+    [LOG_LEVEL_META_KEY]: LoggingLevelSchema$1.optional()
+  });
+  const ToolSchema$1 = object2({
+    ...BaseMetadataSchema$1.shape,
+    ...IconsSchema$1.shape,
+    description: string2().optional(),
+    inputSchema: looseObject({
+      $schema: string2().optional(),
+      type: literal("object")
+    }),
+    outputSchema: looseObject({ $schema: string2().optional() }).optional(),
+    annotations: ToolAnnotationsSchema$1.optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ToolResultContentSchema$1 = object2({
+    type: literal("tool_result"),
+    toolUseId: string2(),
+    content: array(ContentBlockSchema$1),
+    structuredContent: unknown().optional(),
+    isError: boolean2().optional(),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const SamplingMessageContentBlockSchema$1 = union([
+    TextContentSchema$1,
+    ImageContentSchema$1,
+    AudioContentSchema$1,
+    ToolUseContentSchema$1,
+    ToolResultContentSchema$1
+  ]);
+  const SamplingMessageSchema$1 = object2({
+    role: RoleSchema$1,
+    content: union([SamplingMessageContentBlockSchema$1, array(SamplingMessageContentBlockSchema$1)]),
+    _meta: record(string2(), unknown()).optional()
+  });
+  const ResultTypeSchema = string2();
+  const ResultMetaSchema = looseObject({ [SERVER_INFO_META_KEY]: ImplementationSchema$1.optional().catch(void 0) });
+  const wireMeta = ResultMetaSchema.optional();
+  function wireResult(shape) {
+    return looseObject({
+      _meta: wireMeta,
+      resultType: ResultTypeSchema.default("complete"),
+      ...shape
+    });
+  }
+  const ResultSchema$1 = wireResult({});
+  const PaginatedResultSchema$1 = wireResult({ nextCursor: CursorSchema$1.optional() });
+  const CallToolResultSchema$1 = wireResult({
+    content: array(ContentBlockSchema$1),
+    structuredContent: unknown().optional(),
+    isError: boolean2().optional()
+  });
+  const ListToolsResultSchema$1 = wireResult({
+    ttlMs: number2().int().min(0),
+    cacheScope: _enum(["public", "private"]),
+    tools: array(ToolSchema$1),
+    nextCursor: CursorSchema$1.optional()
+  });
+  const ListPromptsResultSchema$1 = wireResult({
+    ttlMs: number2().int().min(0),
+    cacheScope: _enum(["public", "private"]),
+    prompts: array(PromptSchema$1),
+    nextCursor: CursorSchema$1.optional()
+  });
+  const GetPromptResultSchema$1 = wireResult({
+    description: string2().optional(),
+    messages: array(PromptMessageSchema$1)
+  });
+  const ListResourcesResultSchema$1 = wireResult({
+    ttlMs: number2().int().min(0),
+    cacheScope: _enum(["public", "private"]),
+    resources: array(ResourceSchema$1),
+    nextCursor: CursorSchema$1.optional()
+  });
+  const ListResourceTemplatesResultSchema$1 = wireResult({
+    ttlMs: number2().int().min(0),
+    cacheScope: _enum(["public", "private"]),
+    resourceTemplates: array(ResourceTemplateSchema$1),
+    nextCursor: CursorSchema$1.optional()
+  });
+  const ReadResourceResultSchema$1 = wireResult({
+    ttlMs: number2().int().min(0),
+    cacheScope: _enum(["public", "private"]),
+    contents: array(union([TextResourceContentsSchema$1, BlobResourceContentsSchema$1]))
+  });
+  const CompleteResultSchema$1 = wireResult({ completion: object2({
+    values: array(string2()).max(100),
+    total: number2().int().optional(),
+    hasMore: boolean2().optional()
+  }).loose() });
+  const CacheableResultSchema = wireResult({
+    ttlMs: number2().int().min(0),
+    cacheScope: _enum(["public", "private"])
+  });
+  const DiscoverResultSchema$1 = wireResult({
+    ttlMs: number2().int().min(0).catch(0),
+    cacheScope: _enum(["public", "private"]).catch("private"),
+    supportedVersions: array(string2()),
+    capabilities: ServerCapabilities2026Schema,
+    instructions: string2().optional()
+  });
+  const CreateMessageRequestParamsSchema$1 = object2({
+    messages: array(SamplingMessageSchema$1),
+    modelPreferences: ModelPreferencesSchema$1.optional(),
+    systemPrompt: string2().optional(),
+    includeContext: _enum([
+      "none",
+      "thisServer",
+      "allServers"
+    ]).optional(),
+    temperature: number2().optional(),
+    maxTokens: number2().int(),
+    stopSequences: array(string2()).optional(),
+    metadata: JSONObjectSchema$1.optional(),
+    tools: array(ToolSchema$1).optional(),
+    toolChoice: ToolChoiceSchema$1.optional()
+  });
+  const CreateMessageRequestSchema$1 = object2({
+    method: literal("sampling/createMessage"),
+    params: CreateMessageRequestParamsSchema$1
+  });
+  const ListRootsRequestSchema$1 = object2({
+    method: literal("roots/list"),
+    params: object2({ _meta: record(string2(), unknown()).optional() }).optional()
+  });
+  const CreateMessageResultSchema$1 = object2({
+    ...SamplingMessageSchema$1.shape,
+    model: string2(),
+    stopReason: string2().optional()
+  });
+  const ListRootsResultSchema$1 = object2({ roots: array(RootSchema$1) });
+  const ElicitResultSchema$1 = object2({
+    action: _enum([
+      "accept",
+      "decline",
+      "cancel"
+    ]),
+    content: record(string2(), union([
+      string2(),
+      number2(),
+      boolean2(),
+      array(string2())
+    ])).optional()
+  });
+  const ElicitRequestURLParamsSchema$1 = object2({
+    mode: literal("url"),
+    message: string2(),
+    url: string2().url()
+  });
+  const ElicitRequestParamsSchema$1 = union([ElicitRequestFormParamsSchema$1, ElicitRequestURLParamsSchema$1]);
+  const ElicitRequestSchema$1 = object2({
+    method: literal("elicitation/create"),
+    params: ElicitRequestParamsSchema$1
+  });
+  const InputRequestSchema = union([
+    CreateMessageRequestSchema$1,
+    ListRootsRequestSchema$1,
+    ElicitRequestSchema$1
+  ]);
+  const InputResponseSchema = union([
+    CreateMessageResultSchema$1,
+    ListRootsResultSchema$1,
+    ElicitResultSchema$1
+  ]);
+  const InputRequestsSchema = record(string2(), InputRequestSchema);
+  const InputResponsesSchema = record(string2(), InputResponseSchema);
+  const InputRequiredResultSchema = wireResult({
+    inputRequests: InputRequestsSchema.optional(),
+    requestState: string2().optional()
+  });
+  const retryParamsShape = {
+    inputResponses: InputResponsesSchema.optional(),
+    requestState: string2().optional()
+  };
+  const InputResponseRequestParamsSchema = object2({
+    _meta: RequestMetaEnvelopeSchema,
+    ...retryParamsShape
+  });
+  const DispatchRequestMetaSchema = looseObject({ progressToken: ProgressTokenSchema$1.optional() });
+  function wireRequest(method, paramsShape) {
+    return object2({
+      method: literal(method),
+      params: object2({
+        _meta: RequestMetaEnvelopeSchema,
+        ...paramsShape
+      })
+    });
+  }
+  function dispatchRequest(method, paramsShape) {
+    return object2({
+      method: literal(method),
+      params: object2({
+        _meta: DispatchRequestMetaSchema.optional(),
+        ...paramsShape
+      }).optional()
+    });
+  }
+  const callToolParamsShape = {
+    name: string2(),
+    arguments: record(string2(), unknown()).optional(),
+    ...retryParamsShape
+  };
+  const paginatedParamsShape = { cursor: CursorSchema$1.optional() };
+  const CallToolRequestSchema$1 = wireRequest("tools/call", callToolParamsShape);
+  const ListToolsRequestSchema$1 = wireRequest("tools/list", paginatedParamsShape);
+  const ListPromptsRequestSchema$1 = wireRequest("prompts/list", paginatedParamsShape);
+  const GetPromptRequestSchema$1 = wireRequest("prompts/get", {
+    name: string2(),
+    arguments: record(string2(), string2()).optional(),
+    ...retryParamsShape
+  });
+  const ListResourcesRequestSchema$1 = wireRequest("resources/list", paginatedParamsShape);
+  const ListResourceTemplatesRequestSchema$1 = wireRequest("resources/templates/list", paginatedParamsShape);
+  const ReadResourceRequestSchema$1 = wireRequest("resources/read", {
+    uri: string2(),
+    ...retryParamsShape
+  });
+  const completeParamsShape = {
+    ref: union([PromptReferenceSchema$1, ResourceTemplateReferenceSchema$1]),
+    argument: object2({
+      name: string2(),
+      value: string2()
+    }),
+    context: object2({ arguments: record(string2(), string2()).optional() }).optional()
+  };
+  const CompleteRequestSchema$1 = wireRequest("completion/complete", completeParamsShape);
+  const DiscoverRequestSchema$1 = wireRequest("server/discover", {});
+  const SubscriptionFilterSchema$1 = object2({
+    toolsListChanged: boolean2().optional(),
+    promptsListChanged: boolean2().optional(),
+    resourcesListChanged: boolean2().optional(),
+    resourceSubscriptions: array(string2()).optional()
+  });
+  const subscriptionsListenParamsShape = { notifications: SubscriptionFilterSchema$1 };
+  const SubscriptionsListenRequestSchema$1 = wireRequest("subscriptions/listen", subscriptionsListenParamsShape);
+  const SubscriptionsListenResultMetaSchema$1 = ResultMetaSchema.extend({ "io.modelcontextprotocol/subscriptionId": RequestIdSchema$1 });
+  const SubscriptionsListenResultSchema$1 = looseObject({
+    _meta: SubscriptionsListenResultMetaSchema$1,
+    resultType: ResultTypeSchema.default("complete")
+  });
+  const dispatchRequestSchemas = {
+    "tools/call": dispatchRequest("tools/call", callToolParamsShape),
+    "tools/list": dispatchRequest("tools/list", paginatedParamsShape),
+    "prompts/get": dispatchRequest("prompts/get", {
+      name: string2(),
+      arguments: record(string2(), string2()).optional()
+    }),
+    "prompts/list": dispatchRequest("prompts/list", paginatedParamsShape),
+    "resources/list": dispatchRequest("resources/list", paginatedParamsShape),
+    "resources/templates/list": dispatchRequest("resources/templates/list", paginatedParamsShape),
+    "resources/read": dispatchRequest("resources/read", { uri: string2() }),
+    "completion/complete": dispatchRequest("completion/complete", completeParamsShape),
+    "server/discover": dispatchRequest("server/discover", {}),
+    "subscriptions/listen": dispatchRequest("subscriptions/listen", subscriptionsListenParamsShape)
+  };
+  function liftedResult(shape) {
+    return looseObject({
+      _meta: wireMeta,
+      ...shape
+    });
+  }
+  const dispatchResultSchemas = {
+    "tools/call": liftedResult({
+      content: array(ContentBlockSchema$1),
+      structuredContent: unknown().optional(),
+      isError: boolean2().optional()
+    }),
+    "tools/list": liftedResult({
+      ttlMs: number2().int().min(0),
+      cacheScope: _enum(["public", "private"]),
+      tools: array(ToolSchema$1),
+      nextCursor: CursorSchema$1.optional()
+    }),
+    "prompts/get": liftedResult({
+      description: string2().optional(),
+      messages: array(PromptMessageSchema$1)
+    }),
+    "prompts/list": liftedResult({
+      ttlMs: number2().int().min(0),
+      cacheScope: _enum(["public", "private"]),
+      prompts: array(PromptSchema$1),
+      nextCursor: CursorSchema$1.optional()
+    }),
+    "resources/list": liftedResult({
+      ttlMs: number2().int().min(0),
+      cacheScope: _enum(["public", "private"]),
+      resources: array(ResourceSchema$1),
+      nextCursor: CursorSchema$1.optional()
+    }),
+    "resources/templates/list": liftedResult({
+      ttlMs: number2().int().min(0),
+      cacheScope: _enum(["public", "private"]),
+      resourceTemplates: array(ResourceTemplateSchema$1),
+      nextCursor: CursorSchema$1.optional()
+    }),
+    "resources/read": liftedResult({
+      ttlMs: number2().int().min(0),
+      cacheScope: _enum(["public", "private"]),
+      contents: array(union([TextResourceContentsSchema$1, BlobResourceContentsSchema$1]))
+    }),
+    "completion/complete": liftedResult({ completion: object2({
+      values: array(string2()).max(100),
+      total: number2().int().optional(),
+      hasMore: boolean2().optional()
+    }).loose() }),
+    "server/discover": liftedResult({
+      ttlMs: number2().int().min(0).catch(0),
+      cacheScope: _enum(["public", "private"]).catch("private"),
+      supportedVersions: array(string2()),
+      capabilities: ServerCapabilities2026Schema,
+      instructions: string2().optional()
+    }),
+    "subscriptions/listen": liftedResult({})
+  };
+  const NotificationMetaSchema = looseObject({ "io.modelcontextprotocol/subscriptionId": RequestIdSchema$1.optional() });
+  const SubscriptionsAcknowledgedNotificationSchema$1 = object2({
+    method: literal("notifications/subscriptions/acknowledged"),
+    params: object2({
+      _meta: NotificationMetaSchema.optional(),
+      notifications: SubscriptionFilterSchema$1
     })
   });
-  if (!response.ok) {
-    throw await parseErrorResponse(response);
+  const CancelledNotificationParamsSchema$1 = object2({
+    _meta: NotificationMetaSchema.optional(),
+    requestId: RequestIdSchema$1,
+    reason: string2().optional()
+  });
+  const CancelledNotificationSchema$1 = object2({
+    method: literal("notifications/cancelled"),
+    params: CancelledNotificationParamsSchema$1
+  });
+  const notificationSchemas2026 = {
+    "notifications/cancelled": CancelledNotificationSchema$1,
+    "notifications/progress": ProgressNotificationSchema$1,
+    "notifications/message": LoggingMessageNotificationSchema$1,
+    "notifications/resources/updated": ResourceUpdatedNotificationSchema$1,
+    "notifications/resources/list_changed": ResourceListChangedNotificationSchema$1,
+    "notifications/tools/list_changed": ToolListChangedNotificationSchema$1,
+    "notifications/prompts/list_changed": PromptListChangedNotificationSchema$1,
+    "notifications/subscriptions/acknowledged": SubscriptionsAcknowledgedNotificationSchema$1
+  };
+  const wireResultResponse = (result) => object2({
+    jsonrpc: literal("2.0"),
+    id: union([string2(), number2().int()]),
+    result
+  }).strict();
+  return {
+    JSONValueSchema: JSONValueSchema$1,
+    JSONObjectSchema: JSONObjectSchema$1,
+    ProgressTokenSchema: ProgressTokenSchema$1,
+    CursorSchema: CursorSchema$1,
+    RequestIdSchema: RequestIdSchema$1,
+    RoleSchema: RoleSchema$1,
+    LoggingLevelSchema: LoggingLevelSchema$1,
+    TaskMetadataSchema: TaskMetadataSchema$1,
+    RelatedTaskMetadataSchema: RelatedTaskMetadataSchema$1,
+    RequestMetaSchema: RequestMetaSchema$1,
+    BaseRequestParamsSchema: BaseRequestParamsSchema$1,
+    TaskAugmentedRequestParamsSchema: TaskAugmentedRequestParamsSchema$1,
+    NotificationsParamsSchema: NotificationsParamsSchema$1,
+    NotificationSchema: NotificationSchema$1,
+    IconSchema: IconSchema$1,
+    IconsSchema: IconsSchema$1,
+    BaseMetadataSchema: BaseMetadataSchema$1,
+    ImplementationSchema: ImplementationSchema$1,
+    ClientTasksCapabilitySchema: ClientTasksCapabilitySchema$1,
+    ServerTasksCapabilitySchema: ServerTasksCapabilitySchema$1,
+    ClientCapabilitiesSchema: ClientCapabilitiesSchema$1,
+    ServerCapabilitiesSchema: ServerCapabilitiesSchema$1,
+    ProgressSchema: ProgressSchema$1,
+    ProgressNotificationParamsSchema: ProgressNotificationParamsSchema$1,
+    ProgressNotificationSchema: ProgressNotificationSchema$1,
+    LoggingMessageNotificationParamsSchema: LoggingMessageNotificationParamsSchema$1,
+    LoggingMessageNotificationSchema: LoggingMessageNotificationSchema$1,
+    ResourceContentsSchema: ResourceContentsSchema$1,
+    TextResourceContentsSchema: TextResourceContentsSchema$1,
+    BlobResourceContentsSchema: BlobResourceContentsSchema$1,
+    AnnotationsSchema: AnnotationsSchema$1,
+    ResourceSchema: ResourceSchema$1,
+    ResourceTemplateSchema: ResourceTemplateSchema$1,
+    ResourceListChangedNotificationSchema: ResourceListChangedNotificationSchema$1,
+    ResourceUpdatedNotificationParamsSchema: ResourceUpdatedNotificationParamsSchema$1,
+    ResourceUpdatedNotificationSchema: ResourceUpdatedNotificationSchema$1,
+    PromptArgumentSchema: PromptArgumentSchema$1,
+    PromptSchema: PromptSchema$1,
+    PromptListChangedNotificationSchema: PromptListChangedNotificationSchema$1,
+    TextContentSchema: TextContentSchema$1,
+    ImageContentSchema: ImageContentSchema$1,
+    AudioContentSchema: AudioContentSchema$1,
+    ToolUseContentSchema: ToolUseContentSchema$1,
+    EmbeddedResourceSchema: EmbeddedResourceSchema$1,
+    ResourceLinkSchema: ResourceLinkSchema$1,
+    ContentBlockSchema: ContentBlockSchema$1,
+    PromptMessageSchema: PromptMessageSchema$1,
+    ToolAnnotationsSchema: ToolAnnotationsSchema$1,
+    ToolListChangedNotificationSchema: ToolListChangedNotificationSchema$1,
+    ModelHintSchema: ModelHintSchema$1,
+    ModelPreferencesSchema: ModelPreferencesSchema$1,
+    ToolChoiceSchema: ToolChoiceSchema$1,
+    BooleanSchemaSchema: BooleanSchemaSchema$1,
+    StringSchemaSchema: StringSchemaSchema$1,
+    NumberSchemaSchema: NumberSchemaSchema$1,
+    UntitledSingleSelectEnumSchemaSchema: UntitledSingleSelectEnumSchemaSchema$1,
+    TitledSingleSelectEnumSchemaSchema: TitledSingleSelectEnumSchemaSchema$1,
+    LegacyTitledEnumSchemaSchema: LegacyTitledEnumSchemaSchema$1,
+    SingleSelectEnumSchemaSchema: SingleSelectEnumSchemaSchema$1,
+    UntitledMultiSelectEnumSchemaSchema: UntitledMultiSelectEnumSchemaSchema$1,
+    TitledMultiSelectEnumSchemaSchema: TitledMultiSelectEnumSchemaSchema$1,
+    MultiSelectEnumSchemaSchema: MultiSelectEnumSchemaSchema$1,
+    EnumSchemaSchema: EnumSchemaSchema$1,
+    PrimitiveSchemaDefinitionSchema: PrimitiveSchemaDefinitionSchema$1,
+    ElicitRequestFormParamsSchema: ElicitRequestFormParamsSchema$1,
+    ResourceTemplateReferenceSchema: ResourceTemplateReferenceSchema$1,
+    PromptReferenceSchema: PromptReferenceSchema$1,
+    RootSchema: RootSchema$1,
+    ClientCapabilities2026Schema,
+    ServerCapabilities2026Schema,
+    RequestMetaEnvelopeSchema,
+    ToolSchema: ToolSchema$1,
+    ToolResultContentSchema: ToolResultContentSchema$1,
+    SamplingMessageContentBlockSchema: SamplingMessageContentBlockSchema$1,
+    SamplingMessageSchema: SamplingMessageSchema$1,
+    ResultTypeSchema,
+    ResultMetaSchema,
+    ResultSchema: ResultSchema$1,
+    PaginatedResultSchema: PaginatedResultSchema$1,
+    CallToolResultSchema: CallToolResultSchema$1,
+    ListToolsResultSchema: ListToolsResultSchema$1,
+    ListPromptsResultSchema: ListPromptsResultSchema$1,
+    GetPromptResultSchema: GetPromptResultSchema$1,
+    ListResourcesResultSchema: ListResourcesResultSchema$1,
+    ListResourceTemplatesResultSchema: ListResourceTemplatesResultSchema$1,
+    ReadResourceResultSchema: ReadResourceResultSchema$1,
+    CompleteResultSchema: CompleteResultSchema$1,
+    CacheableResultSchema,
+    DiscoverResultSchema: DiscoverResultSchema$1,
+    CreateMessageRequestParamsSchema: CreateMessageRequestParamsSchema$1,
+    CreateMessageRequestSchema: CreateMessageRequestSchema$1,
+    ListRootsRequestSchema: ListRootsRequestSchema$1,
+    CreateMessageResultSchema: CreateMessageResultSchema$1,
+    ListRootsResultSchema: ListRootsResultSchema$1,
+    ElicitResultSchema: ElicitResultSchema$1,
+    ElicitRequestURLParamsSchema: ElicitRequestURLParamsSchema$1,
+    ElicitRequestParamsSchema: ElicitRequestParamsSchema$1,
+    ElicitRequestSchema: ElicitRequestSchema$1,
+    InputRequestSchema,
+    InputResponseSchema,
+    InputRequestsSchema,
+    InputResponsesSchema,
+    InputRequiredResultSchema,
+    InputResponseRequestParamsSchema,
+    CallToolRequestSchema: CallToolRequestSchema$1,
+    ListToolsRequestSchema: ListToolsRequestSchema$1,
+    ListPromptsRequestSchema: ListPromptsRequestSchema$1,
+    GetPromptRequestSchema: GetPromptRequestSchema$1,
+    ListResourcesRequestSchema: ListResourcesRequestSchema$1,
+    ListResourceTemplatesRequestSchema: ListResourceTemplatesRequestSchema$1,
+    ReadResourceRequestSchema: ReadResourceRequestSchema$1,
+    CompleteRequestSchema: CompleteRequestSchema$1,
+    DiscoverRequestSchema: DiscoverRequestSchema$1,
+    SubscriptionFilterSchema: SubscriptionFilterSchema$1,
+    SubscriptionsListenRequestSchema: SubscriptionsListenRequestSchema$1,
+    SubscriptionsListenResultMetaSchema: SubscriptionsListenResultMetaSchema$1,
+    SubscriptionsListenResultSchema: SubscriptionsListenResultSchema$1,
+    dispatchRequestSchemas,
+    dispatchResultSchemas,
+    NotificationMetaSchema,
+    SubscriptionsAcknowledgedNotificationSchema: SubscriptionsAcknowledgedNotificationSchema$1,
+    CancelledNotificationParamsSchema: CancelledNotificationParamsSchema$1,
+    CancelledNotificationSchema: CancelledNotificationSchema$1,
+    notificationSchemas2026,
+    JSONRPCResultResponseSchema: wireResultResponse(ResultSchema$1),
+    CallToolResultResponseSchema: wireResultResponse(union([CallToolResultSchema$1, InputRequiredResultSchema])),
+    ListToolsResultResponseSchema: wireResultResponse(ListToolsResultSchema$1),
+    ListPromptsResultResponseSchema: wireResultResponse(ListPromptsResultSchema$1),
+    GetPromptResultResponseSchema: wireResultResponse(union([GetPromptResultSchema$1, InputRequiredResultSchema])),
+    ListResourcesResultResponseSchema: wireResultResponse(ListResourcesResultSchema$1),
+    ListResourceTemplatesResultResponseSchema: wireResultResponse(ListResourceTemplatesResultSchema$1),
+    ReadResourceResultResponseSchema: wireResultResponse(union([ReadResourceResultSchema$1, InputRequiredResultSchema])),
+    CompleteResultResponseSchema: wireResultResponse(CompleteResultSchema$1),
+    DiscoverResultResponseSchema: wireResultResponse(DiscoverResultSchema$1)
+  };
+}
+var memo2;
+function buildSchemas2026() {
+  return memo2 ??= build();
+}
+var CACHEABLE_RESULT_METHODS = [
+  "tools/list",
+  "prompts/list",
+  "resources/list",
+  "resources/templates/list",
+  "resources/read",
+  "server/discover"
+];
+function isCacheableResultMethod(method) {
+  return CACHEABLE_RESULT_METHODS.includes(method);
+}
+var RESULT_CACHE_HINT_FALLBACK = /* @__PURE__ */ Symbol("modelcontextprotocol.resultCacheHintFallback");
+function cacheHintFallbackOf(result) {
+  return result[RESULT_CACHE_HINT_FALLBACK];
+}
+function isValidCacheTtlMs(value) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+function isValidCacheScope(value) {
+  return value === "public" || value === "private";
+}
+var ProtocolErrorCode = /* @__PURE__ */ (function(ProtocolErrorCode$1) {
+  ProtocolErrorCode$1[ProtocolErrorCode$1["ParseError"] = -32700] = "ParseError";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["InvalidRequest"] = -32600] = "InvalidRequest";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["MethodNotFound"] = -32601] = "MethodNotFound";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["InvalidParams"] = -32602] = "InvalidParams";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["InternalError"] = -32603] = "InternalError";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["ResourceNotFound"] = -32002] = "ResourceNotFound";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["MissingRequiredClientCapability"] = -32021] = "MissingRequiredClientCapability";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["UnsupportedProtocolVersion"] = -32022] = "UnsupportedProtocolVersion";
+  ProtocolErrorCode$1[ProtocolErrorCode$1["UrlElicitationRequired"] = -32042] = "UrlElicitationRequired";
+  return ProtocolErrorCode$1;
+})({});
+var ProtocolError = class ProtocolError2 extends Error {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.ProtocolError" });
   }
-  return OAuthClientInformationFullSchema.parse(await response.json());
+  static [Symbol.hasInstance](value) {
+    return brandedHasInstance(this, value);
+  }
+  /**
+  * Brand-based type guard: equivalent to `value instanceof this`, as an
+  * explicit static predicate (the axios/AWS-SDK `isInstance` style). Reads
+  * the caller's own brand via `this`, so every branded subclass gets a
+  * correctly-scoped guard by inheritance. Must be invoked on the class —
+  * in callback position write `v => SdkError.isInstance(v)`, not
+  * `.filter(SdkError.isInstance)` (detached calls throw rather than
+  * silently matching nothing).
+  */
+  static isInstance(value) {
+    if (typeof this !== "function") throw new TypeError("isInstance must be called on the class (e.g. `SdkError.isInstance(value)`); for callbacks use `v => SdkError.isInstance(v)`");
+    return brandedHasInstance(this, value);
+  }
+  constructor(code, message, data) {
+    super(message);
+    this.code = code;
+    this.data = data;
+    this.name = "ProtocolError";
+    stampErrorBrands(this, new.target);
+  }
+  /**
+  * Factory method to create the appropriate error type based on the error code and data
+  */
+  static fromError(code, message, data) {
+    if (code === ProtocolErrorCode.UrlElicitationRequired && data) {
+      const errorData = data;
+      if (errorData.elicitations) return new UrlElicitationRequiredError2(errorData.elicitations, message);
+    }
+    if (code === ProtocolErrorCode.UnsupportedProtocolVersion && data) {
+      const errorData = data;
+      if (Array.isArray(errorData.supported) && typeof errorData.requested === "string") return new UnsupportedProtocolVersionError({
+        supported: errorData.supported,
+        requested: errorData.requested
+      }, message);
+    }
+    if (code === ProtocolErrorCode.InvalidParams || code === ProtocolErrorCode.ResourceNotFound) {
+      const errorData = data;
+      if (typeof errorData?.uri === "string" && (code === ProtocolErrorCode.ResourceNotFound || Object.keys(errorData).length === 1)) return new ResourceNotFoundError(errorData.uri, message);
+    }
+    if (code === ProtocolErrorCode.MissingRequiredClientCapability && data) {
+      const errorData = data;
+      if (errorData.requiredCapabilities !== null && typeof errorData.requiredCapabilities === "object" && !Array.isArray(errorData.requiredCapabilities)) return new MissingRequiredClientCapabilityError({ requiredCapabilities: errorData.requiredCapabilities }, message);
+    }
+    return new ProtocolError2(code, message, data);
+  }
+};
+var ResourceNotFoundError = class extends ProtocolError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.ResourceNotFoundError" });
+  }
+  constructor(uri, message = `Resource not found: ${uri}`) {
+    super(ProtocolErrorCode.InvalidParams, message, { uri });
+  }
+  /** The URI that was requested and not found. */
+  get uri() {
+    return this.data.uri;
+  }
+};
+var UrlElicitationRequiredError2 = class extends ProtocolError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.UrlElicitationRequiredError" });
+  }
+  constructor(elicitations, message = `URL elicitation${elicitations.length > 1 ? "s" : ""} required`) {
+    super(ProtocolErrorCode.UrlElicitationRequired, message, { elicitations });
+  }
+  get elicitations() {
+    return this.data?.elicitations ?? [];
+  }
+};
+var UnsupportedProtocolVersionError = class extends ProtocolError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.UnsupportedProtocolVersionError" });
+  }
+  constructor(data, message = `Unsupported protocol version: ${data.requested}`) {
+    super(ProtocolErrorCode.UnsupportedProtocolVersion, message, data);
+  }
+  /**
+  * Protocol versions the receiver supports.
+  */
+  get supported() {
+    return this.data.supported;
+  }
+  /**
+  * The protocol version that was requested.
+  */
+  get requested() {
+    return this.data.requested;
+  }
+};
+var MissingRequiredClientCapabilityError = class extends ProtocolError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.MissingRequiredClientCapabilityError" });
+  }
+  constructor(data, message = `Missing required client capabilities: ${Object.keys(data.requiredCapabilities).join(", ")}`) {
+    super(ProtocolErrorCode.MissingRequiredClientCapability, message, data);
+  }
+  /**
+  * The capabilities the server requires from the client to process the
+  * request (only the missing capabilities are listed).
+  */
+  get requiredCapabilities() {
+    return this.data.requiredCapabilities;
+  }
+};
+var DEFAULT_CACHE_TTL_MS = 0;
+var DEFAULT_CACHE_SCOPE = "private";
+var EXTENDED_RESULT_TYPE_METHODS = [
+  "tools/call",
+  "prompts/get",
+  "resources/read"
+];
+function stampResultType(method, result) {
+  const provided = result["resultType"];
+  if (provided === void 0) return {
+    ...result,
+    resultType: "complete"
+  };
+  if (provided === "complete") return result;
+  if (EXTENDED_RESULT_TYPE_METHODS.includes(method)) return result;
+  throw new ProtocolError(ProtocolErrorCode.InternalError, `Handler for ${method} returned resultType '${String(provided)}', but results of ${method} only support 'complete' on protocol revision 2026-07-28`);
+}
+function fillCacheFields(method, result) {
+  const fallback = cacheHintFallbackOf(result);
+  if (result["resultType"] !== "complete" || !isCacheableResultMethod(method)) return fallback === void 0 ? result : stripCacheHintFallback(result);
+  const provided = result;
+  const ttlMs = isValidCacheTtlMs(provided["ttlMs"]) ? provided["ttlMs"] : resolveTtlMs(fallback);
+  const cacheScope = isValidCacheScope(provided["cacheScope"]) ? provided["cacheScope"] : resolveCacheScope(fallback);
+  const filled = {
+    ...provided,
+    ttlMs,
+    cacheScope
+  };
+  delete filled[RESULT_CACHE_HINT_FALLBACK];
+  return filled;
+}
+function isPlainObject$3(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function stampServerInfoMeta(result, serverInfo) {
+  if (serverInfo === void 0) return result;
+  const meta2 = result["_meta"];
+  if (meta2 === void 0) return {
+    ...result,
+    _meta: { [SERVER_INFO_META_KEY]: serverInfo }
+  };
+  if (!isPlainObject$3(meta2)) return result;
+  if (meta2[SERVER_INFO_META_KEY] !== void 0) return result;
+  return {
+    ...result,
+    _meta: {
+      ...meta2,
+      [SERVER_INFO_META_KEY]: serverInfo
+    }
+  };
+}
+function resolveTtlMs(fallback) {
+  return fallback !== void 0 && isValidCacheTtlMs(fallback.ttlMs) ? fallback.ttlMs : DEFAULT_CACHE_TTL_MS;
+}
+function resolveCacheScope(fallback) {
+  return fallback !== void 0 && isValidCacheScope(fallback.cacheScope) ? fallback.cacheScope : DEFAULT_CACHE_SCOPE;
+}
+function stripCacheHintFallback(result) {
+  const copy = { ...result };
+  delete copy[RESULT_CACHE_HINT_FALLBACK];
+  return copy;
+}
+var INPUT_REQUEST_METHODS_2026 = [
+  "elicitation/create",
+  "sampling/createMessage",
+  "roots/list"
+];
+var maps;
+function inputSchemaMaps() {
+  if (maps) return maps;
+  const s = buildSchemas2026();
+  maps = {
+    request: {
+      "elicitation/create": object2({
+        method: literal("elicitation/create"),
+        params: s.ElicitRequestParamsSchema
+      }),
+      "sampling/createMessage": object2({
+        method: literal("sampling/createMessage"),
+        params: s.CreateMessageRequestParamsSchema
+      }),
+      "roots/list": object2({
+        method: literal("roots/list"),
+        params: looseObject({}).optional()
+      })
+    },
+    response: {
+      "elicitation/create": s.ElicitResultSchema,
+      "sampling/createMessage": s.CreateMessageResultSchema,
+      "roots/list": s.ListRootsResultSchema
+    }
+  };
+  return maps;
+}
+function isInputRequestMethod2026(method) {
+  return INPUT_REQUEST_METHODS_2026.includes(method);
+}
+function getInputRequestSchema2026(method) {
+  return isInputRequestMethod2026(method) ? inputSchemaMaps().request[method] : void 0;
+}
+function getInputResponseSchema2026(method) {
+  return isInputRequestMethod2026(method) ? inputSchemaMaps().response[method] : void 0;
+}
+var requestMethodKeys = {
+  "tools/call": null,
+  "tools/list": null,
+  "prompts/get": null,
+  "prompts/list": null,
+  "resources/list": null,
+  "resources/templates/list": null,
+  "resources/read": null,
+  "completion/complete": null,
+  "server/discover": null,
+  "subscriptions/listen": null
+};
+var notificationMethodKeys = {
+  "notifications/cancelled": null,
+  "notifications/progress": null,
+  "notifications/message": null,
+  "notifications/resources/updated": null,
+  "notifications/resources/list_changed": null,
+  "notifications/tools/list_changed": null,
+  "notifications/prompts/list_changed": null,
+  "notifications/subscriptions/acknowledged": null
+};
+function hasRequestMethod2026(method) {
+  return Object.prototype.hasOwnProperty.call(requestMethodKeys, method);
+}
+function hasNotificationMethod2026(method) {
+  return Object.prototype.hasOwnProperty.call(notificationMethodKeys, method);
+}
+function hasResultMethod2026(method) {
+  return Object.prototype.hasOwnProperty.call(requestMethodKeys, method);
+}
+function getRequestSchema2026(method) {
+  return hasRequestMethod2026(method) ? buildSchemas2026().dispatchRequestSchemas[method] : void 0;
+}
+function getResultSchema2026(method) {
+  return hasResultMethod2026(method) ? buildSchemas2026().dispatchResultSchemas[method] : void 0;
+}
+function getNotificationSchema2026(method) {
+  return hasNotificationMethod2026(method) ? buildSchemas2026().notificationSchemas2026[method] : void 0;
+}
+var rev2026RequestMethods = Object.keys(requestMethodKeys);
+var rev2026NotificationMethods = Object.keys(notificationMethodKeys);
+function isPlainObject$2(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function triState(schema, raw) {
+  if (schema === void 0) return {
+    ok: false,
+    reason: "not-in-era"
+  };
+  const parsed = schema.safeParse(raw);
+  return parsed.success ? {
+    ok: true,
+    value: parsed.data
+  } : {
+    ok: false,
+    reason: "invalid",
+    message: String(parsed.error)
+  };
+}
+var NOT_IN_ERA = {
+  ok: false,
+  reason: "not-in-era"
+};
+var REQUIRED_ENVELOPE_KEYS = [PROTOCOL_VERSION_META_KEY, CLIENT_CAPABILITIES_META_KEY];
+function enforceDeletedFields(method, result) {
+  let next = result;
+  let copied = false;
+  const copy = () => {
+    if (!copied) {
+      next = { ...next };
+      copied = true;
+    }
+    return next;
+  };
+  const tools = result.tools;
+  if (method === "tools/list" && Array.isArray(tools) && tools.some((tool) => isPlainObject$2(tool) && "execution" in tool)) copy().tools = tools.map((tool) => {
+    if (!isPlainObject$2(tool) || !("execution" in tool)) return tool;
+    const rest = { ...tool };
+    delete rest["execution"];
+    return rest;
+  });
+  const capabilities = result.capabilities;
+  if (isPlainObject$2(capabilities) && "tasks" in capabilities) {
+    const rest = { ...capabilities };
+    delete rest["tasks"];
+    copy().capabilities = rest;
+  }
+  return next;
+}
+var rev2026Codec = {
+  era: "2026-07-28",
+  hasRequestMethod: hasRequestMethod2026,
+  hasNotificationMethod: hasNotificationMethod2026,
+  hasInputRequestMethod: (method) => getInputRequestSchema2026(method) !== void 0,
+  validateRequest: (method, raw) => triState(getRequestSchema2026(method), raw),
+  validateResult: (method, raw) => triState(getResultSchema2026(method), raw),
+  validateNotification: (method, raw) => triState(getNotificationSchema2026(method), raw),
+  validateInputRequest: (method, raw) => triState(getInputRequestSchema2026(method), raw),
+  validateInputResponse: (method, raw) => triState(getInputResponseSchema2026(method), raw),
+  samplingResultVariant: () => NOT_IN_ERA,
+  outboundEnvelope(material) {
+    return {
+      [PROTOCOL_VERSION_META_KEY]: material.protocolVersion,
+      [CLIENT_INFO_META_KEY]: material.clientInfo,
+      [CLIENT_CAPABILITIES_META_KEY]: material.clientCapabilities,
+      ...material.logLevel !== void 0 && { [LOG_LEVEL_META_KEY]: material.logLevel }
+    };
+  },
+  validateEnvelopeMeta(meta2) {
+    const issues = [];
+    for (const key of REQUIRED_ENVELOPE_KEYS) if (!(key in meta2)) issues.push({
+      key,
+      problem: "missing"
+    });
+    const parsed = buildSchemas2026().RequestMetaEnvelopeSchema.safeParse(meta2);
+    if (!parsed.success) for (const issue2 of parsed.error.issues) {
+      const path12 = issue2.path.map(String);
+      const key = path12.length > 0 ? path12.join(".") : "_meta";
+      if (path12.length === 1 && issues.some((existing) => existing.key === key && existing.problem === "missing")) continue;
+      issues.push({
+        key,
+        problem: issue2.message
+      });
+    }
+    return issues;
+  },
+  projectCallToolResult: (result) => appendTextFallbackForNonObject(result),
+  inputRequestSchema: getInputRequestSchema2026,
+  decodeResult(method, raw) {
+    if (!isPlainObject$2(raw)) return {
+      kind: "invalid",
+      error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: not an object`, { method })
+    };
+    const rawResultType = raw["resultType"];
+    if (rawResultType === void 0) return {
+      kind: "invalid",
+      error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: missing required resultType \u2014 servers implementing protocol revision 2026-07-28 MUST include it (the absent-means-complete bridge applies only to earlier-revision servers)`, {
+        method,
+        violation: "missing-resultType"
+      })
+    };
+    if (typeof rawResultType !== "string") return {
+      kind: "invalid",
+      error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: non-string resultType`, {
+        method,
+        resultType: rawResultType
+      })
+    };
+    if (rawResultType === "input_required") {
+      const rawInputRequests = raw["inputRequests"];
+      const inputRequests = isPlainObject$2(rawInputRequests) ? rawInputRequests : {};
+      const requestState = raw["requestState"];
+      if (Object.keys(inputRequests).length === 0 && typeof requestState !== "string") return {
+        kind: "invalid",
+        error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: input_required carries neither inputRequests nor requestState (every input_required result must include at least one of the two)`, {
+          method,
+          violation: "input-required-missing-both"
+        })
+      };
+      return {
+        kind: "input_required",
+        inputRequests,
+        ...typeof requestState === "string" && { requestState }
+      };
+    }
+    if (rawResultType !== "complete") return {
+      kind: "invalid",
+      error: new SdkError(SdkErrorCode.UnsupportedResultType, `Unsupported result type '${rawResultType}' for ${method}`, {
+        resultType: rawResultType,
+        method
+      })
+    };
+    const wireResultSchemas = getWireResultSchemas();
+    const wireSchema = Object.hasOwn(wireResultSchemas, method) ? wireResultSchemas[method] : void 0;
+    if (wireSchema !== void 0) {
+      const parsed = wireSchema.safeParse(raw);
+      if (!parsed.success) return {
+        kind: "invalid",
+        error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: ${parsed.error}`, { method })
+      };
+    }
+    const lifted = { ...raw };
+    delete lifted["resultType"];
+    return {
+      kind: "complete",
+      result: lifted
+    };
+  },
+  encodeResult(method, result, serverInfo) {
+    return stampServerInfoMeta(fillCacheFields(method, stampResultType(method, enforceDeletedFields(method, result))), serverInfo);
+  },
+  encodeErrorCode: (code) => code === -32002 ? -32602 : code,
+  checkInboundEnvelope(material) {
+    if (material.envelope === void 0) return "Request is missing the required _meta envelope for protocol revision 2026-07-28 (io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientCapabilities)";
+    const parsed = buildSchemas2026().RequestMetaEnvelopeSchema.safeParse(material.envelope);
+    if (!parsed.success) return `Invalid _meta envelope for protocol revision 2026-07-28: ${parsed.error.issues.map((issue2) => issue2.message).join("; ")}`;
+  }
+};
+var wireResultSchemasMemo;
+function getWireResultSchemas() {
+  if (wireResultSchemasMemo) return wireResultSchemasMemo;
+  const s = buildSchemas2026();
+  wireResultSchemasMemo = {
+    "tools/call": s.CallToolResultSchema,
+    "tools/list": s.ListToolsResultSchema,
+    "prompts/get": s.GetPromptResultSchema,
+    "prompts/list": s.ListPromptsResultSchema,
+    "resources/list": s.ListResourcesResultSchema,
+    "resources/templates/list": s.ListResourceTemplatesResultSchema,
+    "resources/read": s.ReadResourceResultSchema,
+    "completion/complete": s.CompleteResultSchema,
+    "server/discover": s.DiscoverResultSchema
+  };
+  return wireResultSchemasMemo;
+}
+var MODERN_WIRE_REVISION = "2026-07-28";
+function codecForVersion(version2) {
+  return version2 !== void 0 && isModernProtocolVersion(version2) ? rev2026Codec : rev2025Codec;
+}
+function classifiedWireEra(classification) {
+  if (classification.revision !== void 0) return codecForVersion(classification.revision).era;
+  return classification.era === "modern" ? rev2026Codec.era : rev2025Codec.era;
+}
+function isSpecRequestMethod(method) {
+  return ALL_CODECS.some((codec) => codec.hasRequestMethod(method));
+}
+function isSpecNotificationMethod(method) {
+  return ALL_CODECS.some((codec) => codec.hasNotificationMethod(method));
+}
+var ALL_CODECS = [rev2025Codec, rev2026Codec];
+var schemas_exports2 = /* @__PURE__ */ __exportAll({
+  AnnotationsSchema: () => AnnotationsSchema2,
+  AudioContentSchema: () => AudioContentSchema2,
+  BaseMetadataSchema: () => BaseMetadataSchema2,
+  BaseRequestParamsSchema: () => BaseRequestParamsSchema2,
+  BlobResourceContentsSchema: () => BlobResourceContentsSchema2,
+  BooleanSchemaSchema: () => BooleanSchemaSchema2,
+  CallToolRequestParamsSchema: () => CallToolRequestParamsSchema2,
+  CallToolRequestSchema: () => CallToolRequestSchema2,
+  CallToolResultSchema: () => CallToolResultSchema2,
+  CancelTaskRequestSchema: () => CancelTaskRequestSchema2,
+  CancelTaskResultSchema: () => CancelTaskResultSchema2,
+  CancelledNotificationParamsSchema: () => CancelledNotificationParamsSchema2,
+  CancelledNotificationSchema: () => CancelledNotificationSchema2,
+  ClientCapabilitiesSchema: () => ClientCapabilitiesSchema2,
+  ClientNotificationSchema: () => ClientNotificationSchema2,
+  ClientRequestSchema: () => ClientRequestSchema2,
+  ClientResultSchema: () => ClientResultSchema2,
+  ClientTasksCapabilitySchema: () => ClientTasksCapabilitySchema2,
+  CompatibilityCallToolResultSchema: () => CompatibilityCallToolResultSchema2,
+  CompleteRequestParamsSchema: () => CompleteRequestParamsSchema2,
+  CompleteRequestSchema: () => CompleteRequestSchema2,
+  CompleteResultSchema: () => CompleteResultSchema2,
+  ContentBlockSchema: () => ContentBlockSchema2,
+  CreateMessageRequestParamsSchema: () => CreateMessageRequestParamsSchema2,
+  CreateMessageRequestSchema: () => CreateMessageRequestSchema2,
+  CreateMessageResultSchema: () => CreateMessageResultSchema2,
+  CreateMessageResultWithToolsSchema: () => CreateMessageResultWithToolsSchema2,
+  CreateTaskResultSchema: () => CreateTaskResultSchema2,
+  CursorSchema: () => CursorSchema2,
+  DiscoverRequestSchema: () => DiscoverRequestSchema,
+  DiscoverResultSchema: () => DiscoverResultSchema,
+  ElicitRequestFormParamsSchema: () => ElicitRequestFormParamsSchema2,
+  ElicitRequestParamsSchema: () => ElicitRequestParamsSchema2,
+  ElicitRequestSchema: () => ElicitRequestSchema2,
+  ElicitRequestURLParamsSchema: () => ElicitRequestURLParamsSchema2,
+  ElicitResultSchema: () => ElicitResultSchema2,
+  ElicitationCompleteNotificationParamsSchema: () => ElicitationCompleteNotificationParamsSchema2,
+  ElicitationCompleteNotificationSchema: () => ElicitationCompleteNotificationSchema2,
+  EmbeddedResourceSchema: () => EmbeddedResourceSchema2,
+  EmptyResultSchema: () => EmptyResultSchema2,
+  EnumSchemaSchema: () => EnumSchemaSchema2,
+  GetPromptRequestParamsSchema: () => GetPromptRequestParamsSchema2,
+  GetPromptRequestSchema: () => GetPromptRequestSchema2,
+  GetPromptResultSchema: () => GetPromptResultSchema2,
+  GetTaskPayloadRequestSchema: () => GetTaskPayloadRequestSchema2,
+  GetTaskPayloadResultSchema: () => GetTaskPayloadResultSchema2,
+  GetTaskRequestSchema: () => GetTaskRequestSchema2,
+  GetTaskResultSchema: () => GetTaskResultSchema2,
+  IconSchema: () => IconSchema2,
+  IconsSchema: () => IconsSchema2,
+  ImageContentSchema: () => ImageContentSchema2,
+  ImplementationSchema: () => ImplementationSchema2,
+  InitializeRequestParamsSchema: () => InitializeRequestParamsSchema2,
+  InitializeRequestSchema: () => InitializeRequestSchema2,
+  InitializeResultSchema: () => InitializeResultSchema2,
+  InitializedNotificationSchema: () => InitializedNotificationSchema2,
+  JSONArraySchema: () => JSONArraySchema,
+  JSONObjectSchema: () => JSONObjectSchema,
+  JSONRPCErrorResponseSchema: () => JSONRPCErrorResponseSchema2,
+  JSONRPCMessageSchema: () => JSONRPCMessageSchema2,
+  JSONRPCNotificationSchema: () => JSONRPCNotificationSchema2,
+  JSONRPCRequestSchema: () => JSONRPCRequestSchema2,
+  JSONRPCResponseSchema: () => JSONRPCResponseSchema2,
+  JSONRPCResultResponseSchema: () => JSONRPCResultResponseSchema2,
+  JSONValueSchema: () => JSONValueSchema,
+  LegacyTitledEnumSchemaSchema: () => LegacyTitledEnumSchemaSchema2,
+  ListChangedOptionsBaseSchema: () => ListChangedOptionsBaseSchema2,
+  ListPromptsRequestSchema: () => ListPromptsRequestSchema2,
+  ListPromptsResultSchema: () => ListPromptsResultSchema2,
+  ListResourceTemplatesRequestSchema: () => ListResourceTemplatesRequestSchema2,
+  ListResourceTemplatesResultSchema: () => ListResourceTemplatesResultSchema2,
+  ListResourcesRequestSchema: () => ListResourcesRequestSchema2,
+  ListResourcesResultSchema: () => ListResourcesResultSchema2,
+  ListRootsRequestSchema: () => ListRootsRequestSchema2,
+  ListRootsResultSchema: () => ListRootsResultSchema2,
+  ListTasksRequestSchema: () => ListTasksRequestSchema2,
+  ListTasksResultSchema: () => ListTasksResultSchema2,
+  ListToolsRequestSchema: () => ListToolsRequestSchema2,
+  ListToolsResultSchema: () => ListToolsResultSchema2,
+  LoggingLevelSchema: () => LoggingLevelSchema2,
+  LoggingMessageNotificationParamsSchema: () => LoggingMessageNotificationParamsSchema2,
+  LoggingMessageNotificationSchema: () => LoggingMessageNotificationSchema2,
+  ModelHintSchema: () => ModelHintSchema2,
+  ModelPreferencesSchema: () => ModelPreferencesSchema2,
+  MultiSelectEnumSchemaSchema: () => MultiSelectEnumSchemaSchema2,
+  NotificationSchema: () => NotificationSchema2,
+  NotificationsParamsSchema: () => NotificationsParamsSchema2,
+  NumberSchemaSchema: () => NumberSchemaSchema2,
+  PaginatedRequestParamsSchema: () => PaginatedRequestParamsSchema2,
+  PaginatedRequestSchema: () => PaginatedRequestSchema2,
+  PaginatedResultSchema: () => PaginatedResultSchema2,
+  PingRequestSchema: () => PingRequestSchema2,
+  PrimitiveSchemaDefinitionSchema: () => PrimitiveSchemaDefinitionSchema2,
+  ProgressNotificationParamsSchema: () => ProgressNotificationParamsSchema2,
+  ProgressNotificationSchema: () => ProgressNotificationSchema2,
+  ProgressSchema: () => ProgressSchema2,
+  ProgressTokenSchema: () => ProgressTokenSchema2,
+  PromptArgumentSchema: () => PromptArgumentSchema2,
+  PromptListChangedNotificationSchema: () => PromptListChangedNotificationSchema2,
+  PromptMessageSchema: () => PromptMessageSchema2,
+  PromptReferenceSchema: () => PromptReferenceSchema2,
+  PromptSchema: () => PromptSchema2,
+  ReadResourceRequestParamsSchema: () => ReadResourceRequestParamsSchema2,
+  ReadResourceRequestSchema: () => ReadResourceRequestSchema2,
+  ReadResourceResultSchema: () => ReadResourceResultSchema2,
+  RelatedTaskMetadataSchema: () => RelatedTaskMetadataSchema2,
+  RequestIdSchema: () => RequestIdSchema2,
+  RequestMetaSchema: () => RequestMetaSchema2,
+  RequestSchema: () => RequestSchema2,
+  ResourceContentsSchema: () => ResourceContentsSchema2,
+  ResourceLinkSchema: () => ResourceLinkSchema2,
+  ResourceListChangedNotificationSchema: () => ResourceListChangedNotificationSchema2,
+  ResourceRequestParamsSchema: () => ResourceRequestParamsSchema2,
+  ResourceSchema: () => ResourceSchema2,
+  ResourceTemplateReferenceSchema: () => ResourceTemplateReferenceSchema2,
+  ResourceTemplateSchema: () => ResourceTemplateSchema2,
+  ResourceUpdatedNotificationParamsSchema: () => ResourceUpdatedNotificationParamsSchema2,
+  ResourceUpdatedNotificationSchema: () => ResourceUpdatedNotificationSchema2,
+  ResultMetaObjectSchema: () => ResultMetaObjectSchema,
+  ResultSchema: () => ResultSchema2,
+  RoleSchema: () => RoleSchema2,
+  RootSchema: () => RootSchema2,
+  RootsListChangedNotificationSchema: () => RootsListChangedNotificationSchema2,
+  SamplingContentSchema: () => SamplingContentSchema2,
+  SamplingMessageContentBlockSchema: () => SamplingMessageContentBlockSchema2,
+  SamplingMessageSchema: () => SamplingMessageSchema2,
+  ServerCapabilitiesSchema: () => ServerCapabilitiesSchema2,
+  ServerNotificationSchema: () => ServerNotificationSchema2,
+  ServerRequestSchema: () => ServerRequestSchema2,
+  ServerResultSchema: () => ServerResultSchema2,
+  ServerTasksCapabilitySchema: () => ServerTasksCapabilitySchema2,
+  SetLevelRequestParamsSchema: () => SetLevelRequestParamsSchema2,
+  SetLevelRequestSchema: () => SetLevelRequestSchema2,
+  SingleSelectEnumSchemaSchema: () => SingleSelectEnumSchemaSchema2,
+  StringSchemaSchema: () => StringSchemaSchema2,
+  SubscribeRequestParamsSchema: () => SubscribeRequestParamsSchema2,
+  SubscribeRequestSchema: () => SubscribeRequestSchema2,
+  SubscriptionFilterSchema: () => SubscriptionFilterSchema,
+  SubscriptionsAcknowledgedNotificationParamsSchema: () => SubscriptionsAcknowledgedNotificationParamsSchema,
+  SubscriptionsAcknowledgedNotificationSchema: () => SubscriptionsAcknowledgedNotificationSchema,
+  SubscriptionsListenRequestParamsSchema: () => SubscriptionsListenRequestParamsSchema,
+  SubscriptionsListenRequestSchema: () => SubscriptionsListenRequestSchema,
+  SubscriptionsListenResultMetaSchema: () => SubscriptionsListenResultMetaSchema,
+  SubscriptionsListenResultSchema: () => SubscriptionsListenResultSchema,
+  TaskAugmentedRequestParamsSchema: () => TaskAugmentedRequestParamsSchema2,
+  TaskCreationParamsSchema: () => TaskCreationParamsSchema2,
+  TaskMetadataSchema: () => TaskMetadataSchema2,
+  TaskSchema: () => TaskSchema2,
+  TaskStatusNotificationParamsSchema: () => TaskStatusNotificationParamsSchema2,
+  TaskStatusNotificationSchema: () => TaskStatusNotificationSchema2,
+  TaskStatusSchema: () => TaskStatusSchema2,
+  TextContentSchema: () => TextContentSchema2,
+  TextResourceContentsSchema: () => TextResourceContentsSchema2,
+  TitledMultiSelectEnumSchemaSchema: () => TitledMultiSelectEnumSchemaSchema2,
+  TitledSingleSelectEnumSchemaSchema: () => TitledSingleSelectEnumSchemaSchema2,
+  ToolAnnotationsSchema: () => ToolAnnotationsSchema2,
+  ToolChoiceSchema: () => ToolChoiceSchema2,
+  ToolExecutionSchema: () => ToolExecutionSchema2,
+  ToolListChangedNotificationSchema: () => ToolListChangedNotificationSchema2,
+  ToolResultContentSchema: () => ToolResultContentSchema2,
+  ToolSchema: () => ToolSchema2,
+  ToolUseContentSchema: () => ToolUseContentSchema2,
+  UnsubscribeRequestParamsSchema: () => UnsubscribeRequestParamsSchema2,
+  UnsubscribeRequestSchema: () => UnsubscribeRequestSchema2,
+  UntitledMultiSelectEnumSchemaSchema: () => UntitledMultiSelectEnumSchemaSchema2,
+  UntitledSingleSelectEnumSchemaSchema: () => UntitledSingleSelectEnumSchemaSchema2
+});
+var isJSONRPCRequest2 = (value) => JSONRPCRequestSchema2.safeParse(value).success;
+var isJSONRPCNotification2 = (value) => JSONRPCNotificationSchema2.safeParse(value).success;
+var isJSONRPCResultResponse2 = (value) => JSONRPCResultResponseSchema2.safeParse(value).success;
+var isJSONRPCErrorResponse2 = (value) => JSONRPCErrorResponseSchema2.safeParse(value).success;
+var isInputRequiredResult = (value) => typeof value === "object" && value !== null && !Array.isArray(value) && value.resultType === "input_required";
+var isInitializeRequest = (value) => InitializeRequestSchema2.safeParse(value).success;
+var isInitializedNotification = (value) => InitializedNotificationSchema2.safeParse(value).success;
+var MCP_PARAM_HEADER_PREFIX = "Mcp-Param-";
+var X_MCP_HEADER_KEY = "x-mcp-header";
+var RFC9110_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+var PERMITTED_X_MCP_HEADER_TYPES = /* @__PURE__ */ new Set([
+  "string",
+  "integer",
+  "boolean",
+  "number"
+]);
+function scanXMcpHeaderDeclarations(inputSchema) {
+  const declarations = [];
+  const seenLower = /* @__PURE__ */ new Map();
+  const visit = (node2, path12, reachable) => {
+    if (node2 === null || typeof node2 !== "object") return void 0;
+    const schema = node2;
+    if (X_MCP_HEADER_KEY in schema) {
+      if (!reachable || path12.length === 0) return `${pathName(path12)}: x-mcp-header is only permitted on properties statically reachable via a chain of 'properties' keys (not under items, additionalProperties, oneOf/anyOf/allOf/not, if/then/else, or $ref)`;
+      const raw = schema[X_MCP_HEADER_KEY];
+      if (typeof raw !== "string" || raw.length === 0) return `${pathName(path12)}: x-mcp-header MUST be a non-empty string`;
+      if (!RFC9110_TOKEN.test(raw)) return `${pathName(path12)}: x-mcp-header '${raw}' is not a valid RFC 9110 token (no spaces, control characters or HTTP delimiters)`;
+      const type = typeof schema.type === "string" ? schema.type : void 0;
+      if (type === void 0 || !PERMITTED_X_MCP_HEADER_TYPES.has(type)) return `${pathName(path12)}: x-mcp-header is only permitted on primitive-typed properties (string, integer, boolean); got ${type ?? "<none>"}`;
+      const lower = raw.toLowerCase();
+      const prior = seenLower.get(lower);
+      if (prior !== void 0) return `x-mcp-header '${raw}' is not case-insensitively unique (also declared as '${prior}')`;
+      seenLower.set(lower, raw);
+      declarations.push({
+        path: path12,
+        headerName: raw,
+        type
+      });
+    }
+    const properties = schema.properties;
+    if (properties !== null && typeof properties === "object") for (const [key, child] of Object.entries(properties)) {
+      const fault$1 = visit(child, [...path12, key], reachable);
+      if (fault$1 !== void 0) return fault$1;
+    }
+    for (const k of NON_REACHABLE_SUBSCHEMA_KEYWORDS) {
+      const sub = schema[k];
+      if (sub === void 0) continue;
+      const branches = Array.isArray(sub) ? sub : sub !== null && typeof sub === "object" && OBJECT_VALUED_SUBSCHEMA_KEYWORDS.has(k) ? Object.values(sub) : [sub];
+      for (const branch of branches) {
+        const fault$1 = visit(branch, [...path12, `<${k}>`], false);
+        if (fault$1 !== void 0) return fault$1;
+      }
+    }
+  };
+  const fault = visit(inputSchema, [], true);
+  return fault === void 0 ? {
+    valid: true,
+    declarations
+  } : {
+    valid: false,
+    reason: fault
+  };
+}
+var NON_REACHABLE_SUBSCHEMA_KEYWORDS = [
+  "items",
+  "prefixItems",
+  "contains",
+  "additionalProperties",
+  "unevaluatedProperties",
+  "unevaluatedItems",
+  "propertyNames",
+  "patternProperties",
+  "dependentSchemas",
+  "oneOf",
+  "anyOf",
+  "allOf",
+  "not",
+  "if",
+  "then",
+  "else",
+  "$defs",
+  "definitions"
+];
+var OBJECT_VALUED_SUBSCHEMA_KEYWORDS = /* @__PURE__ */ new Set([
+  "patternProperties",
+  "dependentSchemas",
+  "$defs",
+  "definitions"
+]);
+function pathName(path12) {
+  return path12.length === 0 ? "<root>" : path12.join(".");
+}
+var BASE64_SENTINEL_PREFIX = "=?base64?";
+var BASE64_SENTINEL_SUFFIX = "?=";
+function mcpParamPrimitiveToString(value) {
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return void 0;
+    if (Number.isInteger(value) && !Number.isSafeInteger(value)) return void 0;
+    return String(value);
+  }
+}
+function needsBase64(s) {
+  if (s.length === 0) return true;
+  if (s.startsWith(BASE64_SENTINEL_PREFIX) && s.endsWith(BASE64_SENTINEL_SUFFIX)) return true;
+  if (s !== s.trim()) return true;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.codePointAt(i);
+    if (c === 9 || c >= 32 && c <= 126) continue;
+    return true;
+  }
+  return false;
+}
+function utf8ToBase64(s) {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCodePoint(b);
+  return btoa(bin);
+}
+function encodeMcpParamValue(value) {
+  return needsBase64(value) ? `${BASE64_SENTINEL_PREFIX}${utf8ToBase64(value)}${BASE64_SENTINEL_SUFFIX}` : value;
+}
+function valueAtPath(root, path12) {
+  let node2 = root;
+  for (const key of path12) {
+    if (node2 === null || typeof node2 !== "object") return void 0;
+    node2 = node2[key];
+  }
+  return node2;
+}
+function buildMcpParamHeaders(declarations, args) {
+  const out = {};
+  for (const decl of declarations) {
+    const raw = valueAtPath(args, decl.path);
+    if (raw === void 0 || raw === null) continue;
+    const stringValue = mcpParamPrimitiveToString(raw);
+    if (stringValue === void 0) continue;
+    out[`${MCP_PARAM_HEADER_PREFIX}${decl.headerName}`] = encodeMcpParamValue(stringValue);
+  }
+  return out;
+}
+var HEADER_MISMATCH_ERROR_CODE = -32020;
+var INBOUND_VALIDATION_LADDER = [
+  {
+    rung: "http-method",
+    order: 1,
+    evaluatedAt: "edge",
+    codes: [-32e3],
+    conformance: [],
+    rationale: "The modern era is POST-only; GET/DELETE are body-less 2025-era session operations and are method-routed to legacy serving (405 when legacy serving is not configured), before any body is read."
+  },
+  {
+    rung: "jsonrpc-shape",
+    order: 2,
+    evaluatedAt: "edge",
+    codes: [ProtocolErrorCode.InvalidRequest],
+    conformance: ["server-stateless"],
+    rationale: "The body must be a JSON-RPC request or notification: posted responses and batch arrays containing a modern or invalid element are rejected before classification (element-wise batch rule); all-legacy arrays stay legacy traffic."
+  },
+  {
+    rung: "era-classification",
+    order: 3,
+    evaluatedAt: "edge",
+    codes: [HEADER_MISMATCH_ERROR_CODE, ProtocolErrorCode.UnsupportedProtocolVersion],
+    conformance: [
+      "server-stateless",
+      "http-header-validation",
+      "http-custom-header-server-validation"
+    ],
+    rationale: "Body-primary era classification with the protocol-version header as a cross-check; a header/body disagreement is rejected with -32020 (HeaderMismatch), and an envelope-less request on a modern-only endpoint is answered with the unsupported-protocol-version error naming the supported revisions."
+  },
+  {
+    rung: "envelope",
+    order: 4,
+    evaluatedAt: "edge",
+    codes: [ProtocolErrorCode.InvalidParams],
+    conformance: ["server-stateless"],
+    rationale: "A present envelope claim with a malformed envelope \u2014 and a missing envelope on a request whose protocol-version header names a modern revision \u2014 is an invalid-params rejection naming the offending or missing key(s); never a silent fall back to legacy handling. This is the only place an invalid-params rejection maps to HTTP 400."
+  },
+  {
+    rung: "method-registry",
+    order: 5,
+    evaluatedAt: "dispatch",
+    codes: [ProtocolErrorCode.MethodNotFound],
+    conformance: ["server-stateless"],
+    rationale: "Method existence outranks parameter validity: a method absent from the negotiated revision\u2019s registry (or with no handler installed) answers method-not-found before params or capabilities are looked at."
+  },
+  {
+    rung: "request-params",
+    order: 6,
+    evaluatedAt: "dispatch",
+    codes: [ProtocolErrorCode.InvalidParams],
+    conformance: [],
+    rationale: "Per-method params validation; emitted in-band by the dispatch layer (HTTP 200), never via the ladder status table."
+  },
+  {
+    rung: "standard-header-validation",
+    order: 7,
+    evaluatedAt: "pre-dispatch",
+    codes: [HEADER_MISMATCH_ERROR_CODE],
+    conformance: ["http-header-validation"],
+    rationale: "SEP-2243 standard `Mcp-Method` / `Mcp-Name` headers \u2014 presence, sentinel decoding, and `Mcp-Name` \u2194 body cross-check \u2014 are validated by the HTTP entry on a modern-classified request after the supported-revision gate and before dispatch. The classifier\u2019s own header-mismatch cells (protocol-version, `Mcp-Method` mismatch) stay on the edge `era-classification` rung; this rung carries the entry-layer presence/`Mcp-Name` half. Evaluated before the capability gate, the factory call, and the `Mcp-Param-*` rung so a request that fails several rungs is answered by the standard-header rung first. The documented order (after method-registry 5 and request-params 6) is NOT the observed precedence: serveModern evaluates this rung immediately after the supported-revision gate, so a request that also fails a dispatch rung is answered here before the dispatch rungs (5\u20136) are consulted."
+  },
+  {
+    rung: "client-capabilities",
+    order: 8,
+    evaluatedAt: "pre-dispatch",
+    codes: [ProtocolErrorCode.MissingRequiredClientCapability],
+    conformance: ["server-stateless"],
+    rationale: "The capability requirement is checked by the HTTP entry, pre-dispatch, against the validated envelope the classifier produced \u2014 pinning the spec-mandated HTTP 400 independently of how dispatch- and handler-produced errors are mapped. The documented order (after method resolution and params validation) is preserved observably only while the requirement table is empty: once a served method gains a requirement entry, a request that is missing the capability and would also fail a dispatch rung is answered by this gate first, so the entry must consult the method registry before the gate if the documented precedence is to stay observable."
+  },
+  {
+    rung: "param-header-validation",
+    order: 9,
+    evaluatedAt: "pre-dispatch",
+    codes: [HEADER_MISMATCH_ERROR_CODE],
+    conformance: ["http-custom-header-server-validation"],
+    rationale: "SEP-2243 `Mcp-Param-*` headers are validated against the named tool\u2019s `x-mcp-header` declarations and the body `arguments` after the tool registry is known and before dispatch reaches the handler; a missing/disagreeing/malformed header is rejected 400 / -32020 with the same shape as the standard-header cross-checks. The documented order (after method resolution and params validation) is preserved observably only when the body `arguments` would otherwise validate: the check runs pre-dispatch, so a `tools/call` that fails BOTH this rung and a dispatch-time rung (e.g. order-6 `request-params`, -32602) is answered by this gate first with 400 / -32020, not by the earlier-ordered rung."
+  }
+];
+var LADDER_ERROR_HTTP_STATUS = {
+  [ProtocolErrorCode.ParseError]: 400,
+  [ProtocolErrorCode.InvalidRequest]: 400,
+  [ProtocolErrorCode.MethodNotFound]: 404,
+  [ProtocolErrorCode.UnsupportedProtocolVersion]: 400,
+  [ProtocolErrorCode.MissingRequiredClientCapability]: 400,
+  [HEADER_MISMATCH_ERROR_CODE]: 400
+};
+function parseSchema(schema, data) {
+  return safeParse3(schema, data);
+}
+function shapeKeys(schemas) {
+  return new Set(schemas.flatMap((schema) => Object.keys(schema.shape)));
+}
+function isStandardSchema(schema) {
+  if (schema == null) return false;
+  const schemaType = typeof schema;
+  if (schemaType !== "object" && schemaType !== "function") return false;
+  if (!("~standard" in schema)) return false;
+  return typeof schema["~standard"]?.validate === "function";
+}
+var warnedZodFallback = false;
+var JSON_SCHEMA_CONVERSION_TARGET = "draft-2020-12";
+function standardSchemaToJsonSchema(schema, io = "input") {
+  const std = schema["~standard"];
+  let result;
+  if (std.jsonSchema) result = std.jsonSchema[io]({ target: JSON_SCHEMA_CONVERSION_TARGET });
+  else if (std.vendor === "zod") {
+    if (!("_zod" in schema)) throw new Error("Schema appears to be from zod 3, which the SDK cannot convert to JSON Schema. Upgrade to zod >=4.2.0, or wrap your JSON Schema with fromJsonSchema().");
+    if (!warnedZodFallback) {
+      warnedZodFallback = true;
+      console.warn("[mcp-sdk] Your zod version does not implement `~standard.jsonSchema` (added in zod 4.2.0). Falling back to z.toJSONSchema(). Upgrade to zod >=4.2.0 to silence this warning.");
+    }
+    result = toJSONSchema(schema, {
+      target: JSON_SCHEMA_CONVERSION_TARGET,
+      io
+    });
+  } else throw new Error(`Schema library "${std.vendor}" does not implement StandardJSONSchemaV1 (\`~standard.jsonSchema\`). Upgrade to a version that does, or wrap your JSON Schema with fromJsonSchema().`);
+  if (io === "output") {
+    if (result.type !== void 0) return result;
+    return isProvablyObjectShapedRoot(result) ? {
+      type: "object",
+      ...result
+    } : result;
+  }
+  if (result.type !== void 0 && result.type !== "object") throw new Error(`MCP tool and prompt schemas must describe objects (got type: ${JSON.stringify(result.type)}). Wrap your schema in z.object({...}) or equivalent.`);
+  return {
+    type: "object",
+    ...result
+  };
+}
+function isProvablyObjectShapedRoot(schema) {
+  if ("properties" in schema || "patternProperties" in schema || "additionalProperties" in schema || "required" in schema) return true;
+  for (const key of [
+    "oneOf",
+    "anyOf",
+    "allOf"
+  ]) {
+    const members2 = schema[key];
+    if (Array.isArray(members2) && members2.length > 0) return members2.every((m) => m !== null && typeof m === "object" && (m.type === "object" || isProvablyObjectShapedRoot(m)));
+  }
+  return false;
+}
+function formatIssue(issue2) {
+  if (!issue2.path?.length) return issue2.message;
+  return `${issue2.path.map((p) => String(typeof p === "object" ? p.key : p)).join(".")}: ${issue2.message}`;
+}
+async function validateStandardSchema(schema, data) {
+  const result = await schema["~standard"].validate(data);
+  if (result.issues && result.issues.length > 0) return {
+    success: false,
+    error: result.issues.map((i) => formatIssue(i)).join(", ")
+  };
+  return {
+    success: true,
+    data: result.value
+  };
+}
+function zodEmittedPattern(schema) {
+  const jsonSchema = toJSONSchema(schema, {
+    target: JSON_SCHEMA_CONVERSION_TARGET,
+    io: "input"
+  });
+  return typeof jsonSchema.pattern === "string" ? jsonSchema.pattern : void 0;
+}
+var DATETIME_FRACTION_DIGITS = /\\\.\\d\{(\d+)\}/;
+function datetimeReferenceSchemas(pattern) {
+  const fractionDigits = DATETIME_FRACTION_DIGITS.exec(pattern);
+  const precisions = [
+    void 0,
+    -1,
+    0
+  ];
+  if (fractionDigits) precisions.push(Number(fractionDigits[1]));
+  return [false, true].flatMap((local) => [false, true].flatMap((offset) => precisions.map((precision) => iso_exports.datetime({
+    local,
+    offset,
+    precision
+  }))));
+}
+function referencePatternsForFormat(format, pattern) {
+  let referenceSchemas;
+  switch (format) {
+    case "email":
+      referenceSchemas = [email2()];
+      break;
+    case "uri":
+      referenceSchemas = [url()];
+      break;
+    case "date":
+      referenceSchemas = [iso_exports.date()];
+      break;
+    case "date-time":
+      referenceSchemas = datetimeReferenceSchemas(pattern);
+      break;
+  }
+  return new Set(referenceSchemas.map((schema) => zodEmittedPattern(schema)).filter((emitted) => emitted !== void 0));
+}
+function isLibraryFormatPattern(format, pattern, vendor) {
+  if (vendor !== "zod") return true;
+  return referencePatternsForFormat(format, pattern).has(pattern);
+}
+function isJsonObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function convertStandardElicitationSchema(schema) {
+  try {
+    return standardSchemaToJsonSchema(schema, "input");
+  } catch (error2) {
+    const detail = error2 instanceof Error ? error2.message : String(error2);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Elicitation requestedSchema must describe an object with flat primitive properties: ${detail}`);
+  }
+}
+var ANNOTATION_ONLY_JSON_SCHEMA_KEYWORDS = /* @__PURE__ */ new Set([
+  "$comment",
+  "deprecated",
+  "description",
+  "examples",
+  "readOnly",
+  "title",
+  "writeOnly"
+]);
+function isAnnotationOnlyJsonSchemaKeyword(key) {
+  return ANNOTATION_ONLY_JSON_SCHEMA_KEYWORDS.has(key) || key.startsWith("x-");
+}
+var ROOT_KEYS = /* @__PURE__ */ new Set(["$schema", ...Object.keys(ElicitRequestFormParamsSchema2.shape.requestedSchema.shape)]);
+var PROPERTY_KEYS_BY_TYPE = {
+  string: shapeKeys([
+    StringSchemaSchema2,
+    UntitledSingleSelectEnumSchemaSchema2,
+    TitledSingleSelectEnumSchemaSchema2,
+    LegacyTitledEnumSchemaSchema2
+  ]),
+  number: shapeKeys([NumberSchemaSchema2]),
+  integer: shapeKeys([NumberSchemaSchema2]),
+  boolean: shapeKeys([BooleanSchemaSchema2]),
+  array: shapeKeys([UntitledMultiSelectEnumSchemaSchema2, TitledMultiSelectEnumSchemaSchema2])
+};
+var SUPPORTED_STRING_FORMATS = new Set(StringSchemaSchema2.shape.format.unwrap().options);
+function walkProperty(node2, path12, vendor, unsupported) {
+  if (!isJsonObject(node2)) return node2;
+  const allowedKeys = typeof node2.type === "string" && Object.hasOwn(PROPERTY_KEYS_BY_TYPE, node2.type) ? PROPERTY_KEYS_BY_TYPE[node2.type] : void 0;
+  if (allowedKeys === void 0) return node2;
+  const pruned = {};
+  for (const [key, value] of Object.entries(node2)) if (allowedKeys.has(key) || isAnnotationOnlyJsonSchemaKeyword(key)) pruned[key] = value;
+  else if (key === "pattern" && node2.type === "string" && typeof node2.format === "string") {
+    if (!SUPPORTED_STRING_FORMATS.has(node2.format)) pruned[key] = value;
+    else if (typeof value !== "string" || !isLibraryFormatPattern(node2.format, value, vendor)) unsupported.push(`${path12}.${key}`);
+  } else unsupported.push(`${path12}.${key}`);
+  return pruned;
+}
+function walkRequestedSchema(converted, vendor) {
+  const pruned = {};
+  const unsupported = [];
+  for (const [key, value] of Object.entries(converted)) if (key === "properties" && isJsonObject(value)) pruned[key] = Object.fromEntries(Object.entries(value).map(([name, node2]) => [name, walkProperty(node2, `properties.${name}`, vendor, unsupported)]));
+  else if (ROOT_KEYS.has(key)) pruned[key] = value;
+  else if (!isAnnotationOnlyJsonSchemaKeyword(key)) unsupported.push(key);
+  if (unsupported.length > 0) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Elicitation requestedSchema contains unsupported JSON Schema constraint(s) after Standard Schema conversion: ${unsupported.join(", ")}`);
+  return pruned;
+}
+function describeUnsupportedProperties(pruned, fallback) {
+  if (!isJsonObject(pruned.properties)) return fallback;
+  const offenders = Object.entries(pruned.properties).filter(([, node2]) => !parseSchema(PrimitiveSchemaDefinitionSchema2, node2).success).map(([name]) => `properties.${name}`);
+  return offenders.length > 0 ? offenders.join(", ") : fallback;
+}
+function findDroppedConstraintPaths(original, parsed, path12 = "") {
+  if (Array.isArray(original) && Array.isArray(parsed)) return original.flatMap((item, index) => findDroppedConstraintPaths(item, parsed[index], `${path12}[${index}]`));
+  if (!isJsonObject(original) || !isJsonObject(parsed)) return [];
+  return Object.entries(original).flatMap(([key, value]) => {
+    const childPath = path12 ? `${path12}.${key}` : key;
+    if (!Object.prototype.hasOwnProperty.call(parsed, key)) return isAnnotationOnlyJsonSchemaKeyword(key) ? [] : [childPath];
+    return findDroppedConstraintPaths(value, parsed[key], childPath);
+  });
+}
+function normalizeElicitInputParams(input) {
+  if (!isStandardSchema(input.requestedSchema)) return {
+    ...input,
+    mode: "form",
+    requestedSchema: input.requestedSchema
+  };
+  const vendor = input.requestedSchema["~standard"].vendor;
+  const pruned = walkRequestedSchema(convertStandardElicitationSchema(input.requestedSchema), vendor);
+  const parsed = parseSchema(ElicitRequestFormParamsSchema2.shape.requestedSchema, pruned);
+  if (!parsed.success) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums): ${describeUnsupportedProperties(pruned, parsed.error.message)}`);
+  const droppedConstraints = findDroppedConstraintPaths(pruned, parsed.data);
+  if (droppedConstraints.length > 0) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Elicitation requestedSchema contains unsupported JSON Schema constraint(s) after Standard Schema conversion: ${droppedConstraints.join(", ")}`);
+  const danglingRequired = (parsed.data.required ?? []).filter((key) => !Object.prototype.hasOwnProperty.call(parsed.data.properties, key));
+  if (danglingRequired.length > 0) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Elicitation requestedSchema lists required properties that are not defined in properties: ${danglingRequired.join(", ")}`);
+  return {
+    ...input,
+    mode: "form",
+    requestedSchema: parsed.data
+  };
+}
+function buildInputRequired(spec) {
+  const hasInputRequests = spec.inputRequests !== void 0 && Object.keys(spec.inputRequests).length > 0;
+  const hasRequestState = typeof spec.requestState === "string";
+  if (!hasInputRequests && !hasRequestState) throw new TypeError("inputRequired() requires at least one of inputRequests (with at least one entry) or requestState (spec: every InputRequiredResult MUST include at least one of the two)");
+  return {
+    resultType: "input_required",
+    ...spec.inputRequests !== void 0 && { inputRequests: spec.inputRequests },
+    ...spec.requestState !== void 0 && { requestState: spec.requestState }
+  };
+}
+var inputRequired = Object.assign(buildInputRequired, {
+  elicit(params) {
+    try {
+      return {
+        method: "elicitation/create",
+        params: normalizeElicitInputParams(params)
+      };
+    } catch (error2) {
+      throw error2 instanceof ProtocolError ? new TypeError(error2.message, { cause: error2 }) : error2;
+    }
+  },
+  elicitUrl(params) {
+    return {
+      method: "elicitation/create",
+      params: {
+        ...params,
+        mode: "url"
+      }
+    };
+  },
+  createMessage(params) {
+    return {
+      method: "sampling/createMessage",
+      params
+    };
+  },
+  listRoots() {
+    return { method: "roots/list" };
+  }
+});
+var DEFAULT_INPUT_REQUIRED_AUTO_FULFILL = true;
+var DEFAULT_INPUT_REQUIRED_MAX_ROUNDS = 10;
+var REQUEST_STATE_ONLY_LEG_PACING_MS = 250;
+function resolveInputRequiredDriverConfig(options) {
+  return {
+    autoFulfill: options?.autoFulfill ?? DEFAULT_INPUT_REQUIRED_AUTO_FULFILL,
+    maxRounds: options?.maxRounds ?? DEFAULT_INPUT_REQUIRED_MAX_ROUNDS
+  };
+}
+function buildInputRequiredRetryParams(originalParams, responses, requestState) {
+  const hasResponses = responses !== void 0 && Object.keys(responses).length > 0;
+  if (!hasResponses && requestState === void 0) return originalParams;
+  return {
+    ...originalParams,
+    ...hasResponses && { inputResponses: responses },
+    ...requestState !== void 0 && { requestState }
+  };
+}
+function inputRequiredRoundsExceededMessage(method, maxRounds) {
+  return `Multi-round-trip request '${method}' still required input after ${maxRounds} rounds (inputRequired.maxRounds)`;
+}
+function sleep(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason instanceof SdkError ? signal.reason : new SdkError(SdkErrorCode.RequestTimeout, String(signal.reason)));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason instanceof SdkError ? signal.reason : new SdkError(SdkErrorCode.RequestTimeout, String(signal?.reason)));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+function linkedRoundAbort(outer) {
+  const controller = new AbortController();
+  const onOuterAbort = () => controller.abort(outer?.reason);
+  outer?.addEventListener("abort", onOuterAbort, { once: true });
+  if (outer?.aborted) controller.abort(outer.reason);
+  return {
+    signal: controller.signal,
+    abort: (reason) => controller.abort(reason),
+    dispose: () => outer?.removeEventListener("abort", onOuterAbort)
+  };
+}
+async function runInputRequiredDriver(args) {
+  const { config: config2, method, originalParams, requestOptions, hooks, signal } = args;
+  const startedAt = args.flowStartedAt ?? Date.now();
+  let payload = args.firstPayload;
+  let round = 0;
+  while (true) {
+    round += 1;
+    if (round > config2.maxRounds) throw new SdkError(SdkErrorCode.InputRequiredRoundsExceeded, inputRequiredRoundsExceededMessage(method, config2.maxRounds), {
+      rounds: config2.maxRounds,
+      lastResult: {
+        inputRequests: payload.inputRequests,
+        ...payload.requestState !== void 0 && { requestState: payload.requestState }
+      }
+    });
+    requestOptions.onprogress?.({
+      progress: round,
+      message: `Fulfilling input required by '${method}' (round ${round})`
+    });
+    const entries = Object.entries(payload.inputRequests ?? {});
+    let responses;
+    if (entries.length > 0) {
+      const round$1 = linkedRoundAbort(signal);
+      try {
+        const fulfilled = await Promise.all(entries.map(async ([key, entry]) => {
+          try {
+            return [key, await hooks.dispatchInputRequest(key, entry, round$1.signal)];
+          } catch (error2) {
+            round$1.abort(error2);
+            throw error2;
+          }
+        }));
+        responses = Object.fromEntries(fulfilled);
+      } finally {
+        round$1.dispose();
+      }
+    } else await sleep(REQUEST_STATE_ONLY_LEG_PACING_MS, signal);
+    const legOptions = { ...requestOptions.timeout !== void 0 && { timeout: requestOptions.timeout } };
+    if (requestOptions.maxTotalTimeout !== void 0) {
+      const totalElapsed = Date.now() - startedAt;
+      const remaining = requestOptions.maxTotalTimeout - totalElapsed;
+      if (remaining <= 0) throw new SdkError(SdkErrorCode.RequestTimeout, "Maximum total timeout exceeded", {
+        maxTotalTimeout: requestOptions.maxTotalTimeout,
+        totalElapsed
+      });
+      legOptions.maxTotalTimeout = remaining;
+    }
+    const result = await hooks.retry(buildInputRequiredRetryParams(originalParams, responses, payload.requestState), legOptions);
+    if (isInputRequiredResult(result)) {
+      payload = {
+        inputRequests: result.inputRequests ?? {},
+        ...result.requestState !== void 0 && { requestState: result.requestState }
+      };
+      continue;
+    }
+    return result;
+  }
+}
+var SPEC_SCHEMA_KEYS = [
+  "AnnotationsSchema",
+  "AudioContentSchema",
+  "BaseMetadataSchema",
+  "BlobResourceContentsSchema",
+  "BooleanSchemaSchema",
+  "CallToolRequestSchema",
+  "CallToolRequestParamsSchema",
+  "CallToolResultSchema",
+  "CancelledNotificationSchema",
+  "CancelledNotificationParamsSchema",
+  "CancelTaskRequestSchema",
+  "CancelTaskResultSchema",
+  "ClientCapabilitiesSchema",
+  "ClientNotificationSchema",
+  "ClientRequestSchema",
+  "ClientResultSchema",
+  "CompatibilityCallToolResultSchema",
+  "CompleteRequestSchema",
+  "CompleteRequestParamsSchema",
+  "CompleteResultSchema",
+  "ContentBlockSchema",
+  "CreateMessageRequestSchema",
+  "CreateMessageRequestParamsSchema",
+  "CreateMessageResultSchema",
+  "CreateMessageResultWithToolsSchema",
+  "CreateTaskResultSchema",
+  "CursorSchema",
+  "DiscoverRequestSchema",
+  "DiscoverResultSchema",
+  "ElicitationCompleteNotificationSchema",
+  "ElicitationCompleteNotificationParamsSchema",
+  "ElicitRequestSchema",
+  "ElicitRequestFormParamsSchema",
+  "ElicitRequestParamsSchema",
+  "ElicitRequestURLParamsSchema",
+  "ElicitResultSchema",
+  "EmbeddedResourceSchema",
+  "EmptyResultSchema",
+  "EnumSchemaSchema",
+  "GetPromptRequestSchema",
+  "GetPromptRequestParamsSchema",
+  "GetPromptResultSchema",
+  "GetTaskPayloadRequestSchema",
+  "GetTaskPayloadResultSchema",
+  "GetTaskRequestSchema",
+  "GetTaskResultSchema",
+  "IconSchema",
+  "IconsSchema",
+  "ImageContentSchema",
+  "ImplementationSchema",
+  "InitializedNotificationSchema",
+  "InitializeRequestSchema",
+  "InitializeRequestParamsSchema",
+  "InitializeResultSchema",
+  "JSONArraySchema",
+  "JSONObjectSchema",
+  "JSONRPCErrorResponseSchema",
+  "JSONRPCMessageSchema",
+  "JSONRPCNotificationSchema",
+  "JSONRPCRequestSchema",
+  "JSONRPCResponseSchema",
+  "JSONRPCResultResponseSchema",
+  "JSONValueSchema",
+  "LegacyTitledEnumSchemaSchema",
+  "ListPromptsRequestSchema",
+  "ListPromptsResultSchema",
+  "ListResourcesRequestSchema",
+  "ListResourcesResultSchema",
+  "ListResourceTemplatesRequestSchema",
+  "ListResourceTemplatesResultSchema",
+  "ListRootsRequestSchema",
+  "ListRootsResultSchema",
+  "ListTasksRequestSchema",
+  "ListTasksResultSchema",
+  "ListToolsRequestSchema",
+  "ListToolsResultSchema",
+  "LoggingLevelSchema",
+  "LoggingMessageNotificationSchema",
+  "LoggingMessageNotificationParamsSchema",
+  "ModelHintSchema",
+  "ModelPreferencesSchema",
+  "MultiSelectEnumSchemaSchema",
+  "NotificationSchema",
+  "NumberSchemaSchema",
+  "PaginatedRequestSchema",
+  "PaginatedRequestParamsSchema",
+  "PaginatedResultSchema",
+  "PingRequestSchema",
+  "PrimitiveSchemaDefinitionSchema",
+  "ProgressSchema",
+  "ProgressNotificationSchema",
+  "ProgressNotificationParamsSchema",
+  "ProgressTokenSchema",
+  "PromptSchema",
+  "PromptArgumentSchema",
+  "PromptListChangedNotificationSchema",
+  "PromptMessageSchema",
+  "PromptReferenceSchema",
+  "ReadResourceRequestSchema",
+  "ReadResourceRequestParamsSchema",
+  "ReadResourceResultSchema",
+  "RelatedTaskMetadataSchema",
+  "RequestSchema",
+  "RequestIdSchema",
+  "RequestMetaSchema",
+  "ResourceSchema",
+  "ResourceContentsSchema",
+  "ResourceLinkSchema",
+  "ResourceListChangedNotificationSchema",
+  "ResourceRequestParamsSchema",
+  "ResourceTemplateSchema",
+  "ResourceTemplateReferenceSchema",
+  "ResourceUpdatedNotificationSchema",
+  "ResourceUpdatedNotificationParamsSchema",
+  "ResultMetaObjectSchema",
+  "ResultSchema",
+  "RoleSchema",
+  "RootSchema",
+  "RootsListChangedNotificationSchema",
+  "SamplingContentSchema",
+  "SamplingMessageSchema",
+  "SamplingMessageContentBlockSchema",
+  "ServerCapabilitiesSchema",
+  "ServerNotificationSchema",
+  "ServerRequestSchema",
+  "ServerResultSchema",
+  "SetLevelRequestSchema",
+  "SetLevelRequestParamsSchema",
+  "SingleSelectEnumSchemaSchema",
+  "StringSchemaSchema",
+  "SubscribeRequestSchema",
+  "SubscribeRequestParamsSchema",
+  "SubscriptionFilterSchema",
+  "SubscriptionsAcknowledgedNotificationSchema",
+  "SubscriptionsAcknowledgedNotificationParamsSchema",
+  "SubscriptionsListenRequestSchema",
+  "SubscriptionsListenRequestParamsSchema",
+  "SubscriptionsListenResultSchema",
+  "SubscriptionsListenResultMetaSchema",
+  "TaskAugmentedRequestParamsSchema",
+  "TaskCreationParamsSchema",
+  "TaskMetadataSchema",
+  "TaskSchema",
+  "TaskStatusSchema",
+  "TaskStatusNotificationSchema",
+  "TaskStatusNotificationParamsSchema",
+  "TextContentSchema",
+  "TextResourceContentsSchema",
+  "TitledMultiSelectEnumSchemaSchema",
+  "TitledSingleSelectEnumSchemaSchema",
+  "ToolSchema",
+  "ToolAnnotationsSchema",
+  "ToolChoiceSchema",
+  "ToolExecutionSchema",
+  "ToolListChangedNotificationSchema",
+  "ToolResultContentSchema",
+  "ToolUseContentSchema",
+  "UnsubscribeRequestSchema",
+  "UnsubscribeRequestParamsSchema",
+  "UntitledMultiSelectEnumSchemaSchema",
+  "UntitledSingleSelectEnumSchemaSchema"
+];
+var authSchemas = {
+  IdJagTokenExchangeResponseSchema,
+  OAuthClientInformationFullSchema,
+  OAuthClientInformationSchema,
+  OAuthClientMetadataSchema,
+  OAuthClientRegistrationErrorSchema,
+  OAuthErrorResponseSchema,
+  OAuthMetadataSchema,
+  OAuthProtectedResourceMetadataSchema,
+  OAuthTokenRevocationRequestSchema,
+  OAuthTokensSchema,
+  OpenIdProviderDiscoveryMetadataSchema,
+  OpenIdProviderMetadataSchema
+};
+var _specTypeSchemas = {};
+var _isSpecType = {};
+function register(key, schema) {
+  const name = key.slice(0, -6);
+  _specTypeSchemas[name] = schema;
+  _isSpecType[name] = (v) => schema.safeParse(v).success;
+}
+for (const key of SPEC_SCHEMA_KEYS) register(key, schemas_exports2[key]);
+for (const [key, schema] of Object.entries(authSchemas)) register(key, schema);
+var specTypeSchemas = Object.freeze(_specTypeSchemas);
+var isSpecType = Object.freeze(_isSpecType);
+function bootstrapOutboundCodec(method) {
+  switch (method) {
+    case "initialize":
+    case "notifications/initialized":
+      return codecForVersion(void 0);
+    case "server/discover":
+      return codecForVersion(MODERN_WIRE_REVISION);
+    default:
+      return;
+  }
+}
+var DEFAULT_REQUEST_TIMEOUT_MSEC2 = 6e4;
+var RESERVED_ENVELOPE_META_KEYS = [
+  PROTOCOL_VERSION_META_KEY,
+  CLIENT_INFO_META_KEY,
+  CLIENT_CAPABILITIES_META_KEY,
+  LOG_LEVEL_META_KEY
+];
+var RETRY_PARAMS_KEYS = ["inputResponses", "requestState"];
+function liftWireOnlyMaterial(message, kind) {
+  const params = message.params;
+  if (!isPlainObject$1(params)) return {
+    message,
+    lifted: {}
+  };
+  const meta2 = params._meta;
+  const envelopeKeys = isPlainObject$1(meta2) ? RESERVED_ENVELOPE_META_KEYS.filter((key) => key in meta2) : [];
+  const retryKeys = kind === "request" ? RETRY_PARAMS_KEYS.filter((key) => key in params) : [];
+  if (envelopeKeys.length === 0 && retryKeys.length === 0) return {
+    message,
+    lifted: {}
+  };
+  const lifted = {};
+  const nextParams = { ...params };
+  if (envelopeKeys.length > 0 && isPlainObject$1(meta2)) {
+    const envelope = {};
+    const nextMeta = { ...meta2 };
+    for (const key of envelopeKeys) {
+      envelope[key] = meta2[key];
+      delete nextMeta[key];
+    }
+    lifted.envelope = envelope;
+    if (Object.keys(nextMeta).length > 0) nextParams._meta = nextMeta;
+    else delete nextParams._meta;
+  }
+  for (const key of retryKeys) {
+    if (key === "inputResponses") lifted.inputResponses = nextParams[key];
+    if (key === "requestState") lifted.requestState = nextParams[key];
+    delete nextParams[key];
+  }
+  return {
+    message: {
+      ...message,
+      params: nextParams
+    },
+    lifted
+  };
+}
+function codecResultValidator(codec, method) {
+  const probe = codec.validateResult(method, void 0);
+  if (!probe.ok && probe.reason === "not-in-era") return void 0;
+  return { "~standard": {
+    version: 1,
+    vendor: "mcp-wire-codec",
+    validate(value) {
+      const outcome = codec.validateResult(method, value);
+      if (outcome.ok) return { value: outcome.value };
+      return { issues: [{ message: outcome.reason === "invalid" ? outcome.message : `not-in-era: ${method}` }] };
+    }
+  } };
+}
+function requestStateAccessor(value) {
+  return () => value;
+}
+var NO_REQUEST_STATE = requestStateAccessor(void 0);
+var writeNegotiatedProtocolVersion;
+var Protocol2 = class {
+  _transport;
+  _requestMessageId = 0;
+  _requestHandlers = /* @__PURE__ */ new Map();
+  _requestHandlerAbortControllers = /* @__PURE__ */ new Map();
+  _notificationHandlers = /* @__PURE__ */ new Map();
+  _responseHandlers = /* @__PURE__ */ new Map();
+  _progressHandlers = /* @__PURE__ */ new Map();
+  _timeoutInfo = /* @__PURE__ */ new Map();
+  _pendingDebouncedNotifications = /* @__PURE__ */ new Set();
+  /**
+  * The protocol version negotiated for the current connection (`undefined`
+  * before negotiation completes), which determines the wire era this
+  * instance speaks. Set by the SDK's negotiation and initialize paths
+  * (`Client.connect`, `Server._oninitialize`).
+  */
+  _negotiatedProtocolVersion;
+  static {
+    writeNegotiatedProtocolVersion = (instance, version2) => {
+      instance._negotiatedProtocolVersion = version2;
+    };
+  }
+  _supportedProtocolVersions;
+  /**
+  * Callback for when the connection is closed for any reason.
+  *
+  * This is invoked when {@linkcode Protocol.close | close()} is called as well.
+  */
+  onclose;
+  /**
+  * Callback for when an error occurs.
+  *
+  * Note that errors are not necessarily fatal; they are used for reporting any kind of exceptional condition out of band.
+  */
+  onerror;
+  /**
+  * A handler to invoke for any request types that do not have their own handler installed.
+  */
+  fallbackRequestHandler;
+  /**
+  * A handler to invoke for any notification types that do not have their own handler installed.
+  */
+  fallbackNotificationHandler;
+  constructor(_options) {
+    this._options = _options;
+    this._supportedProtocolVersions = _options?.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS2;
+    this.setNotificationHandler("notifications/cancelled", (notification) => {
+      this._oncancel(notification);
+    });
+    this.setNotificationHandler("notifications/progress", (notification) => {
+      this._onprogress(notification);
+    });
+    this.setRequestHandler("ping", (_request) => ({}));
+  }
+  /**
+  * Drop consult for inbound messages whose transport did not classify them
+  * at the edge — long-lived channels such as stdio, where a role class may
+  * need to decline traffic the negotiated era has no answer for (the
+  * client-side inbound-request drop on modern-era connections: the
+  * 2026-07-28 era has no server→client request channel, and on stdio the
+  * client must never write JSON-RPC responses).
+  *
+  * Consulted ONLY when the transport supplied no
+  * {@linkcode MessageExtraInfo.classification}: edge-classified traffic
+  * never reaches the hook. Returning `'drop'` discards the message without
+  * writing any response (requests are surfaced via `onerror`). The base
+  * implementation returns `undefined`: unclassified traffic keeps today's
+  * dispatch path unchanged. Era selection never happens here — era is
+  * instance state, owned by the serving entry that constructed and
+  * connected the instance.
+  */
+  _shouldDropInbound(_message) {
+  }
+  /**
+  * The per-request `_meta` envelope this instance attaches to every outgoing
+  * request and notification, when one applies. The base implementation
+  * returns `undefined` (no envelope — the 2025-era posture, so legacy-era
+  * outbound traffic is byte-identical to a build without this seam).
+  * `Client` overrides it on a connection that negotiated a modern (2026-07-28+)
+  * era to return the reserved protocol-version / client-info /
+  * client-capabilities keys. User-supplied `_meta` keys take precedence over
+  * the auto-attached ones.
+  */
+  _outboundMetaEnvelope() {
+  }
+  /**
+  * Attach this instance's outbound `_meta` envelope (when one is configured)
+  * to a request or notification. A no-op when the seam returns `undefined`
+  * — the message returns by reference, so the legacy-era wire stays
+  * byte-identical. User-supplied `_meta` keys are spread last so they win
+  * over the auto-attached envelope keys.
+  */
+  _envelopeOutbound(message) {
+    const envelope = this._outboundMetaEnvelope();
+    if (envelope === void 0) return message;
+    const params = message.params ?? {};
+    return {
+      ...message,
+      params: {
+        ...params,
+        _meta: {
+          ...envelope,
+          ...params._meta
+        }
+      }
+    };
+  }
+  /**
+  * Extension point for non-`complete` decoded results in the response
+  * funnel: a result the wire codec discriminated into a kind other than
+  * `'complete'` or `'invalid'` is handed here for the role class to
+  * resolve. The base default surfaces it as a typed
+  * {@linkcode SdkErrorCode.UnsupportedResultType} error (no retry).
+  *
+  * Intended consumers (named so the seam stays accountable):
+  * - the `Client`'s multi-round-trip auto-fulfilment engine, which fulfils
+  *   `'input_required'` results through the registered
+  *   elicitation/sampling/roots handlers and retries via `flow.retry`;
+  * - a future client-side terminal-result handler for
+  *   `subscriptions/listen`, when the spec defines one.
+  *
+  * `Server` instances never receive `input_required` responses on their
+  * outbound legs and leave the base behavior in place.
+  */
+  _resolveNonCompleteResult(decoded, flow) {
+    return Promise.reject(new SdkError(SdkErrorCode.UnsupportedResultType, `Unsupported result type '${decoded.kind}' for ${flow.request.method}`, {
+      resultType: decoded.kind,
+      method: flow.request.method
+    }));
+  }
+  /**
+  * Protected accessor for a registered request handler. Used by role
+  * classes that dispatch synthesized requests through the same stored
+  * handler chain (e.g. the `Client` fulfilling an embedded multi-round-trip
+  * input request).
+  */
+  _getRequestHandler(method) {
+    return this._requestHandlers.get(method);
+  }
+  async _oncancel(notification) {
+    if (!notification.params.requestId) return;
+    this._requestHandlerAbortControllers.get(notification.params.requestId)?.abort(notification.params.reason);
+  }
+  _setupTimeout(messageId, timeout, maxTotalTimeout, onTimeout, resetTimeoutOnProgress = false) {
+    this._timeoutInfo.set(messageId, {
+      timeoutId: setTimeout(onTimeout, timeout),
+      startTime: Date.now(),
+      timeout,
+      maxTotalTimeout,
+      resetTimeoutOnProgress,
+      onTimeout
+    });
+  }
+  _resetTimeout(messageId) {
+    const info = this._timeoutInfo.get(messageId);
+    if (!info) return false;
+    const totalElapsed = Date.now() - info.startTime;
+    if (info.maxTotalTimeout && totalElapsed >= info.maxTotalTimeout) {
+      this._timeoutInfo.delete(messageId);
+      throw new SdkError(SdkErrorCode.RequestTimeout, "Maximum total timeout exceeded", {
+        maxTotalTimeout: info.maxTotalTimeout,
+        totalElapsed
+      });
+    }
+    clearTimeout(info.timeoutId);
+    info.timeoutId = setTimeout(info.onTimeout, info.timeout);
+    return true;
+  }
+  _cleanupTimeout(messageId) {
+    const info = this._timeoutInfo.get(messageId);
+    if (info) {
+      clearTimeout(info.timeoutId);
+      this._timeoutInfo.delete(messageId);
+    }
+  }
+  /**
+  * Attaches to the given transport, starts it, and starts listening for messages.
+  *
+  * The caller assumes ownership of the {@linkcode Transport}, replacing any callbacks that have already been set, and expects that it is the only user of the {@linkcode Transport} instance going forward.
+  */
+  async connect(transport) {
+    this._transport = transport;
+    const _onclose = this.transport?.onclose;
+    this._transport.onclose = () => {
+      try {
+        _onclose?.();
+      } finally {
+        this._onclose();
+      }
+    };
+    const _onerror = this.transport?.onerror;
+    this._transport.onerror = (error2) => {
+      _onerror?.(error2);
+      this._onerror(error2);
+    };
+    const _onmessage = this._transport?.onmessage;
+    this._transport.onmessage = (message, extra) => {
+      _onmessage?.(message, extra);
+      if (isJSONRPCResultResponse2(message) || isJSONRPCErrorResponse2(message)) this._onresponse(message);
+      else if (isJSONRPCRequest2(message)) this._onrequest(message, extra);
+      else if (isJSONRPCNotification2(message)) this._onnotification(message, extra);
+      else this._onerror(/* @__PURE__ */ new Error(`Unknown message type: ${JSON.stringify(message)}`));
+    };
+    transport.setSupportedProtocolVersions?.(this._supportedProtocolVersions);
+    await this._transport.start();
+  }
+  /**
+  * Transport-close hook. Subclass overrides MUST call `super._onclose()`
+  * after their own cleanup — base teardown (response-handler settlement,
+  * timeout clearing, in-flight request abort) does not run otherwise.
+  */
+  _onclose() {
+    const responseHandlers = this._responseHandlers;
+    this._responseHandlers = /* @__PURE__ */ new Map();
+    this._progressHandlers.clear();
+    this._pendingDebouncedNotifications.clear();
+    for (const info of this._timeoutInfo.values()) clearTimeout(info.timeoutId);
+    this._timeoutInfo.clear();
+    const requestHandlerAbortControllers = this._requestHandlerAbortControllers;
+    this._requestHandlerAbortControllers = /* @__PURE__ */ new Map();
+    const error2 = new SdkError(SdkErrorCode.ConnectionClosed, "Connection closed");
+    this._transport = void 0;
+    try {
+      this.onclose?.();
+    } finally {
+      for (const handler of responseHandlers.values()) handler(error2);
+      for (const controller of requestHandlerAbortControllers.values()) controller.abort(error2);
+    }
+  }
+  _onerror(error2) {
+    this.onerror?.(error2);
+  }
+  /**
+  * Inbound-notification dispatch. Subclass overrides MUST delegate
+  * unmatched traffic to `super._onnotification(rawNotification, extra)` —
+  * an override that consumes only what it owns and falls through to base
+  * dispatch for everything else.
+  */
+  _onnotification(rawNotification, extra) {
+    const { message: notification } = liftWireOnlyMaterial(rawNotification, "notification");
+    const codec = this._negotiatedWireCodec();
+    if (extra?.classification === void 0 && this._shouldDropInbound(rawNotification) === "drop") return;
+    if (extra?.classification !== void 0) {
+      const classified = classifiedWireEra(extra.classification);
+      if (classified !== codec.era) {
+        this._onerror(/* @__PURE__ */ new Error(`Era mismatch on inbound notification '${notification.method}': classified as ${classified} but this instance serves ${codec.era}`));
+        return;
+      }
+    }
+    if (isSpecNotificationMethod(notification.method) && !codec.hasNotificationMethod(notification.method)) return;
+    const handler = this._notificationHandlers.get(notification.method);
+    const fallback = this.fallbackNotificationHandler;
+    if (handler === void 0 && fallback === void 0) return;
+    Promise.resolve().then(() => handler === void 0 ? fallback(notification) : handler(notification, codec)).catch((error2) => this._onerror(/* @__PURE__ */ new Error(`Uncaught error in notification handler: ${error2}`)));
+  }
+  _onrequest(rawRequest, extra) {
+    const { message: request, lifted } = liftWireOnlyMaterial(rawRequest, "request");
+    const codec = this._negotiatedWireCodec();
+    if (extra?.classification === void 0 && this._shouldDropInbound(rawRequest) === "drop") {
+      this._onerror(/* @__PURE__ */ new Error(`Dropped inbound request '${rawRequest.method}': not servable on this connection's protocol era`));
+      return;
+    }
+    const capturedTransport = this._transport;
+    const sendErrorResponse = (code, message, data) => {
+      const errorResponse = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code,
+          message,
+          ...data !== void 0 && { data }
+        }
+      };
+      capturedTransport?.send(errorResponse).catch((error2) => this._onerror(/* @__PURE__ */ new Error(`Failed to send an error response: ${error2}`)));
+    };
+    if (extra?.classification !== void 0) {
+      const classified = classifiedWireEra(extra.classification);
+      if (classified !== codec.era) {
+        this._onerror(/* @__PURE__ */ new Error(`Era mismatch on inbound request '${request.method}': classified as ${classified} but this instance serves ${codec.era}`));
+        const requested = extra.classification.revision ?? classified;
+        sendErrorResponse(ProtocolErrorCode.UnsupportedProtocolVersion, `Unsupported protocol version: ${requested}`, {
+          supported: this._supportedProtocolVersions,
+          requested
+        });
+        return;
+      }
+    }
+    if (isSpecRequestMethod(request.method) && !codec.hasRequestMethod(request.method)) {
+      sendErrorResponse(ProtocolErrorCode.MethodNotFound, "Method not found");
+      return;
+    }
+    const handler = this._requestHandlers.get(request.method) ?? this.fallbackRequestHandler;
+    if (handler === void 0) {
+      sendErrorResponse(ProtocolErrorCode.MethodNotFound, "Method not found");
+      return;
+    }
+    const envelopeError = codec.checkInboundEnvelope(lifted);
+    if (envelopeError !== void 0) {
+      sendErrorResponse(ProtocolErrorCode.InvalidParams, envelopeError);
+      return;
+    }
+    const sendNotification = (notification, options) => this._notificationViaCodec(this._resolveOutboundCodec(notification.method), notification, {
+      ...options,
+      relatedRequestId: request.id
+    });
+    const sendRequest = (r, resultSchema, options) => this._requestWithSchemaViaCodec(this._resolveOutboundCodec(r.method), r, resultSchema, {
+      ...options,
+      relatedRequestId: request.id
+    });
+    const abortController = new AbortController();
+    this._requestHandlerAbortControllers.set(request.id, abortController);
+    const partitionedInputResponses = lifted.inputResponses === void 0 ? void 0 : partitionInputResponses(lifted.inputResponses);
+    const baseCtx = {
+      sessionId: capturedTransport?.sessionId,
+      mcpReq: {
+        id: request.id,
+        method: request.method,
+        _meta: request.params?._meta,
+        ...lifted.envelope !== void 0 && { envelope: lifted.envelope },
+        ...partitionedInputResponses !== void 0 && { inputResponses: partitionedInputResponses.accepted },
+        ...partitionedInputResponses !== void 0 && partitionedInputResponses.droppedKeys.length > 0 && { droppedInputResponseKeys: partitionedInputResponses.droppedKeys },
+        requestState: lifted.requestState === void 0 ? NO_REQUEST_STATE : requestStateAccessor(lifted.requestState),
+        signal: abortController.signal,
+        send: ((r, schemaOrOptions, maybeOptions) => {
+          const sendCodec = this._resolveOutboundCodec(r.method);
+          this._assertOutboundRequestInEra(sendCodec, r.method);
+          if (isStandardSchema(schemaOrOptions)) return sendRequest(r, schemaOrOptions, maybeOptions);
+          const validate2 = codecResultValidator(sendCodec, r.method);
+          if (validate2 === void 0) throw new TypeError(`'${r.method}' is not a spec method; pass a result schema as the second argument to ctx.mcpReq.send().`);
+          return sendRequest(r, validate2, schemaOrOptions);
+        }),
+        notify: sendNotification
+      },
+      http: extra?.authInfo ? { authInfo: extra.authInfo } : void 0
+    };
+    const ctx = this.buildContext(baseCtx, extra);
+    Promise.resolve().then(() => handler(request, ctx)).then(async (result) => {
+      if (abortController.signal.aborted) return;
+      let encoded;
+      try {
+        encoded = codec.encodeResult(request.method, result, this._outboundServerInfo());
+      } catch (error2) {
+        this._onerror(/* @__PURE__ */ new Error(`Failed to encode result for ${request.method}: ${error2}`));
+        sendErrorResponse(ProtocolErrorCode.InternalError, "Internal error");
+        return;
+      }
+      const response = {
+        result: encoded,
+        jsonrpc: "2.0",
+        id: request.id
+      };
+      await capturedTransport?.send(response);
+    }, async (error2) => {
+      if (abortController.signal.aborted) return;
+      const thrownCode = Number.isSafeInteger(error2["code"]) ? error2["code"] : ProtocolErrorCode.InternalError;
+      const errorResponse = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: codec.encodeErrorCode(thrownCode),
+          message: error2.message ?? "Internal error",
+          ...error2["data"] !== void 0 && { data: error2["data"] }
+        }
+      };
+      await capturedTransport?.send(errorResponse);
+    }).catch((error2) => this._onerror(/* @__PURE__ */ new Error(`Failed to send response: ${error2}`))).finally(() => {
+      if (this._requestHandlerAbortControllers.get(request.id) === abortController) this._requestHandlerAbortControllers.delete(request.id);
+    });
+  }
+  _onprogress(notification) {
+    const { progressToken, ...params } = notification.params;
+    const messageId = Number(progressToken);
+    const handler = this._progressHandlers.get(messageId);
+    if (!handler) {
+      this._onerror(/* @__PURE__ */ new Error(`Received a progress notification for an unknown token: ${JSON.stringify(notification)}`));
+      return;
+    }
+    const responseHandler = this._responseHandlers.get(messageId);
+    const timeoutInfo = this._timeoutInfo.get(messageId);
+    if (timeoutInfo && responseHandler && timeoutInfo.resetTimeoutOnProgress) try {
+      this._resetTimeout(messageId);
+    } catch (error2) {
+      this._responseHandlers.delete(messageId);
+      this._progressHandlers.delete(messageId);
+      this._cleanupTimeout(messageId);
+      responseHandler(error2);
+      return;
+    }
+    handler(params);
+  }
+  /**
+  * Inbound-response dispatch. Subclass overrides MUST delegate unmatched
+  * traffic to `super._onresponse(response)` — an override that consumes
+  * only what it owns and falls through to base dispatch for everything
+  * else.
+  */
+  _onresponse(response) {
+    const messageId = Number(response.id);
+    const handler = this._responseHandlers.get(messageId);
+    if (handler === void 0) {
+      this._onerror(/* @__PURE__ */ new Error(`Received a response for an unknown message ID: ${JSON.stringify(response)}`));
+      return;
+    }
+    this._responseHandlers.delete(messageId);
+    this._cleanupTimeout(messageId);
+    this._progressHandlers.delete(messageId);
+    if (isJSONRPCResultResponse2(response)) handler(response);
+    else handler(ProtocolError.fromError(response.error.code, response.error.message, response.error.data));
+  }
+  get transport() {
+    return this._transport;
+  }
+  /**
+  * Closes the connection.
+  */
+  async close() {
+    await this._transport?.close();
+  }
+  request(request, schemaOrOptions, maybeOptions) {
+    const codec = this._resolveOutboundCodec(request.method);
+    this._assertOutboundRequestInEra(codec, request.method);
+    if (isStandardSchema(schemaOrOptions)) return this._requestWithSchemaViaCodec(codec, request, schemaOrOptions, maybeOptions);
+    const validate2 = codecResultValidator(codec, request.method);
+    if (validate2 === void 0) throw new TypeError(`'${request.method}' is not a spec method; pass a result schema as the second argument to request().`);
+    return this._requestWithSchemaViaCodec(codec, request, validate2, schemaOrOptions);
+  }
+  /**
+  * The wire codec for this instance's negotiated era — the phase-2 truth:
+  * everything an established connection sends and receives resolves
+  * through it. Legacy until a version has been negotiated.
+  */
+  _negotiatedWireCodec() {
+    return codecForVersion(this._negotiatedProtocolVersion);
+  }
+  /**
+  * Protected accessor for the instance's negotiated wire codec, for role
+  * classes (Client/Server/McpServer) routing era-dependent behavior
+  * through the codec's function-only surface — `samplingResultVariant`,
+  * `outboundEnvelope`, `projectCallToolResult` — instead of branching on
+  * the protocol version themselves.
+  */
+  _wireCodec() {
+    return this._negotiatedWireCodec();
+  }
+  /**
+  * Outbound codec resolution: while the negotiated version is still unset
+  * (the negotiation window), lifecycle messages are bootstrap-pinned BY
+  * METHOD — they self-identify their era (`initialize` IS the legacy
+  * handshake, `server/discover` IS the modern probe). Once a version has
+  * been negotiated, the instance era is authoritative for everything — a
+  * negotiated session never re-routes a method onto the other era.
+  */
+  _resolveOutboundCodec(method) {
+    if (this._negotiatedProtocolVersion === void 0) {
+      const pinned = bootstrapOutboundCodec(method);
+      if (pinned) return pinned;
+    }
+    return this._negotiatedWireCodec();
+  }
+  /**
+  * Era gate for outbound requests — deletions are physical in BOTH
+  * directions: sending a spec method that the resolved era does not define
+  * dies locally with a typed error before anything reaches the transport.
+  * Methods outside the spec universe are consumer-owned extension methods
+  * and stay era-blind.
+  */
+  _assertOutboundRequestInEra(codec, method) {
+    if (isSpecRequestMethod(method) && !codec.hasRequestMethod(method)) throw new SdkError(SdkErrorCode.MethodNotSupportedByProtocolVersion, `Method '${method}' is not supported by the negotiated protocol version (wire era ${codec.era})`, {
+      method,
+      era: codec.era
+    });
+  }
+  /**
+  * Sends a request and waits for a response, using the provided schema for
+  * validation instead of the era registry's method-keyed entry.
+  *
+  * This is the internal implementation used by SDK methods whose result
+  * schema cannot be expressed as a method-keyed registry entry — the one
+  * surviving case is `server.createMessage`, whose result schema depends
+  * on the REQUEST params (tools vs no tools) — and by callers passing
+  * explicit compatibility schemas. Spec methods are still era-gated here:
+  * an explicit schema never smuggles a deleted method onto the wire.
+  */
+  _requestWithSchema(request, resultSchema, options) {
+    const codec = this._resolveOutboundCodec(request.method);
+    this._assertOutboundRequestInEra(codec, request.method);
+    return this._requestWithSchemaViaCodec(codec, request, resultSchema, options);
+  }
+  /**
+  * The request funnel proper, keyed by the resolved era codec: the codec
+  * owns result decoding (raw-first `resultType` discrimination — V-1 —
+  * and the era's lift posture) before the schema validation step.
+  */
+  _requestWithSchemaViaCodec(codec, request, resultSchema, options) {
+    const { relatedRequestId, resumptionToken, onresumptiontoken, headers } = options ?? {};
+    const flowStartedAt = Date.now();
+    let onAbort;
+    let cleanupMessageId;
+    return new Promise((resolve, reject) => {
+      const earlyReject = (error2) => {
+        reject(error2);
+      };
+      if (!this._transport) {
+        earlyReject(/* @__PURE__ */ new Error("Not connected"));
+        return;
+      }
+      if (this._options?.enforceStrictCapabilities === true) try {
+        this.assertCapabilityForMethod(request.method);
+      } catch (error2) {
+        earlyReject(error2);
+        return;
+      }
+      if (options?.signal?.aborted) {
+        const reason = options.signal.reason;
+        throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+      }
+      const requestAbort = codec.era === MODERN_WIRE_REVISION && this._transport.hasPerRequestStream === true ? new AbortController() : void 0;
+      const messageId = this._requestMessageId++;
+      cleanupMessageId = messageId;
+      const jsonrpcRequest = {
+        ...request,
+        jsonrpc: "2.0",
+        id: messageId
+      };
+      if (options?.onprogress) {
+        this._progressHandlers.set(messageId, options.onprogress);
+        jsonrpcRequest.params = {
+          ...request.params,
+          _meta: {
+            ...request.params?._meta,
+            progressToken: messageId
+          }
+        };
+      }
+      const outbound = this._envelopeOutbound(jsonrpcRequest);
+      let responseReceived = false;
+      const cancel = (reason) => {
+        if (responseReceived) return;
+        this._progressHandlers.delete(messageId);
+        if (requestAbort === void 0) this._transport?.send(this._envelopeOutbound({
+          jsonrpc: "2.0",
+          method: "notifications/cancelled",
+          params: {
+            requestId: messageId,
+            reason: String(reason)
+          }
+        }), {
+          relatedRequestId,
+          resumptionToken,
+          onresumptiontoken
+        }).catch((error2) => this._onerror(/* @__PURE__ */ new Error(`Failed to send cancellation: ${error2}`)));
+        else requestAbort.abort();
+        reject(reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason)));
+      };
+      this._responseHandlers.set(messageId, (response) => {
+        if (options?.signal?.aborted) return;
+        responseReceived = true;
+        if (response instanceof Error) return reject(response);
+        let decoded;
+        try {
+          decoded = codec.decodeResult(request.method, response.result);
+        } catch (error2) {
+          return reject(error2 instanceof Error ? error2 : new Error(String(error2)));
+        }
+        if (decoded.kind === "invalid") return reject(decoded.error);
+        if (decoded.kind === "input_required") {
+          if (options?.allowInputRequired === true) return resolve(manualInputRequiredValue(decoded));
+          const flow = {
+            codec,
+            request,
+            resultSchema,
+            options,
+            flowStartedAt,
+            retry: (params, legOptions) => this._requestWithSchemaViaCodec(codec, params === void 0 ? { method: request.method } : {
+              method: request.method,
+              params
+            }, resultSchema, legOptions)
+          };
+          return resolve(this._resolveNonCompleteResult(decoded, flow));
+        }
+        const result = decoded.result;
+        validateStandardSchema(resultSchema, result).then((parseResult) => {
+          if (parseResult.success) resolve(parseResult.data);
+          else reject(new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${request.method}: ${parseResult.error}`));
+        }, reject);
+      });
+      onAbort = () => cancel(options?.signal?.reason);
+      options?.signal?.addEventListener("abort", onAbort, { once: true });
+      const timeout = options?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC2;
+      const timeoutHandler = () => cancel(new SdkError(SdkErrorCode.RequestTimeout, "Request timed out", { timeout }));
+      this._setupTimeout(messageId, timeout, options?.maxTotalTimeout, timeoutHandler, options?.resetTimeoutOnProgress ?? false);
+      this._transport.send(outbound, {
+        relatedRequestId,
+        resumptionToken,
+        onresumptiontoken,
+        headers,
+        requestSignal: requestAbort?.signal
+      }).catch((error2) => {
+        this._progressHandlers.delete(messageId);
+        reject(error2);
+      });
+    }).finally(() => {
+      if (onAbort) options?.signal?.removeEventListener("abort", onAbort);
+      if (cleanupMessageId !== void 0) {
+        this._responseHandlers.delete(cleanupMessageId);
+        this._cleanupTimeout(cleanupMessageId);
+      }
+    });
+  }
+  /**
+  * Emits a notification, which is a one-way message that does not expect a response.
+  */
+  async notification(notification, options) {
+    return this._notificationViaCodec(this._resolveOutboundCodec(notification.method), notification, options);
+  }
+  /**
+  * The notification funnel proper, keyed by the resolved era codec —
+  * direct sends and related notifications (`ctx.mcpReq.notify`) alike
+  * resolve through the instance's negotiated era at send time.
+  */
+  async _notificationViaCodec(codec, notification, options) {
+    if (!this._transport) throw new SdkError(SdkErrorCode.NotConnected, "Not connected");
+    if (isSpecNotificationMethod(notification.method) && !codec.hasNotificationMethod(notification.method)) throw new SdkError(SdkErrorCode.MethodNotSupportedByProtocolVersion, `Notification '${notification.method}' is not supported by the negotiated protocol version (wire era ${codec.era})`, {
+      method: notification.method,
+      era: codec.era
+    });
+    this.assertNotificationCapability(notification.method);
+    const jsonrpcNotification = this._envelopeOutbound({
+      jsonrpc: "2.0",
+      ...notification
+    });
+    if ((this._options?.debouncedNotificationMethods ?? []).includes(notification.method) && !notification.params && !options?.relatedRequestId) {
+      if (this._pendingDebouncedNotifications.has(notification.method)) return;
+      this._pendingDebouncedNotifications.add(notification.method);
+      Promise.resolve().then(() => {
+        this._pendingDebouncedNotifications.delete(notification.method);
+        if (!this._transport) return;
+        this._transport?.send(jsonrpcNotification, options).catch((error2) => this._onerror(error2));
+      });
+      return;
+    }
+    await this._transport.send(jsonrpcNotification, options);
+  }
+  setRequestHandler(method, schemasOrHandler, maybeHandler) {
+    this.assertRequestHandlerCapability(method);
+    let stored;
+    if (typeof schemasOrHandler === "function") {
+      if (!isSpecRequestMethod(method)) throw new TypeError(`'${method}' is not a spec request method; pass schemas as the second argument to setRequestHandler().`);
+      stored = (request, ctx) => {
+        const dispatchCodec = this._negotiatedWireCodec();
+        let outcome = dispatchCodec.validateRequest(method, request);
+        if (!outcome.ok && outcome.reason === "not-in-era") outcome = dispatchCodec.validateInputRequest(method, request);
+        if (!outcome.ok) {
+          if (outcome.reason === "not-in-era") throw new ProtocolError(ProtocolErrorCode.InternalError, `No wire schema for ${method} in the resolved era`);
+          throw new Error(outcome.message);
+        }
+        return Promise.resolve(schemasOrHandler(outcome.value, ctx));
+      };
+    } else if (maybeHandler) stored = async (request, ctx) => {
+      const parsed = await validateStandardSchema(schemasOrHandler.params, { ...request.params });
+      if (!parsed.success) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid params for ${method}: ${parsed.error}`);
+      return maybeHandler(parsed.data, ctx);
+    };
+    else throw new TypeError("setRequestHandler: handler is required");
+    this._requestHandlers.set(method, this._wrapHandler(method, stored));
+  }
+  /**
+  * Hook for subclasses to wrap a registered request handler with role-specific
+  * validation or behavior (e.g. `Server` validates `tools/call` results, `Client`
+  * validates `elicitation/create` mode and result). Runs for both the 2-arg and
+  * 3-arg registration paths. The default implementation is identity.
+  *
+  * Subclasses overriding this hook avoid redeclaring `setRequestHandler`'s overload set.
+  */
+  _wrapHandler(_method, handler) {
+    return handler;
+  }
+  /**
+  * Hook for subclasses to supply the implementation identity the 2026-era
+  * encode seam stamps into outbound result `_meta` under
+  * `io.modelcontextprotocol/serverInfo` (spec PR #3002: servers SHOULD
+  * identify themselves on every response). The default is `undefined` — no
+  * stamp. Only `Server` overrides this: the key identifies the software
+  * producing a response, and the 2025-era codec never stamps anything
+  * regardless (the never-stamp guarantee).
+  */
+  _outboundServerInfo() {
+  }
+  /**
+  * Removes the request handler for the given method.
+  */
+  removeRequestHandler(method) {
+    this._requestHandlers.delete(method);
+  }
+  /**
+  * Asserts that a request handler has not already been set for the given method, in preparation for a new one being automatically installed.
+  */
+  assertCanSetRequestHandler(method) {
+    if (this._requestHandlers.has(method)) throw new Error(`A request handler for ${method} already exists, which would be overridden`);
+  }
+  setNotificationHandler(method, schemasOrHandler, maybeHandler) {
+    if (typeof schemasOrHandler === "function") {
+      if (!isSpecNotificationMethod(method)) throw new TypeError(`'${method}' is not a spec notification method; pass schemas as the second argument to setNotificationHandler().`);
+      this._notificationHandlers.set(method, (notification, codec) => {
+        const outcome = codec.validateNotification(method, notification);
+        if (!outcome.ok) {
+          if (outcome.reason === "not-in-era") throw new ProtocolError(ProtocolErrorCode.InternalError, `No wire schema for ${method} in the resolved era`);
+          throw new Error(outcome.message);
+        }
+        return Promise.resolve(schemasOrHandler(outcome.value));
+      });
+      return;
+    }
+    if (!maybeHandler) throw new TypeError("setNotificationHandler: handler is required");
+    this._notificationHandlers.set(method, async (notification) => {
+      const parsed = await validateStandardSchema(schemasOrHandler.params, { ...notification.params });
+      if (!parsed.success) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid params for notification ${method}: ${parsed.error}`);
+      await maybeHandler(parsed.data, notification);
+    });
+  }
+  /**
+  * Removes the notification handler for the given method.
+  */
+  removeNotificationHandler(method) {
+    this._notificationHandlers.delete(method);
+  }
+};
+function isPlainObject$1(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function mergeCapabilities2(base, additional) {
+  const result = { ...base };
+  for (const key in additional) {
+    const k = key;
+    const addValue = additional[k];
+    if (addValue === void 0) continue;
+    const baseValue = result[k];
+    result[k] = isPlainObject$1(baseValue) && isPlainObject$1(addValue) ? {
+      ...baseValue,
+      ...addValue
+    } : addValue;
+  }
+  return result;
+}
+function isPlainObject3(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function partitionInputResponses(inputResponses) {
+  const accepted = {};
+  const droppedKeys = [];
+  if (!isPlainObject3(inputResponses)) return {
+    accepted,
+    droppedKeys
+  };
+  for (const [key, entry] of Object.entries(inputResponses)) {
+    if (!isPlainObject3(entry) || "method" in entry || "result" in entry) {
+      droppedKeys.push(key);
+      continue;
+    }
+    accepted[key] = entry;
+  }
+  return {
+    accepted,
+    droppedKeys
+  };
+}
+function relatedMessagingUnavailable(member) {
+  throw new SdkError(SdkErrorCode.SendFailed, `ctx.mcpReq.${member} is not available while fulfilling an embedded input request: the request is fulfilled locally and has no related peer request`);
+}
+function synthesizeInputRequestContext(key, method, params, signal, sessionId) {
+  return {
+    sessionId,
+    mcpReq: {
+      id: key,
+      method,
+      _meta: params?.["_meta"],
+      requestState: requestStateAccessor(void 0),
+      signal,
+      send: (() => relatedMessagingUnavailable("send")),
+      notify: () => relatedMessagingUnavailable("notify")
+    }
+  };
+}
+async function dispatchInputRequest(host, codec, key, entry, signal) {
+  if (!isPlainObject3(entry) || typeof entry["method"] !== "string") throw new SdkError(SdkErrorCode.InvalidResult, `Invalid input request '${key}': each inputRequests entry must be an embedded request object with a method`, { key });
+  const method = entry["method"];
+  if (!codec.hasInputRequestMethod(method)) throw new SdkError(SdkErrorCode.InvalidResult, `Invalid input request '${key}': '${method}' is not an embedded request the ${codec.era} revision defines (expected elicitation/create, sampling/createMessage, or roots/list)`, {
+    key,
+    method
+  });
+  const handler = host.getRequestHandler(method);
+  if (handler === void 0) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Cannot fulfil input request '${key}': no handler is registered for '${method}' on this client. Declare the corresponding capability and register a handler, or handle input_required results manually.`, {
+    key,
+    method
+  });
+  const params = isPlainObject3(entry["params"]) ? entry["params"] : void 0;
+  return await handler({
+    jsonrpc: "2.0",
+    id: key,
+    method,
+    ...params !== void 0 && { params }
+  }, host.buildContext(synthesizeInputRequestContext(key, method, params, signal, host.sessionId)));
+}
+function buildRetryLegRequestOptions(options, legOptions) {
+  return {
+    ...options?.signal !== void 0 && { signal: options.signal },
+    ...options?.onprogress !== void 0 && { onprogress: options.onprogress },
+    ...options?.resetTimeoutOnProgress !== void 0 && { resetTimeoutOnProgress: options.resetTimeoutOnProgress },
+    ...options?.headers !== void 0 && { headers: options.headers },
+    ...legOptions.timeout !== void 0 && { timeout: legOptions.timeout },
+    ...legOptions.maxTotalTimeout !== void 0 && { maxTotalTimeout: legOptions.maxTotalTimeout },
+    allowInputRequired: true
+  };
+}
+function runInputRequiredFlow(host, config2, decoded, flow) {
+  const { codec, request, options, flowStartedAt } = flow;
+  const firstPayload = {
+    inputRequests: decoded.inputRequests,
+    ...decoded.requestState !== void 0 && { requestState: decoded.requestState }
+  };
+  const hooks = {
+    dispatchInputRequest: (key, entry, signal) => dispatchInputRequest(host, codec, key, entry, signal),
+    retry: (params, legOptions) => flow.retry(params, buildRetryLegRequestOptions(options, legOptions))
+  };
+  return runInputRequiredDriver({
+    config: config2,
+    method: request.method,
+    originalParams: request.params,
+    firstPayload,
+    flowStartedAt,
+    signal: options?.signal,
+    requestOptions: {
+      ...options?.timeout !== void 0 && { timeout: options.timeout },
+      ...options?.maxTotalTimeout !== void 0 && { maxTotalTimeout: options.maxTotalTimeout },
+      ...options?.onprogress !== void 0 && { onprogress: options.onprogress }
+    },
+    hooks
+  });
+}
+function manualInputRequiredValue(decoded) {
+  return {
+    resultType: "input_required",
+    inputRequests: decoded.inputRequests,
+    ...decoded.requestState !== void 0 && { requestState: decoded.requestState }
+  };
+}
+var require_content_type = /* @__PURE__ */ __commonJSMin(((exports) => {
+  var PARAM_REGEXP = /; *([!#$%&'*+.^_`|~0-9A-Za-z-]+) *= *("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'*+.^_`|~0-9A-Za-z-]+) */g;
+  var QESC_REGEXP = /\\([\u000b\u0020-\u00ff])/g;
+  var TYPE_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+  exports.parse = parse3;
+  function parse3(string4) {
+    if (!string4) throw new TypeError("argument string is required");
+    var header = typeof string4 === "object" ? getcontenttype(string4) : string4;
+    if (typeof header !== "string") throw new TypeError("argument string is required to be a string");
+    var index = header.indexOf(";");
+    var type = index !== -1 ? header.slice(0, index).trim() : header.trim();
+    if (!TYPE_REGEXP.test(type)) throw new TypeError("invalid media type");
+    var obj = new ContentType(type.toLowerCase());
+    if (index !== -1) {
+      var key;
+      var match;
+      var value;
+      PARAM_REGEXP.lastIndex = index;
+      while (match = PARAM_REGEXP.exec(header)) {
+        if (match.index !== index) throw new TypeError("invalid parameter format");
+        index += match[0].length;
+        key = match[1].toLowerCase();
+        value = match[2];
+        if (value.charCodeAt(0) === 34) {
+          value = value.slice(1, -1);
+          if (value.indexOf("\\") !== -1) value = value.replace(QESC_REGEXP, "$1");
+        }
+        obj.parameters[key] = value;
+      }
+      if (index !== header.length) throw new TypeError("invalid parameter format");
+    }
+    return obj;
+  }
+  function getcontenttype(obj) {
+    var header;
+    if (typeof obj.getHeader === "function") header = obj.getHeader("content-type");
+    else if (typeof obj.headers === "object") header = obj.headers && obj.headers["content-type"];
+    if (typeof header !== "string") throw new TypeError("content-type header is missing from object");
+    return header;
+  }
+  function ContentType(type) {
+    this.parameters = /* @__PURE__ */ Object.create(null);
+    this.type = type;
+  }
+}));
+var import_content_type = /* @__PURE__ */ __toESM2(require_content_type(), 1);
+function mediaTypeEssence(header) {
+  if (!header) return;
+  try {
+    return import_content_type.parse(header).type;
+  } catch {
+    const essence = (header.split(";", 1)[0] ?? "").trim().toLowerCase();
+    if (essence === "" || header.slice(essence.length).includes(",")) return;
+    return essence;
+  }
+}
+var STDIO_DEFAULT_MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+function normalizeHeaders(headers) {
+  if (!headers) return {};
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries());
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  return { ...headers };
+}
+function createFetchWithInit(baseFetch = fetch, baseInit) {
+  if (!baseInit) return baseFetch;
+  return async (url2, init) => {
+    return baseFetch(url2, {
+      ...baseInit,
+      ...init,
+      headers: init?.headers ? {
+        ...normalizeHeaders(baseInit.headers),
+        ...normalizeHeaders(init.headers)
+      } : baseInit.headers
+    });
+  };
+}
+
+// node_modules/@modelcontextprotocol/client/dist/ajvProvider-97rDpkRx.mjs
+var require_code$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
+  var _CodeOrName = class {
+  };
+  exports._CodeOrName = _CodeOrName;
+  exports.IDENTIFIER = /^[a-z$_][a-z$_0-9]*$/i;
+  var Name = class extends _CodeOrName {
+    constructor(s) {
+      super();
+      if (!exports.IDENTIFIER.test(s)) throw new Error("CodeGen: name must be a valid identifier");
+      this.str = s;
+    }
+    toString() {
+      return this.str;
+    }
+    emptyStr() {
+      return false;
+    }
+    get names() {
+      return { [this.str]: 1 };
+    }
+  };
+  exports.Name = Name;
+  var _Code = class extends _CodeOrName {
+    constructor(code) {
+      super();
+      this._items = typeof code === "string" ? [code] : code;
+    }
+    toString() {
+      return this.str;
+    }
+    emptyStr() {
+      if (this._items.length > 1) return false;
+      const item = this._items[0];
+      return item === "" || item === '""';
+    }
+    get str() {
+      var _a3;
+      return (_a3 = this._str) !== null && _a3 !== void 0 ? _a3 : this._str = this._items.reduce((s, c) => `${s}${c}`, "");
+    }
+    get names() {
+      var _a3;
+      return (_a3 = this._names) !== null && _a3 !== void 0 ? _a3 : this._names = this._items.reduce((names, c) => {
+        if (c instanceof Name) names[c.str] = (names[c.str] || 0) + 1;
+        return names;
+      }, {});
+    }
+  };
+  exports._Code = _Code;
+  exports.nil = new _Code("");
+  function _(strs, ...args) {
+    const code = [strs[0]];
+    let i = 0;
+    while (i < args.length) {
+      addCodeArg(code, args[i]);
+      code.push(strs[++i]);
+    }
+    return new _Code(code);
+  }
+  exports._ = _;
+  const plus = new _Code("+");
+  function str(strs, ...args) {
+    const expr = [safeStringify(strs[0])];
+    let i = 0;
+    while (i < args.length) {
+      expr.push(plus);
+      addCodeArg(expr, args[i]);
+      expr.push(plus, safeStringify(strs[++i]));
+    }
+    optimize(expr);
+    return new _Code(expr);
+  }
+  exports.str = str;
+  function addCodeArg(code, arg) {
+    if (arg instanceof _Code) code.push(...arg._items);
+    else if (arg instanceof Name) code.push(arg);
+    else code.push(interpolate(arg));
+  }
+  exports.addCodeArg = addCodeArg;
+  function optimize(expr) {
+    let i = 1;
+    while (i < expr.length - 1) {
+      if (expr[i] === plus) {
+        const res = mergeExprItems(expr[i - 1], expr[i + 1]);
+        if (res !== void 0) {
+          expr.splice(i - 1, 3, res);
+          continue;
+        }
+        expr[i++] = "+";
+      }
+      i++;
+    }
+  }
+  function mergeExprItems(a, b) {
+    if (b === '""') return a;
+    if (a === '""') return b;
+    if (typeof a == "string") {
+      if (b instanceof Name || a[a.length - 1] !== '"') return;
+      if (typeof b != "string") return `${a.slice(0, -1)}${b}"`;
+      if (b[0] === '"') return a.slice(0, -1) + b.slice(1);
+      return;
+    }
+    if (typeof b == "string" && b[0] === '"' && !(a instanceof Name)) return `"${a}${b.slice(1)}`;
+  }
+  function strConcat(c1, c2) {
+    return c2.emptyStr() ? c1 : c1.emptyStr() ? c2 : str`${c1}${c2}`;
+  }
+  exports.strConcat = strConcat;
+  function interpolate(x) {
+    return typeof x == "number" || typeof x == "boolean" || x === null ? x : safeStringify(Array.isArray(x) ? x.join(",") : x);
+  }
+  function stringify(x) {
+    return new _Code(safeStringify(x));
+  }
+  exports.stringify = stringify;
+  function safeStringify(x) {
+    return JSON.stringify(x).replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
+  }
+  exports.safeStringify = safeStringify;
+  function getProperty(key) {
+    return typeof key == "string" && exports.IDENTIFIER.test(key) ? new _Code(`.${key}`) : _`[${key}]`;
+  }
+  exports.getProperty = getProperty;
+  function getEsmExportName(key) {
+    if (typeof key == "string" && exports.IDENTIFIER.test(key)) return new _Code(`${key}`);
+    throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`);
+  }
+  exports.getEsmExportName = getEsmExportName;
+  function regexpCode(rx) {
+    return new _Code(rx.toString());
+  }
+  exports.regexpCode = regexpCode;
+}));
+var require_scope2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
+  const code_1 = require_code$1();
+  var ValueError = class extends Error {
+    constructor(name) {
+      super(`CodeGen: "code" for ${name} not defined`);
+      this.value = name.value;
+    }
+  };
+  var UsedValueState;
+  (function(UsedValueState2) {
+    UsedValueState2[UsedValueState2["Started"] = 0] = "Started";
+    UsedValueState2[UsedValueState2["Completed"] = 1] = "Completed";
+  })(UsedValueState || (exports.UsedValueState = UsedValueState = {}));
+  exports.varKinds = {
+    const: new code_1.Name("const"),
+    let: new code_1.Name("let"),
+    var: new code_1.Name("var")
+  };
+  var Scope = class {
+    constructor({ prefixes, parent } = {}) {
+      this._names = {};
+      this._prefixes = prefixes;
+      this._parent = parent;
+    }
+    toName(nameOrPrefix) {
+      return nameOrPrefix instanceof code_1.Name ? nameOrPrefix : this.name(nameOrPrefix);
+    }
+    name(prefix) {
+      return new code_1.Name(this._newName(prefix));
+    }
+    _newName(prefix) {
+      const ng = this._names[prefix] || this._nameGroup(prefix);
+      return `${prefix}${ng.index++}`;
+    }
+    _nameGroup(prefix) {
+      var _a3, _b;
+      if (((_b = (_a3 = this._parent) === null || _a3 === void 0 ? void 0 : _a3._prefixes) === null || _b === void 0 ? void 0 : _b.has(prefix)) || this._prefixes && !this._prefixes.has(prefix)) throw new Error(`CodeGen: prefix "${prefix}" is not allowed in this scope`);
+      return this._names[prefix] = {
+        prefix,
+        index: 0
+      };
+    }
+  };
+  exports.Scope = Scope;
+  var ValueScopeName = class extends code_1.Name {
+    constructor(prefix, nameStr) {
+      super(nameStr);
+      this.prefix = prefix;
+    }
+    setValue(value, { property, itemIndex }) {
+      this.value = value;
+      this.scopePath = (0, code_1._)`.${new code_1.Name(property)}[${itemIndex}]`;
+    }
+  };
+  exports.ValueScopeName = ValueScopeName;
+  const line = (0, code_1._)`\n`;
+  var ValueScope = class extends Scope {
+    constructor(opts) {
+      super(opts);
+      this._values = {};
+      this._scope = opts.scope;
+      this.opts = {
+        ...opts,
+        _n: opts.lines ? line : code_1.nil
+      };
+    }
+    get() {
+      return this._scope;
+    }
+    name(prefix) {
+      return new ValueScopeName(prefix, this._newName(prefix));
+    }
+    value(nameOrPrefix, value) {
+      var _a3;
+      if (value.ref === void 0) throw new Error("CodeGen: ref must be passed in value");
+      const name = this.toName(nameOrPrefix);
+      const { prefix } = name;
+      const valueKey = (_a3 = value.key) !== null && _a3 !== void 0 ? _a3 : value.ref;
+      let vs = this._values[prefix];
+      if (vs) {
+        const _name = vs.get(valueKey);
+        if (_name) return _name;
+      } else vs = this._values[prefix] = /* @__PURE__ */ new Map();
+      vs.set(valueKey, name);
+      const s = this._scope[prefix] || (this._scope[prefix] = []);
+      const itemIndex = s.length;
+      s[itemIndex] = value.ref;
+      name.setValue(value, {
+        property: prefix,
+        itemIndex
+      });
+      return name;
+    }
+    getValue(prefix, keyOrRef) {
+      const vs = this._values[prefix];
+      if (!vs) return;
+      return vs.get(keyOrRef);
+    }
+    scopeRefs(scopeName, values = this._values) {
+      return this._reduceValues(values, (name) => {
+        if (name.scopePath === void 0) throw new Error(`CodeGen: name "${name}" has no value`);
+        return (0, code_1._)`${scopeName}${name.scopePath}`;
+      });
+    }
+    scopeCode(values = this._values, usedValues, getCode) {
+      return this._reduceValues(values, (name) => {
+        if (name.value === void 0) throw new Error(`CodeGen: name "${name}" has no value`);
+        return name.value.code;
+      }, usedValues, getCode);
+    }
+    _reduceValues(values, valueCode, usedValues = {}, getCode) {
+      let code = code_1.nil;
+      for (const prefix in values) {
+        const vs = values[prefix];
+        if (!vs) continue;
+        const nameSet = usedValues[prefix] = usedValues[prefix] || /* @__PURE__ */ new Map();
+        vs.forEach((name) => {
+          if (nameSet.has(name)) return;
+          nameSet.set(name, UsedValueState.Started);
+          let c = valueCode(name);
+          if (c) {
+            const def = this.opts.es5 ? exports.varKinds.var : exports.varKinds.const;
+            code = (0, code_1._)`${code}${def} ${name} = ${c};${this.opts._n}`;
+          } else if (c = getCode === null || getCode === void 0 ? void 0 : getCode(name)) code = (0, code_1._)`${code}${c}${this.opts._n}`;
+          else throw new ValueError(name);
+          nameSet.set(name, UsedValueState.Completed);
+        });
+      }
+      return code;
+    }
+  };
+  exports.ValueScope = ValueScope;
+}));
+var require_codegen2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
+  const code_1 = require_code$1();
+  const scope_1 = require_scope2();
+  var code_2 = require_code$1();
+  Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
+      return code_2._;
+    }
+  });
+  Object.defineProperty(exports, "str", {
+    enumerable: true,
+    get: function() {
+      return code_2.str;
+    }
+  });
+  Object.defineProperty(exports, "strConcat", {
+    enumerable: true,
+    get: function() {
+      return code_2.strConcat;
+    }
+  });
+  Object.defineProperty(exports, "nil", {
+    enumerable: true,
+    get: function() {
+      return code_2.nil;
+    }
+  });
+  Object.defineProperty(exports, "getProperty", {
+    enumerable: true,
+    get: function() {
+      return code_2.getProperty;
+    }
+  });
+  Object.defineProperty(exports, "stringify", {
+    enumerable: true,
+    get: function() {
+      return code_2.stringify;
+    }
+  });
+  Object.defineProperty(exports, "regexpCode", {
+    enumerable: true,
+    get: function() {
+      return code_2.regexpCode;
+    }
+  });
+  Object.defineProperty(exports, "Name", {
+    enumerable: true,
+    get: function() {
+      return code_2.Name;
+    }
+  });
+  var scope_2 = require_scope2();
+  Object.defineProperty(exports, "Scope", {
+    enumerable: true,
+    get: function() {
+      return scope_2.Scope;
+    }
+  });
+  Object.defineProperty(exports, "ValueScope", {
+    enumerable: true,
+    get: function() {
+      return scope_2.ValueScope;
+    }
+  });
+  Object.defineProperty(exports, "ValueScopeName", {
+    enumerable: true,
+    get: function() {
+      return scope_2.ValueScopeName;
+    }
+  });
+  Object.defineProperty(exports, "varKinds", {
+    enumerable: true,
+    get: function() {
+      return scope_2.varKinds;
+    }
+  });
+  exports.operators = {
+    GT: new code_1._Code(">"),
+    GTE: new code_1._Code(">="),
+    LT: new code_1._Code("<"),
+    LTE: new code_1._Code("<="),
+    EQ: new code_1._Code("==="),
+    NEQ: new code_1._Code("!=="),
+    NOT: new code_1._Code("!"),
+    OR: new code_1._Code("||"),
+    AND: new code_1._Code("&&"),
+    ADD: new code_1._Code("+")
+  };
+  var Node = class {
+    optimizeNodes() {
+      return this;
+    }
+    optimizeNames(_names, _constants) {
+      return this;
+    }
+  };
+  var Def = class extends Node {
+    constructor(varKind, name, rhs) {
+      super();
+      this.varKind = varKind;
+      this.name = name;
+      this.rhs = rhs;
+    }
+    render({ es5, _n }) {
+      const varKind = es5 ? scope_1.varKinds.var : this.varKind;
+      const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
+      return `${varKind} ${this.name}${rhs};` + _n;
+    }
+    optimizeNames(names, constants) {
+      if (!names[this.name.str]) return;
+      if (this.rhs) this.rhs = optimizeExpr(this.rhs, names, constants);
+      return this;
+    }
+    get names() {
+      return this.rhs instanceof code_1._CodeOrName ? this.rhs.names : {};
+    }
+  };
+  var Assign = class extends Node {
+    constructor(lhs, rhs, sideEffects) {
+      super();
+      this.lhs = lhs;
+      this.rhs = rhs;
+      this.sideEffects = sideEffects;
+    }
+    render({ _n }) {
+      return `${this.lhs} = ${this.rhs};` + _n;
+    }
+    optimizeNames(names, constants) {
+      if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects) return;
+      this.rhs = optimizeExpr(this.rhs, names, constants);
+      return this;
+    }
+    get names() {
+      return addExprNames(this.lhs instanceof code_1.Name ? {} : { ...this.lhs.names }, this.rhs);
+    }
+  };
+  var AssignOp = class extends Assign {
+    constructor(lhs, op, rhs, sideEffects) {
+      super(lhs, rhs, sideEffects);
+      this.op = op;
+    }
+    render({ _n }) {
+      return `${this.lhs} ${this.op}= ${this.rhs};` + _n;
+    }
+  };
+  var Label = class extends Node {
+    constructor(label) {
+      super();
+      this.label = label;
+      this.names = {};
+    }
+    render({ _n }) {
+      return `${this.label}:` + _n;
+    }
+  };
+  var Break = class extends Node {
+    constructor(label) {
+      super();
+      this.label = label;
+      this.names = {};
+    }
+    render({ _n }) {
+      return `break${this.label ? ` ${this.label}` : ""};` + _n;
+    }
+  };
+  var Throw = class extends Node {
+    constructor(error2) {
+      super();
+      this.error = error2;
+    }
+    render({ _n }) {
+      return `throw ${this.error};` + _n;
+    }
+    get names() {
+      return this.error.names;
+    }
+  };
+  var AnyCode = class extends Node {
+    constructor(code) {
+      super();
+      this.code = code;
+    }
+    render({ _n }) {
+      return `${this.code};` + _n;
+    }
+    optimizeNodes() {
+      return `${this.code}` ? this : void 0;
+    }
+    optimizeNames(names, constants) {
+      this.code = optimizeExpr(this.code, names, constants);
+      return this;
+    }
+    get names() {
+      return this.code instanceof code_1._CodeOrName ? this.code.names : {};
+    }
+  };
+  var ParentNode = class extends Node {
+    constructor(nodes = []) {
+      super();
+      this.nodes = nodes;
+    }
+    render(opts) {
+      return this.nodes.reduce((code, n) => code + n.render(opts), "");
+    }
+    optimizeNodes() {
+      const { nodes } = this;
+      let i = nodes.length;
+      while (i--) {
+        const n = nodes[i].optimizeNodes();
+        if (Array.isArray(n)) nodes.splice(i, 1, ...n);
+        else if (n) nodes[i] = n;
+        else nodes.splice(i, 1);
+      }
+      return nodes.length > 0 ? this : void 0;
+    }
+    optimizeNames(names, constants) {
+      const { nodes } = this;
+      let i = nodes.length;
+      while (i--) {
+        const n = nodes[i];
+        if (n.optimizeNames(names, constants)) continue;
+        subtractNames(names, n.names);
+        nodes.splice(i, 1);
+      }
+      return nodes.length > 0 ? this : void 0;
+    }
+    get names() {
+      return this.nodes.reduce((names, n) => addNames(names, n.names), {});
+    }
+  };
+  var BlockNode = class extends ParentNode {
+    render(opts) {
+      return "{" + opts._n + super.render(opts) + "}" + opts._n;
+    }
+  };
+  var Root = class extends ParentNode {
+  };
+  var Else = class extends BlockNode {
+  };
+  Else.kind = "else";
+  var If = class If2 extends BlockNode {
+    constructor(condition, nodes) {
+      super(nodes);
+      this.condition = condition;
+    }
+    render(opts) {
+      let code = `if(${this.condition})` + super.render(opts);
+      if (this.else) code += "else " + this.else.render(opts);
+      return code;
+    }
+    optimizeNodes() {
+      super.optimizeNodes();
+      const cond = this.condition;
+      if (cond === true) return this.nodes;
+      let e = this.else;
+      if (e) {
+        const ns = e.optimizeNodes();
+        e = this.else = Array.isArray(ns) ? new Else(ns) : ns;
+      }
+      if (e) {
+        if (cond === false) return e instanceof If2 ? e : e.nodes;
+        if (this.nodes.length) return this;
+        return new If2(not(cond), e instanceof If2 ? [e] : e.nodes);
+      }
+      if (cond === false || !this.nodes.length) return void 0;
+      return this;
+    }
+    optimizeNames(names, constants) {
+      var _a3;
+      this.else = (_a3 = this.else) === null || _a3 === void 0 ? void 0 : _a3.optimizeNames(names, constants);
+      if (!(super.optimizeNames(names, constants) || this.else)) return;
+      this.condition = optimizeExpr(this.condition, names, constants);
+      return this;
+    }
+    get names() {
+      const names = super.names;
+      addExprNames(names, this.condition);
+      if (this.else) addNames(names, this.else.names);
+      return names;
+    }
+  };
+  If.kind = "if";
+  var For = class extends BlockNode {
+  };
+  For.kind = "for";
+  var ForLoop = class extends For {
+    constructor(iteration) {
+      super();
+      this.iteration = iteration;
+    }
+    render(opts) {
+      return `for(${this.iteration})` + super.render(opts);
+    }
+    optimizeNames(names, constants) {
+      if (!super.optimizeNames(names, constants)) return;
+      this.iteration = optimizeExpr(this.iteration, names, constants);
+      return this;
+    }
+    get names() {
+      return addNames(super.names, this.iteration.names);
+    }
+  };
+  var ForRange = class extends For {
+    constructor(varKind, name, from, to) {
+      super();
+      this.varKind = varKind;
+      this.name = name;
+      this.from = from;
+      this.to = to;
+    }
+    render(opts) {
+      const varKind = opts.es5 ? scope_1.varKinds.var : this.varKind;
+      const { name, from, to } = this;
+      return `for(${varKind} ${name}=${from}; ${name}<${to}; ${name}++)` + super.render(opts);
+    }
+    get names() {
+      return addExprNames(addExprNames(super.names, this.from), this.to);
+    }
+  };
+  var ForIter = class extends For {
+    constructor(loop, varKind, name, iterable) {
+      super();
+      this.loop = loop;
+      this.varKind = varKind;
+      this.name = name;
+      this.iterable = iterable;
+    }
+    render(opts) {
+      return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
+    }
+    optimizeNames(names, constants) {
+      if (!super.optimizeNames(names, constants)) return;
+      this.iterable = optimizeExpr(this.iterable, names, constants);
+      return this;
+    }
+    get names() {
+      return addNames(super.names, this.iterable.names);
+    }
+  };
+  var Func = class extends BlockNode {
+    constructor(name, args, async) {
+      super();
+      this.name = name;
+      this.args = args;
+      this.async = async;
+    }
+    render(opts) {
+      return `${this.async ? "async " : ""}function ${this.name}(${this.args})` + super.render(opts);
+    }
+  };
+  Func.kind = "func";
+  var Return = class extends ParentNode {
+    render(opts) {
+      return "return " + super.render(opts);
+    }
+  };
+  Return.kind = "return";
+  var Try = class extends BlockNode {
+    render(opts) {
+      let code = "try" + super.render(opts);
+      if (this.catch) code += this.catch.render(opts);
+      if (this.finally) code += this.finally.render(opts);
+      return code;
+    }
+    optimizeNodes() {
+      var _a3, _b;
+      super.optimizeNodes();
+      (_a3 = this.catch) === null || _a3 === void 0 || _a3.optimizeNodes();
+      (_b = this.finally) === null || _b === void 0 || _b.optimizeNodes();
+      return this;
+    }
+    optimizeNames(names, constants) {
+      var _a3, _b;
+      super.optimizeNames(names, constants);
+      (_a3 = this.catch) === null || _a3 === void 0 || _a3.optimizeNames(names, constants);
+      (_b = this.finally) === null || _b === void 0 || _b.optimizeNames(names, constants);
+      return this;
+    }
+    get names() {
+      const names = super.names;
+      if (this.catch) addNames(names, this.catch.names);
+      if (this.finally) addNames(names, this.finally.names);
+      return names;
+    }
+  };
+  var Catch = class extends BlockNode {
+    constructor(error2) {
+      super();
+      this.error = error2;
+    }
+    render(opts) {
+      return `catch(${this.error})` + super.render(opts);
+    }
+  };
+  Catch.kind = "catch";
+  var Finally = class extends BlockNode {
+    render(opts) {
+      return "finally" + super.render(opts);
+    }
+  };
+  Finally.kind = "finally";
+  var CodeGen = class {
+    constructor(extScope, opts = {}) {
+      this._values = {};
+      this._blockStarts = [];
+      this._constants = {};
+      this.opts = {
+        ...opts,
+        _n: opts.lines ? "\n" : ""
+      };
+      this._extScope = extScope;
+      this._scope = new scope_1.Scope({ parent: extScope });
+      this._nodes = [new Root()];
+    }
+    toString() {
+      return this._root.render(this.opts);
+    }
+    name(prefix) {
+      return this._scope.name(prefix);
+    }
+    scopeName(prefix) {
+      return this._extScope.name(prefix);
+    }
+    scopeValue(prefixOrName, value) {
+      const name = this._extScope.value(prefixOrName, value);
+      (this._values[name.prefix] || (this._values[name.prefix] = /* @__PURE__ */ new Set())).add(name);
+      return name;
+    }
+    getScopeValue(prefix, keyOrRef) {
+      return this._extScope.getValue(prefix, keyOrRef);
+    }
+    scopeRefs(scopeName) {
+      return this._extScope.scopeRefs(scopeName, this._values);
+    }
+    scopeCode() {
+      return this._extScope.scopeCode(this._values);
+    }
+    _def(varKind, nameOrPrefix, rhs, constant) {
+      const name = this._scope.toName(nameOrPrefix);
+      if (rhs !== void 0 && constant) this._constants[name.str] = rhs;
+      this._leafNode(new Def(varKind, name, rhs));
+      return name;
+    }
+    const(nameOrPrefix, rhs, _constant) {
+      return this._def(scope_1.varKinds.const, nameOrPrefix, rhs, _constant);
+    }
+    let(nameOrPrefix, rhs, _constant) {
+      return this._def(scope_1.varKinds.let, nameOrPrefix, rhs, _constant);
+    }
+    var(nameOrPrefix, rhs, _constant) {
+      return this._def(scope_1.varKinds.var, nameOrPrefix, rhs, _constant);
+    }
+    assign(lhs, rhs, sideEffects) {
+      return this._leafNode(new Assign(lhs, rhs, sideEffects));
+    }
+    add(lhs, rhs) {
+      return this._leafNode(new AssignOp(lhs, exports.operators.ADD, rhs));
+    }
+    code(c) {
+      if (typeof c == "function") c();
+      else if (c !== code_1.nil) this._leafNode(new AnyCode(c));
+      return this;
+    }
+    object(...keyValues) {
+      const code = ["{"];
+      for (const [key, value] of keyValues) {
+        if (code.length > 1) code.push(",");
+        code.push(key);
+        if (key !== value || this.opts.es5) {
+          code.push(":");
+          (0, code_1.addCodeArg)(code, value);
+        }
+      }
+      code.push("}");
+      return new code_1._Code(code);
+    }
+    if(condition, thenBody, elseBody) {
+      this._blockNode(new If(condition));
+      if (thenBody && elseBody) this.code(thenBody).else().code(elseBody).endIf();
+      else if (thenBody) this.code(thenBody).endIf();
+      else if (elseBody) throw new Error('CodeGen: "else" body without "then" body');
+      return this;
+    }
+    elseIf(condition) {
+      return this._elseNode(new If(condition));
+    }
+    else() {
+      return this._elseNode(new Else());
+    }
+    endIf() {
+      return this._endBlockNode(If, Else);
+    }
+    _for(node2, forBody) {
+      this._blockNode(node2);
+      if (forBody) this.code(forBody).endFor();
+      return this;
+    }
+    for(iteration, forBody) {
+      return this._for(new ForLoop(iteration), forBody);
+    }
+    forRange(nameOrPrefix, from, to, forBody, varKind = this.opts.es5 ? scope_1.varKinds.var : scope_1.varKinds.let) {
+      const name = this._scope.toName(nameOrPrefix);
+      return this._for(new ForRange(varKind, name, from, to), () => forBody(name));
+    }
+    forOf(nameOrPrefix, iterable, forBody, varKind = scope_1.varKinds.const) {
+      const name = this._scope.toName(nameOrPrefix);
+      if (this.opts.es5) {
+        const arr = iterable instanceof code_1.Name ? iterable : this.var("_arr", iterable);
+        return this.forRange("_i", 0, (0, code_1._)`${arr}.length`, (i) => {
+          this.var(name, (0, code_1._)`${arr}[${i}]`);
+          forBody(name);
+        });
+      }
+      return this._for(new ForIter("of", varKind, name, iterable), () => forBody(name));
+    }
+    forIn(nameOrPrefix, obj, forBody, varKind = this.opts.es5 ? scope_1.varKinds.var : scope_1.varKinds.const) {
+      if (this.opts.ownProperties) return this.forOf(nameOrPrefix, (0, code_1._)`Object.keys(${obj})`, forBody);
+      const name = this._scope.toName(nameOrPrefix);
+      return this._for(new ForIter("in", varKind, name, obj), () => forBody(name));
+    }
+    endFor() {
+      return this._endBlockNode(For);
+    }
+    label(label) {
+      return this._leafNode(new Label(label));
+    }
+    break(label) {
+      return this._leafNode(new Break(label));
+    }
+    return(value) {
+      const node2 = new Return();
+      this._blockNode(node2);
+      this.code(value);
+      if (node2.nodes.length !== 1) throw new Error('CodeGen: "return" should have one node');
+      return this._endBlockNode(Return);
+    }
+    try(tryBody, catchCode, finallyCode) {
+      if (!catchCode && !finallyCode) throw new Error('CodeGen: "try" without "catch" and "finally"');
+      const node2 = new Try();
+      this._blockNode(node2);
+      this.code(tryBody);
+      if (catchCode) {
+        const error2 = this.name("e");
+        this._currNode = node2.catch = new Catch(error2);
+        catchCode(error2);
+      }
+      if (finallyCode) {
+        this._currNode = node2.finally = new Finally();
+        this.code(finallyCode);
+      }
+      return this._endBlockNode(Catch, Finally);
+    }
+    throw(error2) {
+      return this._leafNode(new Throw(error2));
+    }
+    block(body, nodeCount) {
+      this._blockStarts.push(this._nodes.length);
+      if (body) this.code(body).endBlock(nodeCount);
+      return this;
+    }
+    endBlock(nodeCount) {
+      const len = this._blockStarts.pop();
+      if (len === void 0) throw new Error("CodeGen: not in self-balancing block");
+      const toClose = this._nodes.length - len;
+      if (toClose < 0 || nodeCount !== void 0 && toClose !== nodeCount) throw new Error(`CodeGen: wrong number of nodes: ${toClose} vs ${nodeCount} expected`);
+      this._nodes.length = len;
+      return this;
+    }
+    func(name, args = code_1.nil, async, funcBody) {
+      this._blockNode(new Func(name, args, async));
+      if (funcBody) this.code(funcBody).endFunc();
+      return this;
+    }
+    endFunc() {
+      return this._endBlockNode(Func);
+    }
+    optimize(n = 1) {
+      while (n-- > 0) {
+        this._root.optimizeNodes();
+        this._root.optimizeNames(this._root.names, this._constants);
+      }
+    }
+    _leafNode(node2) {
+      this._currNode.nodes.push(node2);
+      return this;
+    }
+    _blockNode(node2) {
+      this._currNode.nodes.push(node2);
+      this._nodes.push(node2);
+    }
+    _endBlockNode(N1, N2) {
+      const n = this._currNode;
+      if (n instanceof N1 || N2 && n instanceof N2) {
+        this._nodes.pop();
+        return this;
+      }
+      throw new Error(`CodeGen: not in block "${N2 ? `${N1.kind}/${N2.kind}` : N1.kind}"`);
+    }
+    _elseNode(node2) {
+      const n = this._currNode;
+      if (!(n instanceof If)) throw new Error('CodeGen: "else" without "if"');
+      this._currNode = n.else = node2;
+      return this;
+    }
+    get _root() {
+      return this._nodes[0];
+    }
+    get _currNode() {
+      const ns = this._nodes;
+      return ns[ns.length - 1];
+    }
+    set _currNode(node2) {
+      const ns = this._nodes;
+      ns[ns.length - 1] = node2;
+    }
+  };
+  exports.CodeGen = CodeGen;
+  function addNames(names, from) {
+    for (const n in from) names[n] = (names[n] || 0) + (from[n] || 0);
+    return names;
+  }
+  function addExprNames(names, from) {
+    return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
+  }
+  function optimizeExpr(expr, names, constants) {
+    if (expr instanceof code_1.Name) return replaceName(expr);
+    if (!canOptimize(expr)) return expr;
+    return new code_1._Code(expr._items.reduce((items, c) => {
+      if (c instanceof code_1.Name) c = replaceName(c);
+      if (c instanceof code_1._Code) items.push(...c._items);
+      else items.push(c);
+      return items;
+    }, []));
+    function replaceName(n) {
+      const c = constants[n.str];
+      if (c === void 0 || names[n.str] !== 1) return n;
+      delete names[n.str];
+      return c;
+    }
+    function canOptimize(e) {
+      return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants[c.str] !== void 0);
+    }
+  }
+  function subtractNames(names, from) {
+    for (const n in from) names[n] = (names[n] || 0) - (from[n] || 0);
+  }
+  function not(x) {
+    return typeof x == "boolean" || typeof x == "number" || x === null ? !x : (0, code_1._)`!${par(x)}`;
+  }
+  exports.not = not;
+  const andCode = mappend(exports.operators.AND);
+  function and(...args) {
+    return args.reduce(andCode);
+  }
+  exports.and = and;
+  const orCode = mappend(exports.operators.OR);
+  function or(...args) {
+    return args.reduce(orCode);
+  }
+  exports.or = or;
+  function mappend(op) {
+    return (x, y) => x === code_1.nil ? y : y === code_1.nil ? x : (0, code_1._)`${par(x)} ${op} ${par(y)}`;
+  }
+  function par(x) {
+    return x instanceof code_1.Name ? x : (0, code_1._)`(${x})`;
+  }
+}));
+var require_util2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
+  const codegen_1 = require_codegen2();
+  const code_1 = require_code$1();
+  function toHash(arr) {
+    const hash = {};
+    for (const item of arr) hash[item] = true;
+    return hash;
+  }
+  exports.toHash = toHash;
+  function alwaysValidSchema(it, schema) {
+    if (typeof schema == "boolean") return schema;
+    if (Object.keys(schema).length === 0) return true;
+    checkUnknownRules(it, schema);
+    return !schemaHasRules(schema, it.self.RULES.all);
+  }
+  exports.alwaysValidSchema = alwaysValidSchema;
+  function checkUnknownRules(it, schema = it.schema) {
+    const { opts, self } = it;
+    if (!opts.strictSchema) return;
+    if (typeof schema === "boolean") return;
+    const rules = self.RULES.keywords;
+    for (const key in schema) if (!rules[key]) checkStrictMode(it, `unknown keyword: "${key}"`);
+  }
+  exports.checkUnknownRules = checkUnknownRules;
+  function schemaHasRules(schema, rules) {
+    if (typeof schema == "boolean") return !schema;
+    for (const key in schema) if (rules[key]) return true;
+    return false;
+  }
+  exports.schemaHasRules = schemaHasRules;
+  function schemaHasRulesButRef(schema, RULES) {
+    if (typeof schema == "boolean") return !schema;
+    for (const key in schema) if (key !== "$ref" && RULES.all[key]) return true;
+    return false;
+  }
+  exports.schemaHasRulesButRef = schemaHasRulesButRef;
+  function schemaRefOrVal({ topSchemaRef, schemaPath }, schema, keyword, $data) {
+    if (!$data) {
+      if (typeof schema == "number" || typeof schema == "boolean") return schema;
+      if (typeof schema == "string") return (0, codegen_1._)`${schema}`;
+    }
+    return (0, codegen_1._)`${topSchemaRef}${schemaPath}${(0, codegen_1.getProperty)(keyword)}`;
+  }
+  exports.schemaRefOrVal = schemaRefOrVal;
+  function unescapeFragment(str) {
+    return unescapeJsonPointer(decodeURIComponent(str));
+  }
+  exports.unescapeFragment = unescapeFragment;
+  function escapeFragment(str) {
+    return encodeURIComponent(escapeJsonPointer(str));
+  }
+  exports.escapeFragment = escapeFragment;
+  function escapeJsonPointer(str) {
+    if (typeof str == "number") return `${str}`;
+    return str.replace(/~/g, "~0").replace(/\//g, "~1");
+  }
+  exports.escapeJsonPointer = escapeJsonPointer;
+  function unescapeJsonPointer(str) {
+    return str.replace(/~1/g, "/").replace(/~0/g, "~");
+  }
+  exports.unescapeJsonPointer = unescapeJsonPointer;
+  function eachItem(xs, f) {
+    if (Array.isArray(xs)) for (const x of xs) f(x);
+    else f(xs);
+  }
+  exports.eachItem = eachItem;
+  function makeMergeEvaluated({ mergeNames, mergeToName, mergeValues: mergeValues2, resultToName }) {
+    return (gen, from, to, toName) => {
+      const res = to === void 0 ? from : to instanceof codegen_1.Name ? (from instanceof codegen_1.Name ? mergeNames(gen, from, to) : mergeToName(gen, from, to), to) : from instanceof codegen_1.Name ? (mergeToName(gen, to, from), from) : mergeValues2(from, to);
+      return toName === codegen_1.Name && !(res instanceof codegen_1.Name) ? resultToName(gen, res) : res;
+    };
+  }
+  exports.mergeEvaluated = {
+    props: makeMergeEvaluated({
+      mergeNames: (gen, from, to) => gen.if((0, codegen_1._)`${to} !== true && ${from} !== undefined`, () => {
+        gen.if((0, codegen_1._)`${from} === true`, () => gen.assign(to, true), () => gen.assign(to, (0, codegen_1._)`${to} || {}`).code((0, codegen_1._)`Object.assign(${to}, ${from})`));
+      }),
+      mergeToName: (gen, from, to) => gen.if((0, codegen_1._)`${to} !== true`, () => {
+        if (from === true) gen.assign(to, true);
+        else {
+          gen.assign(to, (0, codegen_1._)`${to} || {}`);
+          setEvaluated(gen, to, from);
+        }
+      }),
+      mergeValues: (from, to) => from === true ? true : {
+        ...from,
+        ...to
+      },
+      resultToName: evaluatedPropsToName
+    }),
+    items: makeMergeEvaluated({
+      mergeNames: (gen, from, to) => gen.if((0, codegen_1._)`${to} !== true && ${from} !== undefined`, () => gen.assign(to, (0, codegen_1._)`${from} === true ? true : ${to} > ${from} ? ${to} : ${from}`)),
+      mergeToName: (gen, from, to) => gen.if((0, codegen_1._)`${to} !== true`, () => gen.assign(to, from === true ? true : (0, codegen_1._)`${to} > ${from} ? ${to} : ${from}`)),
+      mergeValues: (from, to) => from === true ? true : Math.max(from, to),
+      resultToName: (gen, items) => gen.var("items", items)
+    })
+  };
+  function evaluatedPropsToName(gen, ps) {
+    if (ps === true) return gen.var("props", true);
+    const props = gen.var("props", (0, codegen_1._)`{}`);
+    if (ps !== void 0) setEvaluated(gen, props, ps);
+    return props;
+  }
+  exports.evaluatedPropsToName = evaluatedPropsToName;
+  function setEvaluated(gen, props, ps) {
+    Object.keys(ps).forEach((p) => gen.assign((0, codegen_1._)`${props}${(0, codegen_1.getProperty)(p)}`, true));
+  }
+  exports.setEvaluated = setEvaluated;
+  const snippets = {};
+  function useFunc(gen, f) {
+    return gen.scopeValue("func", {
+      ref: f,
+      code: snippets[f.code] || (snippets[f.code] = new code_1._Code(f.code))
+    });
+  }
+  exports.useFunc = useFunc;
+  var Type;
+  (function(Type2) {
+    Type2[Type2["Num"] = 0] = "Num";
+    Type2[Type2["Str"] = 1] = "Str";
+  })(Type || (exports.Type = Type = {}));
+  function getErrorPath(dataProp, dataPropType, jsPropertySyntax) {
+    if (dataProp instanceof codegen_1.Name) {
+      const isNumber = dataPropType === Type.Num;
+      return jsPropertySyntax ? isNumber ? (0, codegen_1._)`"[" + ${dataProp} + "]"` : (0, codegen_1._)`"['" + ${dataProp} + "']"` : isNumber ? (0, codegen_1._)`"/" + ${dataProp}` : (0, codegen_1._)`"/" + ${dataProp}.replace(/~/g, "~0").replace(/\\//g, "~1")`;
+    }
+    return jsPropertySyntax ? (0, codegen_1.getProperty)(dataProp).toString() : "/" + escapeJsonPointer(dataProp);
+  }
+  exports.getErrorPath = getErrorPath;
+  function checkStrictMode(it, msg, mode = it.opts.strictSchema) {
+    if (!mode) return;
+    msg = `strict mode: ${msg}`;
+    if (mode === true) throw new Error(msg);
+    it.self.logger.warn(msg);
+  }
+  exports.checkStrictMode = checkStrictMode;
+}));
+var require_names2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const names = {
+    data: new codegen_1.Name("data"),
+    valCxt: new codegen_1.Name("valCxt"),
+    instancePath: new codegen_1.Name("instancePath"),
+    parentData: new codegen_1.Name("parentData"),
+    parentDataProperty: new codegen_1.Name("parentDataProperty"),
+    rootData: new codegen_1.Name("rootData"),
+    dynamicAnchors: new codegen_1.Name("dynamicAnchors"),
+    vErrors: new codegen_1.Name("vErrors"),
+    errors: new codegen_1.Name("errors"),
+    this: new codegen_1.Name("this"),
+    self: new codegen_1.Name("self"),
+    scope: new codegen_1.Name("scope"),
+    json: new codegen_1.Name("json"),
+    jsonPos: new codegen_1.Name("jsonPos"),
+    jsonLen: new codegen_1.Name("jsonLen"),
+    jsonPart: new codegen_1.Name("jsonPart")
+  };
+  exports.default = names;
+}));
+var require_errors2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const names_1 = require_names2();
+  exports.keywordError = { message: ({ keyword }) => (0, codegen_1.str)`must pass "${keyword}" keyword validation` };
+  exports.keyword$DataError = { message: ({ keyword, schemaType }) => schemaType ? (0, codegen_1.str)`"${keyword}" keyword must be ${schemaType} ($data)` : (0, codegen_1.str)`"${keyword}" keyword is invalid ($data)` };
+  function reportError(cxt, error2 = exports.keywordError, errorPaths, overrideAllErrors) {
+    const { it } = cxt;
+    const { gen, compositeRule, allErrors } = it;
+    const errObj = errorObjectCode(cxt, error2, errorPaths);
+    if (overrideAllErrors !== null && overrideAllErrors !== void 0 ? overrideAllErrors : compositeRule || allErrors) addError(gen, errObj);
+    else returnErrors(it, (0, codegen_1._)`[${errObj}]`);
+  }
+  exports.reportError = reportError;
+  function reportExtraError(cxt, error2 = exports.keywordError, errorPaths) {
+    const { it } = cxt;
+    const { gen, compositeRule, allErrors } = it;
+    addError(gen, errorObjectCode(cxt, error2, errorPaths));
+    if (!(compositeRule || allErrors)) returnErrors(it, names_1.default.vErrors);
+  }
+  exports.reportExtraError = reportExtraError;
+  function resetErrorsCount(gen, errsCount) {
+    gen.assign(names_1.default.errors, errsCount);
+    gen.if((0, codegen_1._)`${names_1.default.vErrors} !== null`, () => gen.if(errsCount, () => gen.assign((0, codegen_1._)`${names_1.default.vErrors}.length`, errsCount), () => gen.assign(names_1.default.vErrors, null)));
+  }
+  exports.resetErrorsCount = resetErrorsCount;
+  function extendErrors({ gen, keyword, schemaValue, data, errsCount, it }) {
+    if (errsCount === void 0) throw new Error("ajv implementation error");
+    const err = gen.name("err");
+    gen.forRange("i", errsCount, names_1.default.errors, (i) => {
+      gen.const(err, (0, codegen_1._)`${names_1.default.vErrors}[${i}]`);
+      gen.if((0, codegen_1._)`${err}.instancePath === undefined`, () => gen.assign((0, codegen_1._)`${err}.instancePath`, (0, codegen_1.strConcat)(names_1.default.instancePath, it.errorPath)));
+      gen.assign((0, codegen_1._)`${err}.schemaPath`, (0, codegen_1.str)`${it.errSchemaPath}/${keyword}`);
+      if (it.opts.verbose) {
+        gen.assign((0, codegen_1._)`${err}.schema`, schemaValue);
+        gen.assign((0, codegen_1._)`${err}.data`, data);
+      }
+    });
+  }
+  exports.extendErrors = extendErrors;
+  function addError(gen, errObj) {
+    const err = gen.const("err", errObj);
+    gen.if((0, codegen_1._)`${names_1.default.vErrors} === null`, () => gen.assign(names_1.default.vErrors, (0, codegen_1._)`[${err}]`), (0, codegen_1._)`${names_1.default.vErrors}.push(${err})`);
+    gen.code((0, codegen_1._)`${names_1.default.errors}++`);
+  }
+  function returnErrors(it, errs) {
+    const { gen, validateName, schemaEnv } = it;
+    if (schemaEnv.$async) gen.throw((0, codegen_1._)`new ${it.ValidationError}(${errs})`);
+    else {
+      gen.assign((0, codegen_1._)`${validateName}.errors`, errs);
+      gen.return(false);
+    }
+  }
+  const E = {
+    keyword: new codegen_1.Name("keyword"),
+    schemaPath: new codegen_1.Name("schemaPath"),
+    params: new codegen_1.Name("params"),
+    propertyName: new codegen_1.Name("propertyName"),
+    message: new codegen_1.Name("message"),
+    schema: new codegen_1.Name("schema"),
+    parentSchema: new codegen_1.Name("parentSchema")
+  };
+  function errorObjectCode(cxt, error2, errorPaths) {
+    const { createErrors } = cxt.it;
+    if (createErrors === false) return (0, codegen_1._)`{}`;
+    return errorObject(cxt, error2, errorPaths);
+  }
+  function errorObject(cxt, error2, errorPaths = {}) {
+    const { gen, it } = cxt;
+    const keyValues = [errorInstancePath(it, errorPaths), errorSchemaPath(cxt, errorPaths)];
+    extraErrorProps(cxt, error2, keyValues);
+    return gen.object(...keyValues);
+  }
+  function errorInstancePath({ errorPath }, { instancePath }) {
+    const instPath = instancePath ? (0, codegen_1.str)`${errorPath}${(0, util_1.getErrorPath)(instancePath, util_1.Type.Str)}` : errorPath;
+    return [names_1.default.instancePath, (0, codegen_1.strConcat)(names_1.default.instancePath, instPath)];
+  }
+  function errorSchemaPath({ keyword, it: { errSchemaPath } }, { schemaPath, parentSchema }) {
+    let schPath = parentSchema ? errSchemaPath : (0, codegen_1.str)`${errSchemaPath}/${keyword}`;
+    if (schemaPath) schPath = (0, codegen_1.str)`${schPath}${(0, util_1.getErrorPath)(schemaPath, util_1.Type.Str)}`;
+    return [E.schemaPath, schPath];
+  }
+  function extraErrorProps(cxt, { params, message }, keyValues) {
+    const { keyword, data, schemaValue, it } = cxt;
+    const { opts, propertyName, topSchemaRef, schemaPath } = it;
+    keyValues.push([E.keyword, keyword], [E.params, typeof params == "function" ? params(cxt) : params || (0, codegen_1._)`{}`]);
+    if (opts.messages) keyValues.push([E.message, typeof message == "function" ? message(cxt) : message]);
+    if (opts.verbose) keyValues.push([E.schema, schemaValue], [E.parentSchema, (0, codegen_1._)`${topSchemaRef}${schemaPath}`], [names_1.default.data, data]);
+    if (propertyName) keyValues.push([E.propertyName, propertyName]);
+  }
+}));
+var require_boolSchema2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
+  const errors_1 = require_errors2();
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const boolError = { message: "boolean schema is false" };
+  function topBoolOrEmptySchema(it) {
+    const { gen, schema, validateName } = it;
+    if (schema === false) falseSchemaError(it, false);
+    else if (typeof schema == "object" && schema.$async === true) gen.return(names_1.default.data);
+    else {
+      gen.assign((0, codegen_1._)`${validateName}.errors`, null);
+      gen.return(true);
+    }
+  }
+  exports.topBoolOrEmptySchema = topBoolOrEmptySchema;
+  function boolOrEmptySchema(it, valid) {
+    const { gen, schema } = it;
+    if (schema === false) {
+      gen.var(valid, false);
+      falseSchemaError(it);
+    } else gen.var(valid, true);
+  }
+  exports.boolOrEmptySchema = boolOrEmptySchema;
+  function falseSchemaError(it, overrideAllErrors) {
+    const { gen, data } = it;
+    const cxt = {
+      gen,
+      keyword: "false schema",
+      data,
+      schema: false,
+      schemaCode: false,
+      schemaValue: false,
+      params: {},
+      it
+    };
+    (0, errors_1.reportError)(cxt, boolError, void 0, overrideAllErrors);
+  }
+}));
+var require_rules2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.getRules = exports.isJSONType = void 0;
+  const jsonTypes = /* @__PURE__ */ new Set([
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "null",
+    "object",
+    "array"
+  ]);
+  function isJSONType(x) {
+    return typeof x == "string" && jsonTypes.has(x);
+  }
+  exports.isJSONType = isJSONType;
+  function getRules() {
+    const groups = {
+      number: {
+        type: "number",
+        rules: []
+      },
+      string: {
+        type: "string",
+        rules: []
+      },
+      array: {
+        type: "array",
+        rules: []
+      },
+      object: {
+        type: "object",
+        rules: []
+      }
+    };
+    return {
+      types: {
+        ...groups,
+        integer: true,
+        boolean: true,
+        null: true
+      },
+      rules: [
+        { rules: [] },
+        groups.number,
+        groups.string,
+        groups.array,
+        groups.object
+      ],
+      post: { rules: [] },
+      all: {},
+      keywords: {}
+    };
+  }
+  exports.getRules = getRules;
+}));
+var require_applicability2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
+  function schemaHasRulesForType({ schema, self }, type) {
+    const group = self.RULES.types[type];
+    return group && group !== true && shouldUseGroup(schema, group);
+  }
+  exports.schemaHasRulesForType = schemaHasRulesForType;
+  function shouldUseGroup(schema, group) {
+    return group.rules.some((rule) => shouldUseRule(schema, rule));
+  }
+  exports.shouldUseGroup = shouldUseGroup;
+  function shouldUseRule(schema, rule) {
+    var _a3;
+    return schema[rule.keyword] !== void 0 || ((_a3 = rule.definition.implements) === null || _a3 === void 0 ? void 0 : _a3.some((kwd) => schema[kwd] !== void 0));
+  }
+  exports.shouldUseRule = shouldUseRule;
+}));
+var require_dataType2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
+  const rules_1 = require_rules2();
+  const applicability_1 = require_applicability2();
+  const errors_1 = require_errors2();
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  var DataType;
+  (function(DataType2) {
+    DataType2[DataType2["Correct"] = 0] = "Correct";
+    DataType2[DataType2["Wrong"] = 1] = "Wrong";
+  })(DataType || (exports.DataType = DataType = {}));
+  function getSchemaTypes(schema) {
+    const types = getJSONTypes(schema.type);
+    if (types.includes("null")) {
+      if (schema.nullable === false) throw new Error("type: null contradicts nullable: false");
+    } else {
+      if (!types.length && schema.nullable !== void 0) throw new Error('"nullable" cannot be used without "type"');
+      if (schema.nullable === true) types.push("null");
+    }
+    return types;
+  }
+  exports.getSchemaTypes = getSchemaTypes;
+  function getJSONTypes(ts) {
+    const types = Array.isArray(ts) ? ts : ts ? [ts] : [];
+    if (types.every(rules_1.isJSONType)) return types;
+    throw new Error("type must be JSONType or JSONType[]: " + types.join(","));
+  }
+  exports.getJSONTypes = getJSONTypes;
+  function coerceAndCheckDataType(it, types) {
+    const { gen, data, opts } = it;
+    const coerceTo = coerceToTypes(types, opts.coerceTypes);
+    const checkTypes = types.length > 0 && !(coerceTo.length === 0 && types.length === 1 && (0, applicability_1.schemaHasRulesForType)(it, types[0]));
+    if (checkTypes) {
+      const wrongType = checkDataTypes(types, data, opts.strictNumbers, DataType.Wrong);
+      gen.if(wrongType, () => {
+        if (coerceTo.length) coerceData(it, types, coerceTo);
+        else reportTypeError(it);
+      });
+    }
+    return checkTypes;
+  }
+  exports.coerceAndCheckDataType = coerceAndCheckDataType;
+  const COERCIBLE = /* @__PURE__ */ new Set([
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "null"
+  ]);
+  function coerceToTypes(types, coerceTypes) {
+    return coerceTypes ? types.filter((t) => COERCIBLE.has(t) || coerceTypes === "array" && t === "array") : [];
+  }
+  function coerceData(it, types, coerceTo) {
+    const { gen, data, opts } = it;
+    const dataType = gen.let("dataType", (0, codegen_1._)`typeof ${data}`);
+    const coerced = gen.let("coerced", (0, codegen_1._)`undefined`);
+    if (opts.coerceTypes === "array") gen.if((0, codegen_1._)`${dataType} == 'object' && Array.isArray(${data}) && ${data}.length == 1`, () => gen.assign(data, (0, codegen_1._)`${data}[0]`).assign(dataType, (0, codegen_1._)`typeof ${data}`).if(checkDataTypes(types, data, opts.strictNumbers), () => gen.assign(coerced, data)));
+    gen.if((0, codegen_1._)`${coerced} !== undefined`);
+    for (const t of coerceTo) if (COERCIBLE.has(t) || t === "array" && opts.coerceTypes === "array") coerceSpecificType(t);
+    gen.else();
+    reportTypeError(it);
+    gen.endIf();
+    gen.if((0, codegen_1._)`${coerced} !== undefined`, () => {
+      gen.assign(data, coerced);
+      assignParentData(it, coerced);
+    });
+    function coerceSpecificType(t) {
+      switch (t) {
+        case "string":
+          gen.elseIf((0, codegen_1._)`${dataType} == "number" || ${dataType} == "boolean"`).assign(coerced, (0, codegen_1._)`"" + ${data}`).elseIf((0, codegen_1._)`${data} === null`).assign(coerced, (0, codegen_1._)`""`);
+          return;
+        case "number":
+          gen.elseIf((0, codegen_1._)`${dataType} == "boolean" || ${data} === null
+              || (${dataType} == "string" && ${data} && ${data} == +${data})`).assign(coerced, (0, codegen_1._)`+${data}`);
+          return;
+        case "integer":
+          gen.elseIf((0, codegen_1._)`${dataType} === "boolean" || ${data} === null
+              || (${dataType} === "string" && ${data} && ${data} == +${data} && !(${data} % 1))`).assign(coerced, (0, codegen_1._)`+${data}`);
+          return;
+        case "boolean":
+          gen.elseIf((0, codegen_1._)`${data} === "false" || ${data} === 0 || ${data} === null`).assign(coerced, false).elseIf((0, codegen_1._)`${data} === "true" || ${data} === 1`).assign(coerced, true);
+          return;
+        case "null":
+          gen.elseIf((0, codegen_1._)`${data} === "" || ${data} === 0 || ${data} === false`);
+          gen.assign(coerced, null);
+          return;
+        case "array":
+          gen.elseIf((0, codegen_1._)`${dataType} === "string" || ${dataType} === "number"
+              || ${dataType} === "boolean" || ${data} === null`).assign(coerced, (0, codegen_1._)`[${data}]`);
+      }
+    }
+  }
+  function assignParentData({ gen, parentData, parentDataProperty }, expr) {
+    gen.if((0, codegen_1._)`${parentData} !== undefined`, () => gen.assign((0, codegen_1._)`${parentData}[${parentDataProperty}]`, expr));
+  }
+  function checkDataType(dataType, data, strictNums, correct = DataType.Correct) {
+    const EQ = correct === DataType.Correct ? codegen_1.operators.EQ : codegen_1.operators.NEQ;
+    let cond;
+    switch (dataType) {
+      case "null":
+        return (0, codegen_1._)`${data} ${EQ} null`;
+      case "array":
+        cond = (0, codegen_1._)`Array.isArray(${data})`;
+        break;
+      case "object":
+        cond = (0, codegen_1._)`${data} && typeof ${data} == "object" && !Array.isArray(${data})`;
+        break;
+      case "integer":
+        cond = numCond((0, codegen_1._)`!(${data} % 1) && !isNaN(${data})`);
+        break;
+      case "number":
+        cond = numCond();
+        break;
+      default:
+        return (0, codegen_1._)`typeof ${data} ${EQ} ${dataType}`;
+    }
+    return correct === DataType.Correct ? cond : (0, codegen_1.not)(cond);
+    function numCond(_cond = codegen_1.nil) {
+      return (0, codegen_1.and)((0, codegen_1._)`typeof ${data} == "number"`, _cond, strictNums ? (0, codegen_1._)`isFinite(${data})` : codegen_1.nil);
+    }
+  }
+  exports.checkDataType = checkDataType;
+  function checkDataTypes(dataTypes, data, strictNums, correct) {
+    if (dataTypes.length === 1) return checkDataType(dataTypes[0], data, strictNums, correct);
+    let cond;
+    const types = (0, util_1.toHash)(dataTypes);
+    if (types.array && types.object) {
+      const notObj = (0, codegen_1._)`typeof ${data} != "object"`;
+      cond = types.null ? notObj : (0, codegen_1._)`!${data} || ${notObj}`;
+      delete types.null;
+      delete types.array;
+      delete types.object;
+    } else cond = codegen_1.nil;
+    if (types.number) delete types.integer;
+    for (const t in types) cond = (0, codegen_1.and)(cond, checkDataType(t, data, strictNums, correct));
+    return cond;
+  }
+  exports.checkDataTypes = checkDataTypes;
+  const typeError = {
+    message: ({ schema }) => `must be ${schema}`,
+    params: ({ schema, schemaValue }) => typeof schema == "string" ? (0, codegen_1._)`{type: ${schema}}` : (0, codegen_1._)`{type: ${schemaValue}}`
+  };
+  function reportTypeError(it) {
+    const cxt = getTypeErrorContext(it);
+    (0, errors_1.reportError)(cxt, typeError);
+  }
+  exports.reportTypeError = reportTypeError;
+  function getTypeErrorContext(it) {
+    const { gen, data, schema } = it;
+    const schemaCode = (0, util_1.schemaRefOrVal)(it, schema, "type");
+    return {
+      gen,
+      keyword: "type",
+      data,
+      schema: schema.type,
+      schemaCode,
+      schemaValue: schemaCode,
+      parentSchema: schema,
+      params: {},
+      it
+    };
+  }
+}));
+var require_defaults2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.assignDefaults = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  function assignDefaults(it, ty) {
+    const { properties, items } = it.schema;
+    if (ty === "object" && properties) for (const key in properties) assignDefault(it, key, properties[key].default);
+    else if (ty === "array" && Array.isArray(items)) items.forEach((sch, i) => assignDefault(it, i, sch.default));
+  }
+  exports.assignDefaults = assignDefaults;
+  function assignDefault(it, prop, defaultValue) {
+    const { gen, compositeRule, data, opts } = it;
+    if (defaultValue === void 0) return;
+    const childData = (0, codegen_1._)`${data}${(0, codegen_1.getProperty)(prop)}`;
+    if (compositeRule) {
+      (0, util_1.checkStrictMode)(it, `default is ignored for: ${childData}`);
+      return;
+    }
+    let condition = (0, codegen_1._)`${childData} === undefined`;
+    if (opts.useDefaults === "empty") condition = (0, codegen_1._)`${condition} || ${childData} === null || ${childData} === ""`;
+    gen.if(condition, (0, codegen_1._)`${childData} = ${(0, codegen_1.stringify)(defaultValue)}`);
+  }
+}));
+var require_code3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const names_1 = require_names2();
+  const util_2 = require_util2();
+  function checkReportMissingProp(cxt, prop) {
+    const { gen, data, it } = cxt;
+    gen.if(noPropertyInData(gen, data, prop, it.opts.ownProperties), () => {
+      cxt.setParams({ missingProperty: (0, codegen_1._)`${prop}` }, true);
+      cxt.error();
+    });
+  }
+  exports.checkReportMissingProp = checkReportMissingProp;
+  function checkMissingProp({ gen, data, it: { opts } }, properties, missing) {
+    return (0, codegen_1.or)(...properties.map((prop) => (0, codegen_1.and)(noPropertyInData(gen, data, prop, opts.ownProperties), (0, codegen_1._)`${missing} = ${prop}`)));
+  }
+  exports.checkMissingProp = checkMissingProp;
+  function reportMissingProp(cxt, missing) {
+    cxt.setParams({ missingProperty: missing }, true);
+    cxt.error();
+  }
+  exports.reportMissingProp = reportMissingProp;
+  function hasPropFunc(gen) {
+    return gen.scopeValue("func", {
+      ref: Object.prototype.hasOwnProperty,
+      code: (0, codegen_1._)`Object.prototype.hasOwnProperty`
+    });
+  }
+  exports.hasPropFunc = hasPropFunc;
+  function isOwnProperty(gen, data, property) {
+    return (0, codegen_1._)`${hasPropFunc(gen)}.call(${data}, ${property})`;
+  }
+  exports.isOwnProperty = isOwnProperty;
+  function propertyInData(gen, data, property, ownProperties) {
+    const cond = (0, codegen_1._)`${data}${(0, codegen_1.getProperty)(property)} !== undefined`;
+    return ownProperties ? (0, codegen_1._)`${cond} && ${isOwnProperty(gen, data, property)}` : cond;
+  }
+  exports.propertyInData = propertyInData;
+  function noPropertyInData(gen, data, property, ownProperties) {
+    const cond = (0, codegen_1._)`${data}${(0, codegen_1.getProperty)(property)} === undefined`;
+    return ownProperties ? (0, codegen_1.or)(cond, (0, codegen_1.not)(isOwnProperty(gen, data, property))) : cond;
+  }
+  exports.noPropertyInData = noPropertyInData;
+  function allSchemaProperties(schemaMap) {
+    return schemaMap ? Object.keys(schemaMap).filter((p) => p !== "__proto__") : [];
+  }
+  exports.allSchemaProperties = allSchemaProperties;
+  function schemaProperties(it, schemaMap) {
+    return allSchemaProperties(schemaMap).filter((p) => !(0, util_1.alwaysValidSchema)(it, schemaMap[p]));
+  }
+  exports.schemaProperties = schemaProperties;
+  function callValidateCode({ schemaCode, data, it: { gen, topSchemaRef, schemaPath, errorPath }, it }, func, context, passSchema) {
+    const dataAndSchema = passSchema ? (0, codegen_1._)`${schemaCode}, ${data}, ${topSchemaRef}${schemaPath}` : data;
+    const valCxt = [
+      [names_1.default.instancePath, (0, codegen_1.strConcat)(names_1.default.instancePath, errorPath)],
+      [names_1.default.parentData, it.parentData],
+      [names_1.default.parentDataProperty, it.parentDataProperty],
+      [names_1.default.rootData, names_1.default.rootData]
+    ];
+    if (it.opts.dynamicRef) valCxt.push([names_1.default.dynamicAnchors, names_1.default.dynamicAnchors]);
+    const args = (0, codegen_1._)`${dataAndSchema}, ${gen.object(...valCxt)}`;
+    return context !== codegen_1.nil ? (0, codegen_1._)`${func}.call(${context}, ${args})` : (0, codegen_1._)`${func}(${args})`;
+  }
+  exports.callValidateCode = callValidateCode;
+  const newRegExp = (0, codegen_1._)`new RegExp`;
+  function usePattern({ gen, it: { opts } }, pattern) {
+    const u = opts.unicodeRegExp ? "u" : "";
+    const { regExp } = opts.code;
+    const rx = regExp(pattern, u);
+    return gen.scopeValue("pattern", {
+      key: rx.toString(),
+      ref: rx,
+      code: (0, codegen_1._)`${regExp.code === "new RegExp" ? newRegExp : (0, util_2.useFunc)(gen, regExp)}(${pattern}, ${u})`
+    });
+  }
+  exports.usePattern = usePattern;
+  function validateArray(cxt) {
+    const { gen, data, keyword, it } = cxt;
+    const valid = gen.name("valid");
+    if (it.allErrors) {
+      const validArr = gen.let("valid", true);
+      validateItems(() => gen.assign(validArr, false));
+      return validArr;
+    }
+    gen.var(valid, true);
+    validateItems(() => gen.break());
+    return valid;
+    function validateItems(notValid) {
+      const len = gen.const("len", (0, codegen_1._)`${data}.length`);
+      gen.forRange("i", 0, len, (i) => {
+        cxt.subschema({
+          keyword,
+          dataProp: i,
+          dataPropType: util_1.Type.Num
+        }, valid);
+        gen.if((0, codegen_1.not)(valid), notValid);
+      });
+    }
+  }
+  exports.validateArray = validateArray;
+  function validateUnion(cxt) {
+    const { gen, schema, keyword, it } = cxt;
+    if (!Array.isArray(schema)) throw new Error("ajv implementation error");
+    if (schema.some((sch) => (0, util_1.alwaysValidSchema)(it, sch)) && !it.opts.unevaluated) return;
+    const valid = gen.let("valid", false);
+    const schValid = gen.name("_valid");
+    gen.block(() => schema.forEach((_sch, i) => {
+      const schCxt = cxt.subschema({
+        keyword,
+        schemaProp: i,
+        compositeRule: true
+      }, schValid);
+      gen.assign(valid, (0, codegen_1._)`${valid} || ${schValid}`);
+      if (!cxt.mergeValidEvaluated(schCxt, schValid)) gen.if((0, codegen_1.not)(valid));
+    }));
+    cxt.result(valid, () => cxt.reset(), () => cxt.error(true));
+  }
+  exports.validateUnion = validateUnion;
+}));
+var require_keyword2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const code_1 = require_code3();
+  const errors_1 = require_errors2();
+  function macroKeywordCode(cxt, def) {
+    const { gen, keyword, schema, parentSchema, it } = cxt;
+    const macroSchema = def.macro.call(it.self, schema, parentSchema, it);
+    const schemaRef = useKeyword(gen, keyword, macroSchema);
+    if (it.opts.validateSchema !== false) it.self.validateSchema(macroSchema, true);
+    const valid = gen.name("valid");
+    cxt.subschema({
+      schema: macroSchema,
+      schemaPath: codegen_1.nil,
+      errSchemaPath: `${it.errSchemaPath}/${keyword}`,
+      topSchemaRef: schemaRef,
+      compositeRule: true
+    }, valid);
+    cxt.pass(valid, () => cxt.error(true));
+  }
+  exports.macroKeywordCode = macroKeywordCode;
+  function funcKeywordCode(cxt, def) {
+    var _a3;
+    const { gen, keyword, schema, parentSchema, $data, it } = cxt;
+    checkAsyncKeyword(it, def);
+    const validateRef = useKeyword(gen, keyword, !$data && def.compile ? def.compile.call(it.self, schema, parentSchema, it) : def.validate);
+    const valid = gen.let("valid");
+    cxt.block$data(valid, validateKeyword);
+    cxt.ok((_a3 = def.valid) !== null && _a3 !== void 0 ? _a3 : valid);
+    function validateKeyword() {
+      if (def.errors === false) {
+        assignValid();
+        if (def.modifying) modifyData(cxt);
+        reportErrs(() => cxt.error());
+      } else {
+        const ruleErrs = def.async ? validateAsync2() : validateSync();
+        if (def.modifying) modifyData(cxt);
+        reportErrs(() => addErrs(cxt, ruleErrs));
+      }
+    }
+    function validateAsync2() {
+      const ruleErrs = gen.let("ruleErrs", null);
+      gen.try(() => assignValid((0, codegen_1._)`await `), (e) => gen.assign(valid, false).if((0, codegen_1._)`${e} instanceof ${it.ValidationError}`, () => gen.assign(ruleErrs, (0, codegen_1._)`${e}.errors`), () => gen.throw(e)));
+      return ruleErrs;
+    }
+    function validateSync() {
+      const validateErrs = (0, codegen_1._)`${validateRef}.errors`;
+      gen.assign(validateErrs, null);
+      assignValid(codegen_1.nil);
+      return validateErrs;
+    }
+    function assignValid(_await = def.async ? (0, codegen_1._)`await ` : codegen_1.nil) {
+      const passCxt = it.opts.passContext ? names_1.default.this : names_1.default.self;
+      const passSchema = !("compile" in def && !$data || def.schema === false);
+      gen.assign(valid, (0, codegen_1._)`${_await}${(0, code_1.callValidateCode)(cxt, validateRef, passCxt, passSchema)}`, def.modifying);
+    }
+    function reportErrs(errors) {
+      var _a$1;
+      gen.if((0, codegen_1.not)((_a$1 = def.valid) !== null && _a$1 !== void 0 ? _a$1 : valid), errors);
+    }
+  }
+  exports.funcKeywordCode = funcKeywordCode;
+  function modifyData(cxt) {
+    const { gen, data, it } = cxt;
+    gen.if(it.parentData, () => gen.assign(data, (0, codegen_1._)`${it.parentData}[${it.parentDataProperty}]`));
+  }
+  function addErrs(cxt, errs) {
+    const { gen } = cxt;
+    gen.if((0, codegen_1._)`Array.isArray(${errs})`, () => {
+      gen.assign(names_1.default.vErrors, (0, codegen_1._)`${names_1.default.vErrors} === null ? ${errs} : ${names_1.default.vErrors}.concat(${errs})`).assign(names_1.default.errors, (0, codegen_1._)`${names_1.default.vErrors}.length`);
+      (0, errors_1.extendErrors)(cxt);
+    }, () => cxt.error());
+  }
+  function checkAsyncKeyword({ schemaEnv }, def) {
+    if (def.async && !schemaEnv.$async) throw new Error("async keyword in sync schema");
+  }
+  function useKeyword(gen, keyword, result) {
+    if (result === void 0) throw new Error(`keyword "${keyword}" failed to compile`);
+    return gen.scopeValue("keyword", typeof result == "function" ? { ref: result } : {
+      ref: result,
+      code: (0, codegen_1.stringify)(result)
+    });
+  }
+  function validSchemaType(schema, schemaType, allowUndefined = false) {
+    return !schemaType.length || schemaType.some((st) => st === "array" ? Array.isArray(schema) : st === "object" ? schema && typeof schema == "object" && !Array.isArray(schema) : typeof schema == st || allowUndefined && typeof schema == "undefined");
+  }
+  exports.validSchemaType = validSchemaType;
+  function validateKeywordUsage({ schema, opts, self, errSchemaPath }, def, keyword) {
+    if (Array.isArray(def.keyword) ? !def.keyword.includes(keyword) : def.keyword !== keyword) throw new Error("ajv implementation error");
+    const deps = def.dependencies;
+    if (deps === null || deps === void 0 ? void 0 : deps.some((kwd) => !Object.prototype.hasOwnProperty.call(schema, kwd))) throw new Error(`parent schema must have dependencies of ${keyword}: ${deps.join(",")}`);
+    if (def.validateSchema) {
+      if (!def.validateSchema(schema[keyword])) {
+        const msg = `keyword "${keyword}" value is invalid at path "${errSchemaPath}": ` + self.errorsText(def.validateSchema.errors);
+        if (opts.validateSchema === "log") self.logger.error(msg);
+        else throw new Error(msg);
+      }
+    }
+  }
+  exports.validateKeywordUsage = validateKeywordUsage;
+}));
+var require_subschema2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  function getSubschema(it, { keyword, schemaProp, schema, schemaPath, errSchemaPath, topSchemaRef }) {
+    if (keyword !== void 0 && schema !== void 0) throw new Error('both "keyword" and "schema" passed, only one allowed');
+    if (keyword !== void 0) {
+      const sch = it.schema[keyword];
+      return schemaProp === void 0 ? {
+        schema: sch,
+        schemaPath: (0, codegen_1._)`${it.schemaPath}${(0, codegen_1.getProperty)(keyword)}`,
+        errSchemaPath: `${it.errSchemaPath}/${keyword}`
+      } : {
+        schema: sch[schemaProp],
+        schemaPath: (0, codegen_1._)`${it.schemaPath}${(0, codegen_1.getProperty)(keyword)}${(0, codegen_1.getProperty)(schemaProp)}`,
+        errSchemaPath: `${it.errSchemaPath}/${keyword}/${(0, util_1.escapeFragment)(schemaProp)}`
+      };
+    }
+    if (schema !== void 0) {
+      if (schemaPath === void 0 || errSchemaPath === void 0 || topSchemaRef === void 0) throw new Error('"schemaPath", "errSchemaPath" and "topSchemaRef" are required with "schema"');
+      return {
+        schema,
+        schemaPath,
+        topSchemaRef,
+        errSchemaPath
+      };
+    }
+    throw new Error('either "keyword" or "schema" must be passed');
+  }
+  exports.getSubschema = getSubschema;
+  function extendSubschemaData(subschema, it, { dataProp, dataPropType: dpType, data, dataTypes, propertyName }) {
+    if (data !== void 0 && dataProp !== void 0) throw new Error('both "data" and "dataProp" passed, only one allowed');
+    const { gen } = it;
+    if (dataProp !== void 0) {
+      const { errorPath, dataPathArr, opts } = it;
+      dataContextProps(gen.let("data", (0, codegen_1._)`${it.data}${(0, codegen_1.getProperty)(dataProp)}`, true));
+      subschema.errorPath = (0, codegen_1.str)`${errorPath}${(0, util_1.getErrorPath)(dataProp, dpType, opts.jsPropertySyntax)}`;
+      subschema.parentDataProperty = (0, codegen_1._)`${dataProp}`;
+      subschema.dataPathArr = [...dataPathArr, subschema.parentDataProperty];
+    }
+    if (data !== void 0) {
+      dataContextProps(data instanceof codegen_1.Name ? data : gen.let("data", data, true));
+      if (propertyName !== void 0) subschema.propertyName = propertyName;
+    }
+    if (dataTypes) subschema.dataTypes = dataTypes;
+    function dataContextProps(_nextData) {
+      subschema.data = _nextData;
+      subschema.dataLevel = it.dataLevel + 1;
+      subschema.dataTypes = [];
+      it.definedProperties = /* @__PURE__ */ new Set();
+      subschema.parentData = it.data;
+      subschema.dataNames = [...it.dataNames, _nextData];
+    }
+  }
+  exports.extendSubschemaData = extendSubschemaData;
+  function extendSubschemaMode(subschema, { jtdDiscriminator, jtdMetadata, compositeRule, createErrors, allErrors }) {
+    if (compositeRule !== void 0) subschema.compositeRule = compositeRule;
+    if (createErrors !== void 0) subschema.createErrors = createErrors;
+    if (allErrors !== void 0) subschema.allErrors = allErrors;
+    subschema.jtdDiscriminator = jtdDiscriminator;
+    subschema.jtdMetadata = jtdMetadata;
+  }
+  exports.extendSubschemaMode = extendSubschemaMode;
+}));
+var require_fast_deep_equal2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = function equal(a, b) {
+    if (a === b) return true;
+    if (a && b && typeof a == "object" && typeof b == "object") {
+      if (a.constructor !== b.constructor) return false;
+      var length, i, keys;
+      if (Array.isArray(a)) {
+        length = a.length;
+        if (length != b.length) return false;
+        for (i = length; i-- !== 0; ) if (!equal(a[i], b[i])) return false;
+        return true;
+      }
+      if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
+      if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
+      if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+      keys = Object.keys(a);
+      length = keys.length;
+      if (length !== Object.keys(b).length) return false;
+      for (i = length; i-- !== 0; ) if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+      for (i = length; i-- !== 0; ) {
+        var key = keys[i];
+        if (!equal(a[key], b[key])) return false;
+      }
+      return true;
+    }
+    return a !== a && b !== b;
+  };
+}));
+var require_json_schema_traverse2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  var traverse = module.exports = function(schema, opts, cb) {
+    if (typeof opts == "function") {
+      cb = opts;
+      opts = {};
+    }
+    cb = opts.cb || cb;
+    var pre = typeof cb == "function" ? cb : cb.pre || function() {
+    };
+    var post = cb.post || function() {
+    };
+    _traverse(opts, pre, post, schema, "", schema);
+  };
+  traverse.keywords = {
+    additionalItems: true,
+    items: true,
+    contains: true,
+    additionalProperties: true,
+    propertyNames: true,
+    not: true,
+    if: true,
+    then: true,
+    else: true
+  };
+  traverse.arrayKeywords = {
+    items: true,
+    allOf: true,
+    anyOf: true,
+    oneOf: true
+  };
+  traverse.propsKeywords = {
+    $defs: true,
+    definitions: true,
+    properties: true,
+    patternProperties: true,
+    dependencies: true
+  };
+  traverse.skipKeywords = {
+    default: true,
+    enum: true,
+    const: true,
+    required: true,
+    maximum: true,
+    minimum: true,
+    exclusiveMaximum: true,
+    exclusiveMinimum: true,
+    multipleOf: true,
+    maxLength: true,
+    minLength: true,
+    pattern: true,
+    format: true,
+    maxItems: true,
+    minItems: true,
+    uniqueItems: true,
+    maxProperties: true,
+    minProperties: true
+  };
+  function _traverse(opts, pre, post, schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex) {
+    if (schema && typeof schema == "object" && !Array.isArray(schema)) {
+      pre(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
+      for (var key in schema) {
+        var sch = schema[key];
+        if (Array.isArray(sch)) {
+          if (key in traverse.arrayKeywords) for (var i = 0; i < sch.length; i++) _traverse(opts, pre, post, sch[i], jsonPtr + "/" + key + "/" + i, rootSchema, jsonPtr, key, schema, i);
+        } else if (key in traverse.propsKeywords) {
+          if (sch && typeof sch == "object") for (var prop in sch) _traverse(opts, pre, post, sch[prop], jsonPtr + "/" + key + "/" + escapeJsonPtr(prop), rootSchema, jsonPtr, key, schema, prop);
+        } else if (key in traverse.keywords || opts.allKeys && !(key in traverse.skipKeywords)) _traverse(opts, pre, post, sch, jsonPtr + "/" + key, rootSchema, jsonPtr, key, schema);
+      }
+      post(schema, jsonPtr, rootSchema, parentJsonPtr, parentKeyword, parentSchema, keyIndex);
+    }
+  }
+  function escapeJsonPtr(str) {
+    return str.replace(/~/g, "~0").replace(/\//g, "~1");
+  }
+}));
+var require_resolve2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
+  const util_1 = require_util2();
+  const equal = require_fast_deep_equal2();
+  const traverse = require_json_schema_traverse2();
+  const SIMPLE_INLINED = /* @__PURE__ */ new Set([
+    "type",
+    "format",
+    "pattern",
+    "maxLength",
+    "minLength",
+    "maxProperties",
+    "minProperties",
+    "maxItems",
+    "minItems",
+    "maximum",
+    "minimum",
+    "uniqueItems",
+    "multipleOf",
+    "required",
+    "enum",
+    "const"
+  ]);
+  function inlineRef(schema, limit = true) {
+    if (typeof schema == "boolean") return true;
+    if (limit === true) return !hasRef(schema);
+    if (!limit) return false;
+    return countKeys(schema) <= limit;
+  }
+  exports.inlineRef = inlineRef;
+  const REF_KEYWORDS = /* @__PURE__ */ new Set([
+    "$ref",
+    "$recursiveRef",
+    "$recursiveAnchor",
+    "$dynamicRef",
+    "$dynamicAnchor"
+  ]);
+  function hasRef(schema) {
+    for (const key in schema) {
+      if (REF_KEYWORDS.has(key)) return true;
+      const sch = schema[key];
+      if (Array.isArray(sch) && sch.some(hasRef)) return true;
+      if (typeof sch == "object" && hasRef(sch)) return true;
+    }
+    return false;
+  }
+  function countKeys(schema) {
+    let count = 0;
+    for (const key in schema) {
+      if (key === "$ref") return Infinity;
+      count++;
+      if (SIMPLE_INLINED.has(key)) continue;
+      if (typeof schema[key] == "object") (0, util_1.eachItem)(schema[key], (sch) => count += countKeys(sch));
+      if (count === Infinity) return Infinity;
+    }
+    return count;
+  }
+  function getFullPath(resolver, id = "", normalize) {
+    if (normalize !== false) id = normalizeId(id);
+    return _getFullPath(resolver, resolver.parse(id));
+  }
+  exports.getFullPath = getFullPath;
+  function _getFullPath(resolver, p) {
+    return resolver.serialize(p).split("#")[0] + "#";
+  }
+  exports._getFullPath = _getFullPath;
+  const TRAILING_SLASH_HASH = /#\/?$/;
+  function normalizeId(id) {
+    return id ? id.replace(TRAILING_SLASH_HASH, "") : "";
+  }
+  exports.normalizeId = normalizeId;
+  function resolveUrl(resolver, baseId, id) {
+    id = normalizeId(id);
+    return resolver.resolve(baseId, id);
+  }
+  exports.resolveUrl = resolveUrl;
+  const ANCHOR = /^[a-z_][-a-z0-9._]*$/i;
+  function getSchemaRefs(schema, baseId) {
+    if (typeof schema == "boolean") return {};
+    const { schemaId, uriResolver } = this.opts;
+    const schId = normalizeId(schema[schemaId] || baseId);
+    const baseIds = { "": schId };
+    const pathPrefix = getFullPath(uriResolver, schId, false);
+    const localRefs = {};
+    const schemaRefs = /* @__PURE__ */ new Set();
+    traverse(schema, { allKeys: true }, (sch, jsonPtr, _, parentJsonPtr) => {
+      if (parentJsonPtr === void 0) return;
+      const fullPath = pathPrefix + jsonPtr;
+      let innerBaseId = baseIds[parentJsonPtr];
+      if (typeof sch[schemaId] == "string") innerBaseId = addRef.call(this, sch[schemaId]);
+      addAnchor.call(this, sch.$anchor);
+      addAnchor.call(this, sch.$dynamicAnchor);
+      baseIds[jsonPtr] = innerBaseId;
+      function addRef(ref) {
+        const _resolve = this.opts.uriResolver.resolve;
+        ref = normalizeId(innerBaseId ? _resolve(innerBaseId, ref) : ref);
+        if (schemaRefs.has(ref)) throw ambiguos(ref);
+        schemaRefs.add(ref);
+        let schOrRef = this.refs[ref];
+        if (typeof schOrRef == "string") schOrRef = this.refs[schOrRef];
+        if (typeof schOrRef == "object") checkAmbiguosRef(sch, schOrRef.schema, ref);
+        else if (ref !== normalizeId(fullPath)) if (ref[0] === "#") {
+          checkAmbiguosRef(sch, localRefs[ref], ref);
+          localRefs[ref] = sch;
+        } else this.refs[ref] = fullPath;
+        return ref;
+      }
+      function addAnchor(anchor2) {
+        if (typeof anchor2 == "string") {
+          if (!ANCHOR.test(anchor2)) throw new Error(`invalid anchor "${anchor2}"`);
+          addRef.call(this, `#${anchor2}`);
+        }
+      }
+    });
+    return localRefs;
+    function checkAmbiguosRef(sch1, sch2, ref) {
+      if (sch2 !== void 0 && !equal(sch1, sch2)) throw ambiguos(ref);
+    }
+    function ambiguos(ref) {
+      return /* @__PURE__ */ new Error(`reference "${ref}" resolves to more than one schema`);
+    }
+  }
+  exports.getSchemaRefs = getSchemaRefs;
+}));
+var require_validate2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
+  const boolSchema_1 = require_boolSchema2();
+  const dataType_1 = require_dataType2();
+  const applicability_1 = require_applicability2();
+  const dataType_2 = require_dataType2();
+  const defaults_1 = require_defaults2();
+  const keyword_1 = require_keyword2();
+  const subschema_1 = require_subschema2();
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const resolve_1 = require_resolve2();
+  const util_1 = require_util2();
+  const errors_1 = require_errors2();
+  function validateFunctionCode(it) {
+    if (isSchemaObj(it)) {
+      checkKeywords(it);
+      if (schemaCxtHasRules(it)) {
+        topSchemaObjCode(it);
+        return;
+      }
+    }
+    validateFunction(it, () => (0, boolSchema_1.topBoolOrEmptySchema)(it));
+  }
+  exports.validateFunctionCode = validateFunctionCode;
+  function validateFunction({ gen, validateName, schema, schemaEnv, opts }, body) {
+    if (opts.code.es5) gen.func(validateName, (0, codegen_1._)`${names_1.default.data}, ${names_1.default.valCxt}`, schemaEnv.$async, () => {
+      gen.code((0, codegen_1._)`"use strict"; ${funcSourceUrl(schema, opts)}`);
+      destructureValCxtES5(gen, opts);
+      gen.code(body);
+    });
+    else gen.func(validateName, (0, codegen_1._)`${names_1.default.data}, ${destructureValCxt(opts)}`, schemaEnv.$async, () => gen.code(funcSourceUrl(schema, opts)).code(body));
+  }
+  function destructureValCxt(opts) {
+    return (0, codegen_1._)`{${names_1.default.instancePath}="", ${names_1.default.parentData}, ${names_1.default.parentDataProperty}, ${names_1.default.rootData}=${names_1.default.data}${opts.dynamicRef ? (0, codegen_1._)`, ${names_1.default.dynamicAnchors}={}` : codegen_1.nil}}={}`;
+  }
+  function destructureValCxtES5(gen, opts) {
+    gen.if(names_1.default.valCxt, () => {
+      gen.var(names_1.default.instancePath, (0, codegen_1._)`${names_1.default.valCxt}.${names_1.default.instancePath}`);
+      gen.var(names_1.default.parentData, (0, codegen_1._)`${names_1.default.valCxt}.${names_1.default.parentData}`);
+      gen.var(names_1.default.parentDataProperty, (0, codegen_1._)`${names_1.default.valCxt}.${names_1.default.parentDataProperty}`);
+      gen.var(names_1.default.rootData, (0, codegen_1._)`${names_1.default.valCxt}.${names_1.default.rootData}`);
+      if (opts.dynamicRef) gen.var(names_1.default.dynamicAnchors, (0, codegen_1._)`${names_1.default.valCxt}.${names_1.default.dynamicAnchors}`);
+    }, () => {
+      gen.var(names_1.default.instancePath, (0, codegen_1._)`""`);
+      gen.var(names_1.default.parentData, (0, codegen_1._)`undefined`);
+      gen.var(names_1.default.parentDataProperty, (0, codegen_1._)`undefined`);
+      gen.var(names_1.default.rootData, names_1.default.data);
+      if (opts.dynamicRef) gen.var(names_1.default.dynamicAnchors, (0, codegen_1._)`{}`);
+    });
+  }
+  function topSchemaObjCode(it) {
+    const { schema, opts, gen } = it;
+    validateFunction(it, () => {
+      if (opts.$comment && schema.$comment) commentKeyword(it);
+      checkNoDefault(it);
+      gen.let(names_1.default.vErrors, null);
+      gen.let(names_1.default.errors, 0);
+      if (opts.unevaluated) resetEvaluated(it);
+      typeAndKeywords(it);
+      returnResults(it);
+    });
+  }
+  function resetEvaluated(it) {
+    const { gen, validateName } = it;
+    it.evaluated = gen.const("evaluated", (0, codegen_1._)`${validateName}.evaluated`);
+    gen.if((0, codegen_1._)`${it.evaluated}.dynamicProps`, () => gen.assign((0, codegen_1._)`${it.evaluated}.props`, (0, codegen_1._)`undefined`));
+    gen.if((0, codegen_1._)`${it.evaluated}.dynamicItems`, () => gen.assign((0, codegen_1._)`${it.evaluated}.items`, (0, codegen_1._)`undefined`));
+  }
+  function funcSourceUrl(schema, opts) {
+    const schId = typeof schema == "object" && schema[opts.schemaId];
+    return schId && (opts.code.source || opts.code.process) ? (0, codegen_1._)`/*# sourceURL=${schId} */` : codegen_1.nil;
+  }
+  function subschemaCode(it, valid) {
+    if (isSchemaObj(it)) {
+      checkKeywords(it);
+      if (schemaCxtHasRules(it)) {
+        subSchemaObjCode(it, valid);
+        return;
+      }
+    }
+    (0, boolSchema_1.boolOrEmptySchema)(it, valid);
+  }
+  function schemaCxtHasRules({ schema, self }) {
+    if (typeof schema == "boolean") return !schema;
+    for (const key in schema) if (self.RULES.all[key]) return true;
+    return false;
+  }
+  function isSchemaObj(it) {
+    return typeof it.schema != "boolean";
+  }
+  function subSchemaObjCode(it, valid) {
+    const { schema, gen, opts } = it;
+    if (opts.$comment && schema.$comment) commentKeyword(it);
+    updateContext(it);
+    checkAsyncSchema(it);
+    const errsCount = gen.const("_errs", names_1.default.errors);
+    typeAndKeywords(it, errsCount);
+    gen.var(valid, (0, codegen_1._)`${errsCount} === ${names_1.default.errors}`);
+  }
+  function checkKeywords(it) {
+    (0, util_1.checkUnknownRules)(it);
+    checkRefsAndKeywords(it);
+  }
+  function typeAndKeywords(it, errsCount) {
+    if (it.opts.jtd) return schemaKeywords(it, [], false, errsCount);
+    const types = (0, dataType_1.getSchemaTypes)(it.schema);
+    schemaKeywords(it, types, !(0, dataType_1.coerceAndCheckDataType)(it, types), errsCount);
+  }
+  function checkRefsAndKeywords(it) {
+    const { schema, errSchemaPath, opts, self } = it;
+    if (schema.$ref && opts.ignoreKeywordsWithRef && (0, util_1.schemaHasRulesButRef)(schema, self.RULES)) self.logger.warn(`$ref: keywords ignored in schema at path "${errSchemaPath}"`);
+  }
+  function checkNoDefault(it) {
+    const { schema, opts } = it;
+    if (schema.default !== void 0 && opts.useDefaults && opts.strictSchema) (0, util_1.checkStrictMode)(it, "default is ignored in the schema root");
+  }
+  function updateContext(it) {
+    const schId = it.schema[it.opts.schemaId];
+    if (schId) it.baseId = (0, resolve_1.resolveUrl)(it.opts.uriResolver, it.baseId, schId);
+  }
+  function checkAsyncSchema(it) {
+    if (it.schema.$async && !it.schemaEnv.$async) throw new Error("async schema in sync schema");
+  }
+  function commentKeyword({ gen, schemaEnv, schema, errSchemaPath, opts }) {
+    const msg = schema.$comment;
+    if (opts.$comment === true) gen.code((0, codegen_1._)`${names_1.default.self}.logger.log(${msg})`);
+    else if (typeof opts.$comment == "function") {
+      const schemaPath = (0, codegen_1.str)`${errSchemaPath}/$comment`;
+      const rootName = gen.scopeValue("root", { ref: schemaEnv.root });
+      gen.code((0, codegen_1._)`${names_1.default.self}.opts.$comment(${msg}, ${schemaPath}, ${rootName}.schema)`);
+    }
+  }
+  function returnResults(it) {
+    const { gen, schemaEnv, validateName, ValidationError, opts } = it;
+    if (schemaEnv.$async) gen.if((0, codegen_1._)`${names_1.default.errors} === 0`, () => gen.return(names_1.default.data), () => gen.throw((0, codegen_1._)`new ${ValidationError}(${names_1.default.vErrors})`));
+    else {
+      gen.assign((0, codegen_1._)`${validateName}.errors`, names_1.default.vErrors);
+      if (opts.unevaluated) assignEvaluated(it);
+      gen.return((0, codegen_1._)`${names_1.default.errors} === 0`);
+    }
+  }
+  function assignEvaluated({ gen, evaluated, props, items }) {
+    if (props instanceof codegen_1.Name) gen.assign((0, codegen_1._)`${evaluated}.props`, props);
+    if (items instanceof codegen_1.Name) gen.assign((0, codegen_1._)`${evaluated}.items`, items);
+  }
+  function schemaKeywords(it, types, typeErrors, errsCount) {
+    const { gen, schema, data, allErrors, opts, self } = it;
+    const { RULES } = self;
+    if (schema.$ref && (opts.ignoreKeywordsWithRef || !(0, util_1.schemaHasRulesButRef)(schema, RULES))) {
+      gen.block(() => keywordCode(it, "$ref", RULES.all.$ref.definition));
+      return;
+    }
+    if (!opts.jtd) checkStrictTypes(it, types);
+    gen.block(() => {
+      for (const group of RULES.rules) groupKeywords(group);
+      groupKeywords(RULES.post);
+    });
+    function groupKeywords(group) {
+      if (!(0, applicability_1.shouldUseGroup)(schema, group)) return;
+      if (group.type) {
+        gen.if((0, dataType_2.checkDataType)(group.type, data, opts.strictNumbers));
+        iterateKeywords(it, group);
+        if (types.length === 1 && types[0] === group.type && typeErrors) {
+          gen.else();
+          (0, dataType_2.reportTypeError)(it);
+        }
+        gen.endIf();
+      } else iterateKeywords(it, group);
+      if (!allErrors) gen.if((0, codegen_1._)`${names_1.default.errors} === ${errsCount || 0}`);
+    }
+  }
+  function iterateKeywords(it, group) {
+    const { gen, schema, opts: { useDefaults } } = it;
+    if (useDefaults) (0, defaults_1.assignDefaults)(it, group.type);
+    gen.block(() => {
+      for (const rule of group.rules) if ((0, applicability_1.shouldUseRule)(schema, rule)) keywordCode(it, rule.keyword, rule.definition, group.type);
+    });
+  }
+  function checkStrictTypes(it, types) {
+    if (it.schemaEnv.meta || !it.opts.strictTypes) return;
+    checkContextTypes(it, types);
+    if (!it.opts.allowUnionTypes) checkMultipleTypes(it, types);
+    checkKeywordTypes(it, it.dataTypes);
+  }
+  function checkContextTypes(it, types) {
+    if (!types.length) return;
+    if (!it.dataTypes.length) {
+      it.dataTypes = types;
+      return;
+    }
+    types.forEach((t) => {
+      if (!includesType(it.dataTypes, t)) strictTypesError(it, `type "${t}" not allowed by context "${it.dataTypes.join(",")}"`);
+    });
+    narrowSchemaTypes(it, types);
+  }
+  function checkMultipleTypes(it, ts) {
+    if (ts.length > 1 && !(ts.length === 2 && ts.includes("null"))) strictTypesError(it, "use allowUnionTypes to allow union type keyword");
+  }
+  function checkKeywordTypes(it, ts) {
+    const rules = it.self.RULES.all;
+    for (const keyword in rules) {
+      const rule = rules[keyword];
+      if (typeof rule == "object" && (0, applicability_1.shouldUseRule)(it.schema, rule)) {
+        const { type } = rule.definition;
+        if (type.length && !type.some((t) => hasApplicableType(ts, t))) strictTypesError(it, `missing type "${type.join(",")}" for keyword "${keyword}"`);
+      }
+    }
+  }
+  function hasApplicableType(schTs, kwdT) {
+    return schTs.includes(kwdT) || kwdT === "number" && schTs.includes("integer");
+  }
+  function includesType(ts, t) {
+    return ts.includes(t) || t === "integer" && ts.includes("number");
+  }
+  function narrowSchemaTypes(it, withTypes) {
+    const ts = [];
+    for (const t of it.dataTypes) if (includesType(withTypes, t)) ts.push(t);
+    else if (withTypes.includes("integer") && t === "number") ts.push("integer");
+    it.dataTypes = ts;
+  }
+  function strictTypesError(it, msg) {
+    const schemaPath = it.schemaEnv.baseId + it.errSchemaPath;
+    msg += ` at "${schemaPath}" (strictTypes)`;
+    (0, util_1.checkStrictMode)(it, msg, it.opts.strictTypes);
+  }
+  var KeywordCxt = class {
+    constructor(it, def, keyword) {
+      (0, keyword_1.validateKeywordUsage)(it, def, keyword);
+      this.gen = it.gen;
+      this.allErrors = it.allErrors;
+      this.keyword = keyword;
+      this.data = it.data;
+      this.schema = it.schema[keyword];
+      this.$data = def.$data && it.opts.$data && this.schema && this.schema.$data;
+      this.schemaValue = (0, util_1.schemaRefOrVal)(it, this.schema, keyword, this.$data);
+      this.schemaType = def.schemaType;
+      this.parentSchema = it.schema;
+      this.params = {};
+      this.it = it;
+      this.def = def;
+      if (this.$data) this.schemaCode = it.gen.const("vSchema", getData(this.$data, it));
+      else {
+        this.schemaCode = this.schemaValue;
+        if (!(0, keyword_1.validSchemaType)(this.schema, def.schemaType, def.allowUndefined)) throw new Error(`${keyword} value must be ${JSON.stringify(def.schemaType)}`);
+      }
+      if ("code" in def ? def.trackErrors : def.errors !== false) this.errsCount = it.gen.const("_errs", names_1.default.errors);
+    }
+    result(condition, successAction, failAction) {
+      this.failResult((0, codegen_1.not)(condition), successAction, failAction);
+    }
+    failResult(condition, successAction, failAction) {
+      this.gen.if(condition);
+      if (failAction) failAction();
+      else this.error();
+      if (successAction) {
+        this.gen.else();
+        successAction();
+        if (this.allErrors) this.gen.endIf();
+      } else if (this.allErrors) this.gen.endIf();
+      else this.gen.else();
+    }
+    pass(condition, failAction) {
+      this.failResult((0, codegen_1.not)(condition), void 0, failAction);
+    }
+    fail(condition) {
+      if (condition === void 0) {
+        this.error();
+        if (!this.allErrors) this.gen.if(false);
+        return;
+      }
+      this.gen.if(condition);
+      this.error();
+      if (this.allErrors) this.gen.endIf();
+      else this.gen.else();
+    }
+    fail$data(condition) {
+      if (!this.$data) return this.fail(condition);
+      const { schemaCode } = this;
+      this.fail((0, codegen_1._)`${schemaCode} !== undefined && (${(0, codegen_1.or)(this.invalid$data(), condition)})`);
+    }
+    error(append, errorParams, errorPaths) {
+      if (errorParams) {
+        this.setParams(errorParams);
+        this._error(append, errorPaths);
+        this.setParams({});
+        return;
+      }
+      this._error(append, errorPaths);
+    }
+    _error(append, errorPaths) {
+      (append ? errors_1.reportExtraError : errors_1.reportError)(this, this.def.error, errorPaths);
+    }
+    $dataError() {
+      (0, errors_1.reportError)(this, this.def.$dataError || errors_1.keyword$DataError);
+    }
+    reset() {
+      if (this.errsCount === void 0) throw new Error('add "trackErrors" to keyword definition');
+      (0, errors_1.resetErrorsCount)(this.gen, this.errsCount);
+    }
+    ok(cond) {
+      if (!this.allErrors) this.gen.if(cond);
+    }
+    setParams(obj, assign) {
+      if (assign) Object.assign(this.params, obj);
+      else this.params = obj;
+    }
+    block$data(valid, codeBlock, $dataValid = codegen_1.nil) {
+      this.gen.block(() => {
+        this.check$data(valid, $dataValid);
+        codeBlock();
+      });
+    }
+    check$data(valid = codegen_1.nil, $dataValid = codegen_1.nil) {
+      if (!this.$data) return;
+      const { gen, schemaCode, schemaType, def } = this;
+      gen.if((0, codegen_1.or)((0, codegen_1._)`${schemaCode} === undefined`, $dataValid));
+      if (valid !== codegen_1.nil) gen.assign(valid, true);
+      if (schemaType.length || def.validateSchema) {
+        gen.elseIf(this.invalid$data());
+        this.$dataError();
+        if (valid !== codegen_1.nil) gen.assign(valid, false);
+      }
+      gen.else();
+    }
+    invalid$data() {
+      const { gen, schemaCode, schemaType, def, it } = this;
+      return (0, codegen_1.or)(wrong$DataType(), invalid$DataSchema());
+      function wrong$DataType() {
+        if (schemaType.length) {
+          if (!(schemaCode instanceof codegen_1.Name)) throw new Error("ajv implementation error");
+          const st = Array.isArray(schemaType) ? schemaType : [schemaType];
+          return (0, codegen_1._)`${(0, dataType_2.checkDataTypes)(st, schemaCode, it.opts.strictNumbers, dataType_2.DataType.Wrong)}`;
+        }
+        return codegen_1.nil;
+      }
+      function invalid$DataSchema() {
+        if (def.validateSchema) {
+          const validateSchemaRef = gen.scopeValue("validate$data", { ref: def.validateSchema });
+          return (0, codegen_1._)`!${validateSchemaRef}(${schemaCode})`;
+        }
+        return codegen_1.nil;
+      }
+    }
+    subschema(appl, valid) {
+      const subschema = (0, subschema_1.getSubschema)(this.it, appl);
+      (0, subschema_1.extendSubschemaData)(subschema, this.it, appl);
+      (0, subschema_1.extendSubschemaMode)(subschema, appl);
+      const nextContext = {
+        ...this.it,
+        ...subschema,
+        items: void 0,
+        props: void 0
+      };
+      subschemaCode(nextContext, valid);
+      return nextContext;
+    }
+    mergeEvaluated(schemaCxt, toName) {
+      const { it, gen } = this;
+      if (!it.opts.unevaluated) return;
+      if (it.props !== true && schemaCxt.props !== void 0) it.props = util_1.mergeEvaluated.props(gen, schemaCxt.props, it.props, toName);
+      if (it.items !== true && schemaCxt.items !== void 0) it.items = util_1.mergeEvaluated.items(gen, schemaCxt.items, it.items, toName);
+    }
+    mergeValidEvaluated(schemaCxt, valid) {
+      const { it, gen } = this;
+      if (it.opts.unevaluated && (it.props !== true || it.items !== true)) {
+        gen.if(valid, () => this.mergeEvaluated(schemaCxt, codegen_1.Name));
+        return true;
+      }
+    }
+  };
+  exports.KeywordCxt = KeywordCxt;
+  function keywordCode(it, keyword, def, ruleType) {
+    const cxt = new KeywordCxt(it, def, keyword);
+    if ("code" in def) def.code(cxt, ruleType);
+    else if (cxt.$data && def.validate) (0, keyword_1.funcKeywordCode)(cxt, def);
+    else if ("macro" in def) (0, keyword_1.macroKeywordCode)(cxt, def);
+    else if (def.compile || def.validate) (0, keyword_1.funcKeywordCode)(cxt, def);
+  }
+  const JSON_POINTER = /^\/(?:[^~]|~0|~1)*$/;
+  const RELATIVE_JSON_POINTER = /^([0-9]+)(#|\/(?:[^~]|~0|~1)*)?$/;
+  function getData($data, { dataLevel, dataNames, dataPathArr }) {
+    let jsonPointer;
+    let data;
+    if ($data === "") return names_1.default.rootData;
+    if ($data[0] === "/") {
+      if (!JSON_POINTER.test($data)) throw new Error(`Invalid JSON-pointer: ${$data}`);
+      jsonPointer = $data;
+      data = names_1.default.rootData;
+    } else {
+      const matches = RELATIVE_JSON_POINTER.exec($data);
+      if (!matches) throw new Error(`Invalid JSON-pointer: ${$data}`);
+      const up = +matches[1];
+      jsonPointer = matches[2];
+      if (jsonPointer === "#") {
+        if (up >= dataLevel) throw new Error(errorMsg("property/index", up));
+        return dataPathArr[dataLevel - up];
+      }
+      if (up > dataLevel) throw new Error(errorMsg("data", up));
+      data = dataNames[dataLevel - up];
+      if (!jsonPointer) return data;
+    }
+    let expr = data;
+    const segments = jsonPointer.split("/");
+    for (const segment of segments) if (segment) {
+      data = (0, codegen_1._)`${data}${(0, codegen_1.getProperty)((0, util_1.unescapeJsonPointer)(segment))}`;
+      expr = (0, codegen_1._)`${expr} && ${data}`;
+    }
+    return expr;
+    function errorMsg(pointerType, up) {
+      return `Cannot access ${pointerType} ${up} levels up, current level is ${dataLevel}`;
+    }
+  }
+  exports.getData = getData;
+}));
+var require_validation_error2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  var ValidationError = class extends Error {
+    constructor(errors) {
+      super("validation failed");
+      this.errors = errors;
+      this.ajv = this.validation = true;
+    }
+  };
+  exports.default = ValidationError;
+}));
+var require_ref_error2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const resolve_1 = require_resolve2();
+  var MissingRefError = class extends Error {
+    constructor(resolver, baseId, ref, msg) {
+      super(msg || `can't resolve reference ${ref} from id ${baseId}`);
+      this.missingRef = (0, resolve_1.resolveUrl)(resolver, baseId, ref);
+      this.missingSchema = (0, resolve_1.normalizeId)((0, resolve_1.getFullPath)(resolver, this.missingRef));
+    }
+  };
+  exports.default = MissingRefError;
+}));
+var require_compile2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
+  const codegen_1 = require_codegen2();
+  const validation_error_1 = require_validation_error2();
+  const names_1 = require_names2();
+  const resolve_1 = require_resolve2();
+  const util_1 = require_util2();
+  const validate_1 = require_validate2();
+  var SchemaEnv = class {
+    constructor(env) {
+      var _a3;
+      this.refs = {};
+      this.dynamicAnchors = {};
+      let schema;
+      if (typeof env.schema == "object") schema = env.schema;
+      this.schema = env.schema;
+      this.schemaId = env.schemaId;
+      this.root = env.root || this;
+      this.baseId = (_a3 = env.baseId) !== null && _a3 !== void 0 ? _a3 : (0, resolve_1.normalizeId)(schema === null || schema === void 0 ? void 0 : schema[env.schemaId || "$id"]);
+      this.schemaPath = env.schemaPath;
+      this.localRefs = env.localRefs;
+      this.meta = env.meta;
+      this.$async = schema === null || schema === void 0 ? void 0 : schema.$async;
+      this.refs = {};
+    }
+  };
+  exports.SchemaEnv = SchemaEnv;
+  function compileSchema(sch) {
+    const _sch = getCompilingSchema.call(this, sch);
+    if (_sch) return _sch;
+    const rootId = (0, resolve_1.getFullPath)(this.opts.uriResolver, sch.root.baseId);
+    const { es5, lines } = this.opts.code;
+    const { ownProperties } = this.opts;
+    const gen = new codegen_1.CodeGen(this.scope, {
+      es5,
+      lines,
+      ownProperties
+    });
+    let _ValidationError;
+    if (sch.$async) _ValidationError = gen.scopeValue("Error", {
+      ref: validation_error_1.default,
+      code: (0, codegen_1._)`require("ajv/dist/runtime/validation_error").default`
+    });
+    const validateName = gen.scopeName("validate");
+    sch.validateName = validateName;
+    const schemaCxt = {
+      gen,
+      allErrors: this.opts.allErrors,
+      data: names_1.default.data,
+      parentData: names_1.default.parentData,
+      parentDataProperty: names_1.default.parentDataProperty,
+      dataNames: [names_1.default.data],
+      dataPathArr: [codegen_1.nil],
+      dataLevel: 0,
+      dataTypes: [],
+      definedProperties: /* @__PURE__ */ new Set(),
+      topSchemaRef: gen.scopeValue("schema", this.opts.code.source === true ? {
+        ref: sch.schema,
+        code: (0, codegen_1.stringify)(sch.schema)
+      } : { ref: sch.schema }),
+      validateName,
+      ValidationError: _ValidationError,
+      schema: sch.schema,
+      schemaEnv: sch,
+      rootId,
+      baseId: sch.baseId || rootId,
+      schemaPath: codegen_1.nil,
+      errSchemaPath: sch.schemaPath || (this.opts.jtd ? "" : "#"),
+      errorPath: (0, codegen_1._)`""`,
+      opts: this.opts,
+      self: this
+    };
+    let sourceCode;
+    try {
+      this._compilations.add(sch);
+      (0, validate_1.validateFunctionCode)(schemaCxt);
+      gen.optimize(this.opts.code.optimize);
+      const validateCode = gen.toString();
+      sourceCode = `${gen.scopeRefs(names_1.default.scope)}return ${validateCode}`;
+      if (this.opts.code.process) sourceCode = this.opts.code.process(sourceCode, sch);
+      const validate2 = new Function(`${names_1.default.self}`, `${names_1.default.scope}`, sourceCode)(this, this.scope.get());
+      this.scope.value(validateName, { ref: validate2 });
+      validate2.errors = null;
+      validate2.schema = sch.schema;
+      validate2.schemaEnv = sch;
+      if (sch.$async) validate2.$async = true;
+      if (this.opts.code.source === true) validate2.source = {
+        validateName,
+        validateCode,
+        scopeValues: gen._values
+      };
+      if (this.opts.unevaluated) {
+        const { props, items } = schemaCxt;
+        validate2.evaluated = {
+          props: props instanceof codegen_1.Name ? void 0 : props,
+          items: items instanceof codegen_1.Name ? void 0 : items,
+          dynamicProps: props instanceof codegen_1.Name,
+          dynamicItems: items instanceof codegen_1.Name
+        };
+        if (validate2.source) validate2.source.evaluated = (0, codegen_1.stringify)(validate2.evaluated);
+      }
+      sch.validate = validate2;
+      return sch;
+    } catch (e) {
+      delete sch.validate;
+      delete sch.validateName;
+      if (sourceCode) this.logger.error("Error compiling schema, function code:", sourceCode);
+      throw e;
+    } finally {
+      this._compilations.delete(sch);
+    }
+  }
+  exports.compileSchema = compileSchema;
+  function resolveRef(root, baseId, ref) {
+    var _a3;
+    ref = (0, resolve_1.resolveUrl)(this.opts.uriResolver, baseId, ref);
+    const schOrFunc = root.refs[ref];
+    if (schOrFunc) return schOrFunc;
+    let _sch = resolve.call(this, root, ref);
+    if (_sch === void 0) {
+      const schema = (_a3 = root.localRefs) === null || _a3 === void 0 ? void 0 : _a3[ref];
+      const { schemaId } = this.opts;
+      if (schema) _sch = new SchemaEnv({
+        schema,
+        schemaId,
+        root,
+        baseId
+      });
+    }
+    if (_sch === void 0) return;
+    return root.refs[ref] = inlineOrCompile.call(this, _sch);
+  }
+  exports.resolveRef = resolveRef;
+  function inlineOrCompile(sch) {
+    if ((0, resolve_1.inlineRef)(sch.schema, this.opts.inlineRefs)) return sch.schema;
+    return sch.validate ? sch : compileSchema.call(this, sch);
+  }
+  function getCompilingSchema(schEnv) {
+    for (const sch of this._compilations) if (sameSchemaEnv(sch, schEnv)) return sch;
+  }
+  exports.getCompilingSchema = getCompilingSchema;
+  function sameSchemaEnv(s1, s2) {
+    return s1.schema === s2.schema && s1.root === s2.root && s1.baseId === s2.baseId;
+  }
+  function resolve(root, ref) {
+    let sch;
+    while (typeof (sch = this.refs[ref]) == "string") ref = sch;
+    return sch || this.schemas[ref] || resolveSchema.call(this, root, ref);
+  }
+  function resolveSchema(root, ref) {
+    const p = this.opts.uriResolver.parse(ref);
+    const refPath = (0, resolve_1._getFullPath)(this.opts.uriResolver, p);
+    let baseId = (0, resolve_1.getFullPath)(this.opts.uriResolver, root.baseId, void 0);
+    if (Object.keys(root.schema).length > 0 && refPath === baseId) return getJsonPointer.call(this, p, root);
+    const id = (0, resolve_1.normalizeId)(refPath);
+    const schOrRef = this.refs[id] || this.schemas[id];
+    if (typeof schOrRef == "string") {
+      const sch = resolveSchema.call(this, root, schOrRef);
+      if (typeof (sch === null || sch === void 0 ? void 0 : sch.schema) !== "object") return;
+      return getJsonPointer.call(this, p, sch);
+    }
+    if (typeof (schOrRef === null || schOrRef === void 0 ? void 0 : schOrRef.schema) !== "object") return;
+    if (!schOrRef.validate) compileSchema.call(this, schOrRef);
+    if (id === (0, resolve_1.normalizeId)(ref)) {
+      const { schema } = schOrRef;
+      const { schemaId } = this.opts;
+      const schId = schema[schemaId];
+      if (schId) baseId = (0, resolve_1.resolveUrl)(this.opts.uriResolver, baseId, schId);
+      return new SchemaEnv({
+        schema,
+        schemaId,
+        root,
+        baseId
+      });
+    }
+    return getJsonPointer.call(this, p, schOrRef);
+  }
+  exports.resolveSchema = resolveSchema;
+  const PREVENT_SCOPE_CHANGE = /* @__PURE__ */ new Set([
+    "properties",
+    "patternProperties",
+    "enum",
+    "dependencies",
+    "definitions"
+  ]);
+  function getJsonPointer(parsedRef, { baseId, schema, root }) {
+    var _a3;
+    if (((_a3 = parsedRef.fragment) === null || _a3 === void 0 ? void 0 : _a3[0]) !== "/") return;
+    for (const part of parsedRef.fragment.slice(1).split("/")) {
+      if (typeof schema === "boolean") return;
+      const partSchema = schema[(0, util_1.unescapeFragment)(part)];
+      if (partSchema === void 0) return;
+      schema = partSchema;
+      const schId = typeof schema === "object" && schema[this.opts.schemaId];
+      if (!PREVENT_SCOPE_CHANGE.has(part) && schId) baseId = (0, resolve_1.resolveUrl)(this.opts.uriResolver, baseId, schId);
+    }
+    let env;
+    if (typeof schema != "boolean" && schema.$ref && !(0, util_1.schemaHasRulesButRef)(schema, this.RULES)) {
+      const $ref = (0, resolve_1.resolveUrl)(this.opts.uriResolver, baseId, schema.$ref);
+      env = resolveSchema.call(this, root, $ref);
+    }
+    const { schemaId } = this.opts;
+    env = env || new SchemaEnv({
+      schema,
+      schemaId,
+      root,
+      baseId
+    });
+    if (env.schema !== env.root.schema) return env;
+  }
+}));
+var require_data2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$id": "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
+    "description": "Meta-schema for $data reference (JSON AnySchema extension proposal)",
+    "type": "object",
+    "required": ["$data"],
+    "properties": { "$data": {
+      "type": "string",
+      "anyOf": [{ "format": "relative-json-pointer" }, { "format": "json-pointer" }]
+    } },
+    "additionalProperties": false
+  };
+}));
+var require_utils2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  const isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
+  const isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
+  function stringArrayToHexStripped(input) {
+    let acc = "";
+    let code = 0;
+    let i = 0;
+    for (i = 0; i < input.length; i++) {
+      code = input[i].charCodeAt(0);
+      if (code === 48) continue;
+      if (!(code >= 48 && code <= 57 || code >= 65 && code <= 70 || code >= 97 && code <= 102)) return "";
+      acc += input[i];
+      break;
+    }
+    for (i += 1; i < input.length; i++) {
+      code = input[i].charCodeAt(0);
+      if (!(code >= 48 && code <= 57 || code >= 65 && code <= 70 || code >= 97 && code <= 102)) return "";
+      acc += input[i];
+    }
+    return acc;
+  }
+  const nonSimpleDomain = RegExp.prototype.test.bind(/[^!"$&'()*+,\-.;=_`a-z{}~]/u);
+  function consumeIsZone(buffer) {
+    buffer.length = 0;
+    return true;
+  }
+  function consumeHextets(buffer, address, output) {
+    if (buffer.length) {
+      const hex = stringArrayToHexStripped(buffer);
+      if (hex !== "") address.push(hex);
+      else {
+        output.error = true;
+        return false;
+      }
+      buffer.length = 0;
+    }
+    return true;
+  }
+  function getIPV6(input) {
+    let tokenCount = 0;
+    const output = {
+      error: false,
+      address: "",
+      zone: ""
+    };
+    const address = [];
+    const buffer = [];
+    let endipv6Encountered = false;
+    let endIpv6 = false;
+    let consume = consumeHextets;
+    for (let i = 0; i < input.length; i++) {
+      const cursor = input[i];
+      if (cursor === "[" || cursor === "]") continue;
+      if (cursor === ":") {
+        if (endipv6Encountered === true) endIpv6 = true;
+        if (!consume(buffer, address, output)) break;
+        if (++tokenCount > 7) {
+          output.error = true;
+          break;
+        }
+        if (i > 0 && input[i - 1] === ":") endipv6Encountered = true;
+        address.push(":");
+        continue;
+      } else if (cursor === "%") {
+        if (!consume(buffer, address, output)) break;
+        consume = consumeIsZone;
+      } else {
+        buffer.push(cursor);
+        continue;
+      }
+    }
+    if (buffer.length) if (consume === consumeIsZone) output.zone = buffer.join("");
+    else if (endIpv6) address.push(buffer.join(""));
+    else address.push(stringArrayToHexStripped(buffer));
+    output.address = address.join("");
+    return output;
+  }
+  function normalizeIPv6(host) {
+    if (findToken(host, ":") < 2) return {
+      host,
+      isIPV6: false
+    };
+    const ipv62 = getIPV6(host);
+    if (!ipv62.error) {
+      let newHost = ipv62.address;
+      let escapedHost = ipv62.address;
+      if (ipv62.zone) {
+        newHost += "%" + ipv62.zone;
+        escapedHost += "%25" + ipv62.zone;
+      }
+      return {
+        host: newHost,
+        isIPV6: true,
+        escapedHost
+      };
+    } else return {
+      host,
+      isIPV6: false
+    };
+  }
+  function findToken(str, token) {
+    let ind = 0;
+    for (let i = 0; i < str.length; i++) if (str[i] === token) ind++;
+    return ind;
+  }
+  function removeDotSegments(path12) {
+    let input = path12;
+    const output = [];
+    let nextSlash = -1;
+    let len = 0;
+    while (len = input.length) {
+      if (len === 1) if (input === ".") break;
+      else if (input === "/") {
+        output.push("/");
+        break;
+      } else {
+        output.push(input);
+        break;
+      }
+      else if (len === 2) {
+        if (input[0] === ".") {
+          if (input[1] === ".") break;
+          else if (input[1] === "/") {
+            input = input.slice(2);
+            continue;
+          }
+        } else if (input[0] === "/") {
+          if (input[1] === "." || input[1] === "/") {
+            output.push("/");
+            break;
+          }
+        }
+      } else if (len === 3) {
+        if (input === "/..") {
+          if (output.length !== 0) output.pop();
+          output.push("/");
+          break;
+        }
+      }
+      if (input[0] === ".") {
+        if (input[1] === ".") {
+          if (input[2] === "/") {
+            input = input.slice(3);
+            continue;
+          }
+        } else if (input[1] === "/") {
+          input = input.slice(2);
+          continue;
+        }
+      } else if (input[0] === "/") {
+        if (input[1] === ".") {
+          if (input[2] === "/") {
+            input = input.slice(2);
+            continue;
+          } else if (input[2] === ".") {
+            if (input[3] === "/") {
+              input = input.slice(3);
+              if (output.length !== 0) output.pop();
+              continue;
+            }
+          }
+        }
+      }
+      if ((nextSlash = input.indexOf("/", 1)) === -1) {
+        output.push(input);
+        break;
+      } else {
+        output.push(input.slice(0, nextSlash));
+        input = input.slice(nextSlash);
+      }
+    }
+    return output.join("");
+  }
+  function normalizeComponentEncoding(component, esc2) {
+    const func = esc2 !== true ? escape : unescape;
+    if (component.scheme !== void 0) component.scheme = func(component.scheme);
+    if (component.userinfo !== void 0) component.userinfo = func(component.userinfo);
+    if (component.host !== void 0) component.host = func(component.host);
+    if (component.path !== void 0) component.path = func(component.path);
+    if (component.query !== void 0) component.query = func(component.query);
+    if (component.fragment !== void 0) component.fragment = func(component.fragment);
+    return component;
+  }
+  function recomposeAuthority(component) {
+    const uriTokens = [];
+    if (component.userinfo !== void 0) {
+      uriTokens.push(component.userinfo);
+      uriTokens.push("@");
+    }
+    if (component.host !== void 0) {
+      let host = unescape(component.host);
+      if (!isIPv4(host)) {
+        const ipV6res = normalizeIPv6(host);
+        if (ipV6res.isIPV6 === true) host = `[${ipV6res.escapedHost}]`;
+        else host = component.host;
+      }
+      uriTokens.push(host);
+    }
+    if (typeof component.port === "number" || typeof component.port === "string") {
+      uriTokens.push(":");
+      uriTokens.push(String(component.port));
+    }
+    return uriTokens.length ? uriTokens.join("") : void 0;
+  }
+  module.exports = {
+    nonSimpleDomain,
+    recomposeAuthority,
+    normalizeComponentEncoding,
+    removeDotSegments,
+    isIPv4,
+    isUUID,
+    normalizeIPv6,
+    stringArrayToHexStripped
+  };
+}));
+var require_schemes2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  const { isUUID } = require_utils2();
+  const URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
+  const supportedSchemeNames = [
+    "http",
+    "https",
+    "ws",
+    "wss",
+    "urn",
+    "urn:uuid"
+  ];
+  function isValidSchemeName(name) {
+    return supportedSchemeNames.indexOf(name) !== -1;
+  }
+  function wsIsSecure(wsComponent) {
+    if (wsComponent.secure === true) return true;
+    else if (wsComponent.secure === false) return false;
+    else if (wsComponent.scheme) return wsComponent.scheme.length === 3 && (wsComponent.scheme[0] === "w" || wsComponent.scheme[0] === "W") && (wsComponent.scheme[1] === "s" || wsComponent.scheme[1] === "S") && (wsComponent.scheme[2] === "s" || wsComponent.scheme[2] === "S");
+    else return false;
+  }
+  function httpParse(component) {
+    if (!component.host) component.error = component.error || "HTTP URIs must have a host.";
+    return component;
+  }
+  function httpSerialize(component) {
+    const secure = String(component.scheme).toLowerCase() === "https";
+    if (component.port === (secure ? 443 : 80) || component.port === "") component.port = void 0;
+    if (!component.path) component.path = "/";
+    return component;
+  }
+  function wsParse(wsComponent) {
+    wsComponent.secure = wsIsSecure(wsComponent);
+    wsComponent.resourceName = (wsComponent.path || "/") + (wsComponent.query ? "?" + wsComponent.query : "");
+    wsComponent.path = void 0;
+    wsComponent.query = void 0;
+    return wsComponent;
+  }
+  function wsSerialize(wsComponent) {
+    if (wsComponent.port === (wsIsSecure(wsComponent) ? 443 : 80) || wsComponent.port === "") wsComponent.port = void 0;
+    if (typeof wsComponent.secure === "boolean") {
+      wsComponent.scheme = wsComponent.secure ? "wss" : "ws";
+      wsComponent.secure = void 0;
+    }
+    if (wsComponent.resourceName) {
+      const [path12, query] = wsComponent.resourceName.split("?");
+      wsComponent.path = path12 && path12 !== "/" ? path12 : void 0;
+      wsComponent.query = query;
+      wsComponent.resourceName = void 0;
+    }
+    wsComponent.fragment = void 0;
+    return wsComponent;
+  }
+  function urnParse(urnComponent, options) {
+    if (!urnComponent.path) {
+      urnComponent.error = "URN can not be parsed";
+      return urnComponent;
+    }
+    const matches = urnComponent.path.match(URN_REG);
+    if (matches) {
+      const scheme = options.scheme || urnComponent.scheme || "urn";
+      urnComponent.nid = matches[1].toLowerCase();
+      urnComponent.nss = matches[2];
+      const schemeHandler = getSchemeHandler(`${scheme}:${options.nid || urnComponent.nid}`);
+      urnComponent.path = void 0;
+      if (schemeHandler) urnComponent = schemeHandler.parse(urnComponent, options);
+    } else urnComponent.error = urnComponent.error || "URN can not be parsed.";
+    return urnComponent;
+  }
+  function urnSerialize(urnComponent, options) {
+    if (urnComponent.nid === void 0) throw new Error("URN without nid cannot be serialized");
+    const scheme = options.scheme || urnComponent.scheme || "urn";
+    const nid = urnComponent.nid.toLowerCase();
+    const schemeHandler = getSchemeHandler(`${scheme}:${options.nid || nid}`);
+    if (schemeHandler) urnComponent = schemeHandler.serialize(urnComponent, options);
+    const uriComponent = urnComponent;
+    const nss = urnComponent.nss;
+    uriComponent.path = `${nid || options.nid}:${nss}`;
+    options.skipEscape = true;
+    return uriComponent;
+  }
+  function urnuuidParse(urnComponent, options) {
+    const uuidComponent = urnComponent;
+    uuidComponent.uuid = uuidComponent.nss;
+    uuidComponent.nss = void 0;
+    if (!options.tolerant && (!uuidComponent.uuid || !isUUID(uuidComponent.uuid))) uuidComponent.error = uuidComponent.error || "UUID is not valid.";
+    return uuidComponent;
+  }
+  function urnuuidSerialize(uuidComponent) {
+    const urnComponent = uuidComponent;
+    urnComponent.nss = (uuidComponent.uuid || "").toLowerCase();
+    return urnComponent;
+  }
+  const http2 = {
+    scheme: "http",
+    domainHost: true,
+    parse: httpParse,
+    serialize: httpSerialize
+  };
+  const https = {
+    scheme: "https",
+    domainHost: http2.domainHost,
+    parse: httpParse,
+    serialize: httpSerialize
+  };
+  const ws = {
+    scheme: "ws",
+    domainHost: true,
+    parse: wsParse,
+    serialize: wsSerialize
+  };
+  const wss = {
+    scheme: "wss",
+    domainHost: ws.domainHost,
+    parse: ws.parse,
+    serialize: ws.serialize
+  };
+  const urn = {
+    scheme: "urn",
+    parse: urnParse,
+    serialize: urnSerialize,
+    skipNormalize: true
+  };
+  const urnuuid = {
+    scheme: "urn:uuid",
+    parse: urnuuidParse,
+    serialize: urnuuidSerialize,
+    skipNormalize: true
+  };
+  const SCHEMES = {
+    http: http2,
+    https,
+    ws,
+    wss,
+    urn,
+    "urn:uuid": urnuuid
+  };
+  Object.setPrototypeOf(SCHEMES, null);
+  function getSchemeHandler(scheme) {
+    return scheme && (SCHEMES[scheme] || SCHEMES[scheme.toLowerCase()]) || void 0;
+  }
+  module.exports = {
+    wsIsSecure,
+    SCHEMES,
+    isValidSchemeName,
+    getSchemeHandler
+  };
+}));
+var require_fast_uri2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils2();
+  const { SCHEMES, getSchemeHandler } = require_schemes2();
+  function normalize(uri, options) {
+    if (typeof uri === "string") uri = serialize(parse3(uri, options), options);
+    else if (typeof uri === "object") uri = parse3(serialize(uri, options), options);
+    return uri;
+  }
+  function resolve(baseURI, relativeURI, options) {
+    const schemelessOptions = options ? Object.assign({ scheme: "null" }, options) : { scheme: "null" };
+    const resolved = resolveComponent(parse3(baseURI, schemelessOptions), parse3(relativeURI, schemelessOptions), schemelessOptions, true);
+    schemelessOptions.skipEscape = true;
+    return serialize(resolved, schemelessOptions);
+  }
+  function resolveComponent(base, relative, options, skipNormalization) {
+    const target = {};
+    if (!skipNormalization) {
+      base = parse3(serialize(base, options), options);
+      relative = parse3(serialize(relative, options), options);
+    }
+    options = options || {};
+    if (!options.tolerant && relative.scheme) {
+      target.scheme = relative.scheme;
+      target.userinfo = relative.userinfo;
+      target.host = relative.host;
+      target.port = relative.port;
+      target.path = removeDotSegments(relative.path || "");
+      target.query = relative.query;
+    } else {
+      if (relative.userinfo !== void 0 || relative.host !== void 0 || relative.port !== void 0) {
+        target.userinfo = relative.userinfo;
+        target.host = relative.host;
+        target.port = relative.port;
+        target.path = removeDotSegments(relative.path || "");
+        target.query = relative.query;
+      } else {
+        if (!relative.path) {
+          target.path = base.path;
+          if (relative.query !== void 0) target.query = relative.query;
+          else target.query = base.query;
+        } else {
+          if (relative.path[0] === "/") target.path = removeDotSegments(relative.path);
+          else {
+            if ((base.userinfo !== void 0 || base.host !== void 0 || base.port !== void 0) && !base.path) target.path = "/" + relative.path;
+            else if (!base.path) target.path = relative.path;
+            else target.path = base.path.slice(0, base.path.lastIndexOf("/") + 1) + relative.path;
+            target.path = removeDotSegments(target.path);
+          }
+          target.query = relative.query;
+        }
+        target.userinfo = base.userinfo;
+        target.host = base.host;
+        target.port = base.port;
+      }
+      target.scheme = base.scheme;
+    }
+    target.fragment = relative.fragment;
+    return target;
+  }
+  function equal(uriA, uriB, options) {
+    if (typeof uriA === "string") {
+      uriA = unescape(uriA);
+      uriA = serialize(normalizeComponentEncoding(parse3(uriA, options), true), {
+        ...options,
+        skipEscape: true
+      });
+    } else if (typeof uriA === "object") uriA = serialize(normalizeComponentEncoding(uriA, true), {
+      ...options,
+      skipEscape: true
+    });
+    if (typeof uriB === "string") {
+      uriB = unescape(uriB);
+      uriB = serialize(normalizeComponentEncoding(parse3(uriB, options), true), {
+        ...options,
+        skipEscape: true
+      });
+    } else if (typeof uriB === "object") uriB = serialize(normalizeComponentEncoding(uriB, true), {
+      ...options,
+      skipEscape: true
+    });
+    return uriA.toLowerCase() === uriB.toLowerCase();
+  }
+  function serialize(cmpts, opts) {
+    const component = {
+      host: cmpts.host,
+      scheme: cmpts.scheme,
+      userinfo: cmpts.userinfo,
+      port: cmpts.port,
+      path: cmpts.path,
+      query: cmpts.query,
+      nid: cmpts.nid,
+      nss: cmpts.nss,
+      uuid: cmpts.uuid,
+      fragment: cmpts.fragment,
+      reference: cmpts.reference,
+      resourceName: cmpts.resourceName,
+      secure: cmpts.secure,
+      error: ""
+    };
+    const options = Object.assign({}, opts);
+    const uriTokens = [];
+    const schemeHandler = getSchemeHandler(options.scheme || component.scheme);
+    if (schemeHandler && schemeHandler.serialize) schemeHandler.serialize(component, options);
+    if (component.path !== void 0) if (!options.skipEscape) {
+      component.path = escape(component.path);
+      if (component.scheme !== void 0) component.path = component.path.split("%3A").join(":");
+    } else component.path = unescape(component.path);
+    if (options.reference !== "suffix" && component.scheme) uriTokens.push(component.scheme, ":");
+    const authority = recomposeAuthority(component);
+    if (authority !== void 0) {
+      if (options.reference !== "suffix") uriTokens.push("//");
+      uriTokens.push(authority);
+      if (component.path && component.path[0] !== "/") uriTokens.push("/");
+    }
+    if (component.path !== void 0) {
+      let s = component.path;
+      if (!options.absolutePath && (!schemeHandler || !schemeHandler.absolutePath)) s = removeDotSegments(s);
+      if (authority === void 0 && s[0] === "/" && s[1] === "/") s = "/%2F" + s.slice(2);
+      uriTokens.push(s);
+    }
+    if (component.query !== void 0) uriTokens.push("?", component.query);
+    if (component.fragment !== void 0) uriTokens.push("#", component.fragment);
+    return uriTokens.join("");
+  }
+  const URI_PARSE = /^(?:([^#/:?]+):)?(?:\/\/((?:([^#/?@]*)@)?(\[[^#/?\]]+\]|[^#/:?]*)(?::(\d*))?))?([^#?]*)(?:\?([^#]*))?(?:#((?:.|[\n\r])*))?/u;
+  function parse3(uri, opts) {
+    const options = Object.assign({}, opts);
+    const parsed = {
+      scheme: void 0,
+      userinfo: void 0,
+      host: "",
+      port: void 0,
+      path: "",
+      query: void 0,
+      fragment: void 0
+    };
+    let isIP = false;
+    if (options.reference === "suffix") if (options.scheme) uri = options.scheme + ":" + uri;
+    else uri = "//" + uri;
+    const matches = uri.match(URI_PARSE);
+    if (matches) {
+      parsed.scheme = matches[1];
+      parsed.userinfo = matches[3];
+      parsed.host = matches[4];
+      parsed.port = parseInt(matches[5], 10);
+      parsed.path = matches[6] || "";
+      parsed.query = matches[7];
+      parsed.fragment = matches[8];
+      if (isNaN(parsed.port)) parsed.port = matches[5];
+      if (parsed.host) if (isIPv4(parsed.host) === false) {
+        const ipv6result = normalizeIPv6(parsed.host);
+        parsed.host = ipv6result.host.toLowerCase();
+        isIP = ipv6result.isIPV6;
+      } else isIP = true;
+      if (parsed.scheme === void 0 && parsed.userinfo === void 0 && parsed.host === void 0 && parsed.port === void 0 && parsed.query === void 0 && !parsed.path) parsed.reference = "same-document";
+      else if (parsed.scheme === void 0) parsed.reference = "relative";
+      else if (parsed.fragment === void 0) parsed.reference = "absolute";
+      else parsed.reference = "uri";
+      if (options.reference && options.reference !== "suffix" && options.reference !== parsed.reference) parsed.error = parsed.error || "URI is not a " + options.reference + " reference.";
+      const schemeHandler = getSchemeHandler(options.scheme || parsed.scheme);
+      if (!options.unicodeSupport && (!schemeHandler || !schemeHandler.unicodeSupport)) {
+        if (parsed.host && (options.domainHost || schemeHandler && schemeHandler.domainHost) && isIP === false && nonSimpleDomain(parsed.host)) try {
+          parsed.host = URL.domainToASCII(parsed.host.toLowerCase());
+        } catch (e) {
+          parsed.error = parsed.error || "Host's domain name can not be converted to ASCII: " + e;
+        }
+      }
+      if (!schemeHandler || schemeHandler && !schemeHandler.skipNormalize) {
+        if (uri.indexOf("%") !== -1) {
+          if (parsed.scheme !== void 0) parsed.scheme = unescape(parsed.scheme);
+          if (parsed.host !== void 0) parsed.host = unescape(parsed.host);
+        }
+        if (parsed.path) parsed.path = escape(unescape(parsed.path));
+        if (parsed.fragment) parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment));
+      }
+      if (schemeHandler && schemeHandler.parse) schemeHandler.parse(parsed, options);
+    } else parsed.error = parsed.error || "URI can not be parsed.";
+    return parsed;
+  }
+  const fastUri = {
+    SCHEMES,
+    normalize,
+    resolve,
+    resolveComponent,
+    equal,
+    serialize,
+    parse: parse3
+  };
+  module.exports = fastUri;
+  module.exports.default = fastUri;
+  module.exports.fastUri = fastUri;
+}));
+var require_uri2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const uri = require_fast_uri2();
+  uri.code = 'require("ajv/dist/runtime/uri").default';
+  exports.default = uri;
+}));
+var require_core$3 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
+  var validate_1 = require_validate2();
+  Object.defineProperty(exports, "KeywordCxt", {
+    enumerable: true,
+    get: function() {
+      return validate_1.KeywordCxt;
+    }
+  });
+  var codegen_1 = require_codegen2();
+  Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
+      return codegen_1._;
+    }
+  });
+  Object.defineProperty(exports, "str", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.str;
+    }
+  });
+  Object.defineProperty(exports, "stringify", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.stringify;
+    }
+  });
+  Object.defineProperty(exports, "nil", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.nil;
+    }
+  });
+  Object.defineProperty(exports, "Name", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.Name;
+    }
+  });
+  Object.defineProperty(exports, "CodeGen", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.CodeGen;
+    }
+  });
+  const validation_error_1 = require_validation_error2();
+  const ref_error_1 = require_ref_error2();
+  const rules_1 = require_rules2();
+  const compile_1 = require_compile2();
+  const codegen_2 = require_codegen2();
+  const resolve_1 = require_resolve2();
+  const dataType_1 = require_dataType2();
+  const util_1 = require_util2();
+  const $dataRefSchema = require_data2();
+  const uri_1 = require_uri2();
+  const defaultRegExp = (str, flags) => new RegExp(str, flags);
+  defaultRegExp.code = "new RegExp";
+  const META_IGNORE_OPTIONS = [
+    "removeAdditional",
+    "useDefaults",
+    "coerceTypes"
+  ];
+  const EXT_SCOPE_NAMES = /* @__PURE__ */ new Set([
+    "validate",
+    "serialize",
+    "parse",
+    "wrapper",
+    "root",
+    "schema",
+    "keyword",
+    "pattern",
+    "formats",
+    "validate$data",
+    "func",
+    "obj",
+    "Error"
+  ]);
+  const removedOptions = {
+    errorDataPath: "",
+    format: "`validateFormats: false` can be used instead.",
+    nullable: '"nullable" keyword is supported by default.',
+    jsonPointers: "Deprecated jsPropertySyntax can be used instead.",
+    extendRefs: "Deprecated ignoreKeywordsWithRef can be used instead.",
+    missingRefs: "Pass empty schema with $id that should be ignored to ajv.addSchema.",
+    processCode: "Use option `code: {process: (code, schemaEnv: object) => string}`",
+    sourceCode: "Use option `code: {source: true}`",
+    strictDefaults: "It is default now, see option `strict`.",
+    strictKeywords: "It is default now, see option `strict`.",
+    uniqueItems: '"uniqueItems" keyword is always validated.',
+    unknownFormats: "Disable strict mode or pass `true` to `ajv.addFormat` (or `formats` option).",
+    cache: "Map is used as cache, schema object as key.",
+    serialize: "Map is used as cache, schema object as key.",
+    ajvErrors: "It is default now."
+  };
+  const deprecatedOptions = {
+    ignoreKeywordsWithRef: "",
+    jsPropertySyntax: "",
+    unicode: '"minLength"/"maxLength" account for unicode characters by default.'
+  };
+  const MAX_EXPRESSION = 200;
+  function requiredOptions(o) {
+    var _a3, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0;
+    const s = o.strict;
+    const _optz = (_a3 = o.code) === null || _a3 === void 0 ? void 0 : _a3.optimize;
+    const optimize = _optz === true || _optz === void 0 ? 1 : _optz || 0;
+    const regExp = (_c = (_b = o.code) === null || _b === void 0 ? void 0 : _b.regExp) !== null && _c !== void 0 ? _c : defaultRegExp;
+    const uriResolver = (_d = o.uriResolver) !== null && _d !== void 0 ? _d : uri_1.default;
+    return {
+      strictSchema: (_f = (_e = o.strictSchema) !== null && _e !== void 0 ? _e : s) !== null && _f !== void 0 ? _f : true,
+      strictNumbers: (_h = (_g = o.strictNumbers) !== null && _g !== void 0 ? _g : s) !== null && _h !== void 0 ? _h : true,
+      strictTypes: (_k = (_j = o.strictTypes) !== null && _j !== void 0 ? _j : s) !== null && _k !== void 0 ? _k : "log",
+      strictTuples: (_m = (_l = o.strictTuples) !== null && _l !== void 0 ? _l : s) !== null && _m !== void 0 ? _m : "log",
+      strictRequired: (_p = (_o = o.strictRequired) !== null && _o !== void 0 ? _o : s) !== null && _p !== void 0 ? _p : false,
+      code: o.code ? {
+        ...o.code,
+        optimize,
+        regExp
+      } : {
+        optimize,
+        regExp
+      },
+      loopRequired: (_q = o.loopRequired) !== null && _q !== void 0 ? _q : MAX_EXPRESSION,
+      loopEnum: (_r = o.loopEnum) !== null && _r !== void 0 ? _r : MAX_EXPRESSION,
+      meta: (_s = o.meta) !== null && _s !== void 0 ? _s : true,
+      messages: (_t = o.messages) !== null && _t !== void 0 ? _t : true,
+      inlineRefs: (_u = o.inlineRefs) !== null && _u !== void 0 ? _u : true,
+      schemaId: (_v = o.schemaId) !== null && _v !== void 0 ? _v : "$id",
+      addUsedSchema: (_w = o.addUsedSchema) !== null && _w !== void 0 ? _w : true,
+      validateSchema: (_x = o.validateSchema) !== null && _x !== void 0 ? _x : true,
+      validateFormats: (_y = o.validateFormats) !== null && _y !== void 0 ? _y : true,
+      unicodeRegExp: (_z = o.unicodeRegExp) !== null && _z !== void 0 ? _z : true,
+      int32range: (_0 = o.int32range) !== null && _0 !== void 0 ? _0 : true,
+      uriResolver
+    };
+  }
+  var Ajv3 = class {
+    constructor(opts = {}) {
+      this.schemas = {};
+      this.refs = {};
+      this.formats = {};
+      this._compilations = /* @__PURE__ */ new Set();
+      this._loading = {};
+      this._cache = /* @__PURE__ */ new Map();
+      opts = this.opts = {
+        ...opts,
+        ...requiredOptions(opts)
+      };
+      const { es5, lines } = this.opts.code;
+      this.scope = new codegen_2.ValueScope({
+        scope: {},
+        prefixes: EXT_SCOPE_NAMES,
+        es5,
+        lines
+      });
+      this.logger = getLogger(opts.logger);
+      const formatOpt = opts.validateFormats;
+      opts.validateFormats = false;
+      this.RULES = (0, rules_1.getRules)();
+      checkOptions.call(this, removedOptions, opts, "NOT SUPPORTED");
+      checkOptions.call(this, deprecatedOptions, opts, "DEPRECATED", "warn");
+      this._metaOpts = getMetaSchemaOptions.call(this);
+      if (opts.formats) addInitialFormats.call(this);
+      this._addVocabularies();
+      this._addDefaultMetaSchema();
+      if (opts.keywords) addInitialKeywords.call(this, opts.keywords);
+      if (typeof opts.meta == "object") this.addMetaSchema(opts.meta);
+      addInitialSchemas.call(this);
+      opts.validateFormats = formatOpt;
+    }
+    _addVocabularies() {
+      this.addKeyword("$async");
+    }
+    _addDefaultMetaSchema() {
+      const { $data, meta: meta2, schemaId } = this.opts;
+      let _dataRefSchema = $dataRefSchema;
+      if (schemaId === "id") {
+        _dataRefSchema = { ...$dataRefSchema };
+        _dataRefSchema.id = _dataRefSchema.$id;
+        delete _dataRefSchema.$id;
+      }
+      if (meta2 && $data) this.addMetaSchema(_dataRefSchema, _dataRefSchema[schemaId], false);
+    }
+    defaultMeta() {
+      const { meta: meta2, schemaId } = this.opts;
+      return this.opts.defaultMeta = typeof meta2 == "object" ? meta2[schemaId] || meta2 : void 0;
+    }
+    validate(schemaKeyRef, data) {
+      let v;
+      if (typeof schemaKeyRef == "string") {
+        v = this.getSchema(schemaKeyRef);
+        if (!v) throw new Error(`no schema with key or ref "${schemaKeyRef}"`);
+      } else v = this.compile(schemaKeyRef);
+      const valid = v(data);
+      if (!("$async" in v)) this.errors = v.errors;
+      return valid;
+    }
+    compile(schema, _meta) {
+      const sch = this._addSchema(schema, _meta);
+      return sch.validate || this._compileSchemaEnv(sch);
+    }
+    compileAsync(schema, meta2) {
+      if (typeof this.opts.loadSchema != "function") throw new Error("options.loadSchema should be a function");
+      const { loadSchema } = this.opts;
+      return runCompileAsync.call(this, schema, meta2);
+      async function runCompileAsync(_schema, _meta) {
+        await loadMetaSchema.call(this, _schema.$schema);
+        const sch = this._addSchema(_schema, _meta);
+        return sch.validate || _compileAsync.call(this, sch);
+      }
+      async function loadMetaSchema($ref) {
+        if ($ref && !this.getSchema($ref)) await runCompileAsync.call(this, { $ref }, true);
+      }
+      async function _compileAsync(sch) {
+        try {
+          return this._compileSchemaEnv(sch);
+        } catch (e) {
+          if (!(e instanceof ref_error_1.default)) throw e;
+          checkLoaded.call(this, e);
+          await loadMissingSchema.call(this, e.missingSchema);
+          return _compileAsync.call(this, sch);
+        }
+      }
+      function checkLoaded({ missingSchema: ref, missingRef }) {
+        if (this.refs[ref]) throw new Error(`AnySchema ${ref} is loaded but ${missingRef} cannot be resolved`);
+      }
+      async function loadMissingSchema(ref) {
+        const _schema = await _loadSchema.call(this, ref);
+        if (!this.refs[ref]) await loadMetaSchema.call(this, _schema.$schema);
+        if (!this.refs[ref]) this.addSchema(_schema, ref, meta2);
+      }
+      async function _loadSchema(ref) {
+        const p = this._loading[ref];
+        if (p) return p;
+        try {
+          return await (this._loading[ref] = loadSchema(ref));
+        } finally {
+          delete this._loading[ref];
+        }
+      }
+    }
+    addSchema(schema, key, _meta, _validateSchema = this.opts.validateSchema) {
+      if (Array.isArray(schema)) {
+        for (const sch of schema) this.addSchema(sch, void 0, _meta, _validateSchema);
+        return this;
+      }
+      let id;
+      if (typeof schema === "object") {
+        const { schemaId } = this.opts;
+        id = schema[schemaId];
+        if (id !== void 0 && typeof id != "string") throw new Error(`schema ${schemaId} must be string`);
+      }
+      key = (0, resolve_1.normalizeId)(key || id);
+      this._checkUnique(key);
+      this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true);
+      return this;
+    }
+    addMetaSchema(schema, key, _validateSchema = this.opts.validateSchema) {
+      this.addSchema(schema, key, true, _validateSchema);
+      return this;
+    }
+    validateSchema(schema, throwOrLogError) {
+      if (typeof schema == "boolean") return true;
+      let $schema;
+      $schema = schema.$schema;
+      if ($schema !== void 0 && typeof $schema != "string") throw new Error("$schema must be a string");
+      $schema = $schema || this.opts.defaultMeta || this.defaultMeta();
+      if (!$schema) {
+        this.logger.warn("meta-schema not available");
+        this.errors = null;
+        return true;
+      }
+      const valid = this.validate($schema, schema);
+      if (!valid && throwOrLogError) {
+        const message = "schema is invalid: " + this.errorsText();
+        if (this.opts.validateSchema === "log") this.logger.error(message);
+        else throw new Error(message);
+      }
+      return valid;
+    }
+    getSchema(keyRef) {
+      let sch;
+      while (typeof (sch = getSchEnv.call(this, keyRef)) == "string") keyRef = sch;
+      if (sch === void 0) {
+        const { schemaId } = this.opts;
+        const root = new compile_1.SchemaEnv({
+          schema: {},
+          schemaId
+        });
+        sch = compile_1.resolveSchema.call(this, root, keyRef);
+        if (!sch) return;
+        this.refs[keyRef] = sch;
+      }
+      return sch.validate || this._compileSchemaEnv(sch);
+    }
+    removeSchema(schemaKeyRef) {
+      if (schemaKeyRef instanceof RegExp) {
+        this._removeAllSchemas(this.schemas, schemaKeyRef);
+        this._removeAllSchemas(this.refs, schemaKeyRef);
+        return this;
+      }
+      switch (typeof schemaKeyRef) {
+        case "undefined":
+          this._removeAllSchemas(this.schemas);
+          this._removeAllSchemas(this.refs);
+          this._cache.clear();
+          return this;
+        case "string": {
+          const sch = getSchEnv.call(this, schemaKeyRef);
+          if (typeof sch == "object") this._cache.delete(sch.schema);
+          delete this.schemas[schemaKeyRef];
+          delete this.refs[schemaKeyRef];
+          return this;
+        }
+        case "object": {
+          const cacheKey = schemaKeyRef;
+          this._cache.delete(cacheKey);
+          let id = schemaKeyRef[this.opts.schemaId];
+          if (id) {
+            id = (0, resolve_1.normalizeId)(id);
+            delete this.schemas[id];
+            delete this.refs[id];
+          }
+          return this;
+        }
+        default:
+          throw new Error("ajv.removeSchema: invalid parameter");
+      }
+    }
+    addVocabulary(definitions) {
+      for (const def of definitions) this.addKeyword(def);
+      return this;
+    }
+    addKeyword(kwdOrDef, def) {
+      let keyword;
+      if (typeof kwdOrDef == "string") {
+        keyword = kwdOrDef;
+        if (typeof def == "object") {
+          this.logger.warn("these parameters are deprecated, see docs for addKeyword");
+          def.keyword = keyword;
+        }
+      } else if (typeof kwdOrDef == "object" && def === void 0) {
+        def = kwdOrDef;
+        keyword = def.keyword;
+        if (Array.isArray(keyword) && !keyword.length) throw new Error("addKeywords: keyword must be string or non-empty array");
+      } else throw new Error("invalid addKeywords parameters");
+      checkKeyword.call(this, keyword, def);
+      if (!def) {
+        (0, util_1.eachItem)(keyword, (kwd) => addRule.call(this, kwd));
+        return this;
+      }
+      keywordMetaschema.call(this, def);
+      const definition = {
+        ...def,
+        type: (0, dataType_1.getJSONTypes)(def.type),
+        schemaType: (0, dataType_1.getJSONTypes)(def.schemaType)
+      };
+      (0, util_1.eachItem)(keyword, definition.type.length === 0 ? (k) => addRule.call(this, k, definition) : (k) => definition.type.forEach((t) => addRule.call(this, k, definition, t)));
+      return this;
+    }
+    getKeyword(keyword) {
+      const rule = this.RULES.all[keyword];
+      return typeof rule == "object" ? rule.definition : !!rule;
+    }
+    removeKeyword(keyword) {
+      const { RULES } = this;
+      delete RULES.keywords[keyword];
+      delete RULES.all[keyword];
+      for (const group of RULES.rules) {
+        const i = group.rules.findIndex((rule) => rule.keyword === keyword);
+        if (i >= 0) group.rules.splice(i, 1);
+      }
+      return this;
+    }
+    addFormat(name, format) {
+      if (typeof format == "string") format = new RegExp(format);
+      this.formats[name] = format;
+      return this;
+    }
+    errorsText(errors = this.errors, { separator = ", ", dataVar = "data" } = {}) {
+      if (!errors || errors.length === 0) return "No errors";
+      return errors.map((e) => `${dataVar}${e.instancePath} ${e.message}`).reduce((text, msg) => text + separator + msg);
+    }
+    $dataMetaSchema(metaSchema, keywordsJsonPointers) {
+      const rules = this.RULES.all;
+      metaSchema = JSON.parse(JSON.stringify(metaSchema));
+      for (const jsonPointer of keywordsJsonPointers) {
+        const segments = jsonPointer.split("/").slice(1);
+        let keywords = metaSchema;
+        for (const seg of segments) keywords = keywords[seg];
+        for (const key in rules) {
+          const rule = rules[key];
+          if (typeof rule != "object") continue;
+          const { $data } = rule.definition;
+          const schema = keywords[key];
+          if ($data && schema) keywords[key] = schemaOrData(schema);
+        }
+      }
+      return metaSchema;
+    }
+    _removeAllSchemas(schemas, regex) {
+      for (const keyRef in schemas) {
+        const sch = schemas[keyRef];
+        if (!regex || regex.test(keyRef)) {
+          if (typeof sch == "string") delete schemas[keyRef];
+          else if (sch && !sch.meta) {
+            this._cache.delete(sch.schema);
+            delete schemas[keyRef];
+          }
+        }
+      }
+    }
+    _addSchema(schema, meta2, baseId, validateSchema = this.opts.validateSchema, addSchema = this.opts.addUsedSchema) {
+      let id;
+      const { schemaId } = this.opts;
+      if (typeof schema == "object") id = schema[schemaId];
+      else if (this.opts.jtd) throw new Error("schema must be object");
+      else if (typeof schema != "boolean") throw new Error("schema must be object or boolean");
+      let sch = this._cache.get(schema);
+      if (sch !== void 0) return sch;
+      baseId = (0, resolve_1.normalizeId)(id || baseId);
+      const localRefs = resolve_1.getSchemaRefs.call(this, schema, baseId);
+      sch = new compile_1.SchemaEnv({
+        schema,
+        schemaId,
+        meta: meta2,
+        baseId,
+        localRefs
+      });
+      this._cache.set(sch.schema, sch);
+      if (addSchema && !baseId.startsWith("#")) {
+        if (baseId) this._checkUnique(baseId);
+        this.refs[baseId] = sch;
+      }
+      if (validateSchema) this.validateSchema(schema, true);
+      return sch;
+    }
+    _checkUnique(id) {
+      if (this.schemas[id] || this.refs[id]) throw new Error(`schema with key or id "${id}" already exists`);
+    }
+    _compileSchemaEnv(sch) {
+      if (sch.meta) this._compileMetaSchema(sch);
+      else compile_1.compileSchema.call(this, sch);
+      if (!sch.validate) throw new Error("ajv implementation error");
+      return sch.validate;
+    }
+    _compileMetaSchema(sch) {
+      const currentOpts = this.opts;
+      this.opts = this._metaOpts;
+      try {
+        compile_1.compileSchema.call(this, sch);
+      } finally {
+        this.opts = currentOpts;
+      }
+    }
+  };
+  Ajv3.ValidationError = validation_error_1.default;
+  Ajv3.MissingRefError = ref_error_1.default;
+  exports.default = Ajv3;
+  function checkOptions(checkOpts, options, msg, log = "error") {
+    for (const key in checkOpts) {
+      const opt = key;
+      if (opt in options) this.logger[log](`${msg}: option ${key}. ${checkOpts[opt]}`);
+    }
+  }
+  function getSchEnv(keyRef) {
+    keyRef = (0, resolve_1.normalizeId)(keyRef);
+    return this.schemas[keyRef] || this.refs[keyRef];
+  }
+  function addInitialSchemas() {
+    const optsSchemas = this.opts.schemas;
+    if (!optsSchemas) return;
+    if (Array.isArray(optsSchemas)) this.addSchema(optsSchemas);
+    else for (const key in optsSchemas) this.addSchema(optsSchemas[key], key);
+  }
+  function addInitialFormats() {
+    for (const name in this.opts.formats) {
+      const format = this.opts.formats[name];
+      if (format) this.addFormat(name, format);
+    }
+  }
+  function addInitialKeywords(defs) {
+    if (Array.isArray(defs)) {
+      this.addVocabulary(defs);
+      return;
+    }
+    this.logger.warn("keywords option as map is deprecated, pass array");
+    for (const keyword in defs) {
+      const def = defs[keyword];
+      if (!def.keyword) def.keyword = keyword;
+      this.addKeyword(def);
+    }
+  }
+  function getMetaSchemaOptions() {
+    const metaOpts = { ...this.opts };
+    for (const opt of META_IGNORE_OPTIONS) delete metaOpts[opt];
+    return metaOpts;
+  }
+  const noLogs = {
+    log() {
+    },
+    warn() {
+    },
+    error() {
+    }
+  };
+  function getLogger(logger) {
+    if (logger === false) return noLogs;
+    if (logger === void 0) return console;
+    if (logger.log && logger.warn && logger.error) return logger;
+    throw new Error("logger must implement log, warn and error methods");
+  }
+  const KEYWORD_NAME = /^[a-z_$][a-z0-9_$:-]*$/i;
+  function checkKeyword(keyword, def) {
+    const { RULES } = this;
+    (0, util_1.eachItem)(keyword, (kwd) => {
+      if (RULES.keywords[kwd]) throw new Error(`Keyword ${kwd} is already defined`);
+      if (!KEYWORD_NAME.test(kwd)) throw new Error(`Keyword ${kwd} has invalid name`);
+    });
+    if (!def) return;
+    if (def.$data && !("code" in def || "validate" in def)) throw new Error('$data keyword must have "code" or "validate" function');
+  }
+  function addRule(keyword, definition, dataType) {
+    var _a3;
+    const post = definition === null || definition === void 0 ? void 0 : definition.post;
+    if (dataType && post) throw new Error('keyword with "post" flag cannot have "type"');
+    const { RULES } = this;
+    let ruleGroup = post ? RULES.post : RULES.rules.find(({ type: t }) => t === dataType);
+    if (!ruleGroup) {
+      ruleGroup = {
+        type: dataType,
+        rules: []
+      };
+      RULES.rules.push(ruleGroup);
+    }
+    RULES.keywords[keyword] = true;
+    if (!definition) return;
+    const rule = {
+      keyword,
+      definition: {
+        ...definition,
+        type: (0, dataType_1.getJSONTypes)(definition.type),
+        schemaType: (0, dataType_1.getJSONTypes)(definition.schemaType)
+      }
+    };
+    if (definition.before) addBeforeRule.call(this, ruleGroup, rule, definition.before);
+    else ruleGroup.rules.push(rule);
+    RULES.all[keyword] = rule;
+    (_a3 = definition.implements) === null || _a3 === void 0 || _a3.forEach((kwd) => this.addKeyword(kwd));
+  }
+  function addBeforeRule(ruleGroup, rule, before) {
+    const i = ruleGroup.rules.findIndex((_rule) => _rule.keyword === before);
+    if (i >= 0) ruleGroup.rules.splice(i, 0, rule);
+    else {
+      ruleGroup.rules.push(rule);
+      this.logger.warn(`rule ${before} is not defined`);
+    }
+  }
+  function keywordMetaschema(def) {
+    let { metaSchema } = def;
+    if (metaSchema === void 0) return;
+    if (def.$data && this.opts.$data) metaSchema = schemaOrData(metaSchema);
+    def.validateSchema = this.compile(metaSchema, true);
+  }
+  const $dataRef = { $ref: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#" };
+  function schemaOrData(schema) {
+    return { anyOf: [schema, $dataRef] };
+  }
+}));
+var require_id2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const def = {
+    keyword: "id",
+    code() {
+      throw new Error('NOT SUPPORTED: keyword "id", use "$id" for schema ID');
+    }
+  };
+  exports.default = def;
+}));
+var require_ref2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.callRef = exports.getValidate = void 0;
+  const ref_error_1 = require_ref_error2();
+  const code_1 = require_code3();
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const compile_1 = require_compile2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "$ref",
+    schemaType: "string",
+    code(cxt) {
+      const { gen, schema: $ref, it } = cxt;
+      const { baseId, schemaEnv: env, validateName, opts, self } = it;
+      const { root } = env;
+      if (($ref === "#" || $ref === "#/") && baseId === root.baseId) return callRootRef();
+      const schOrEnv = compile_1.resolveRef.call(self, root, baseId, $ref);
+      if (schOrEnv === void 0) throw new ref_error_1.default(it.opts.uriResolver, baseId, $ref);
+      if (schOrEnv instanceof compile_1.SchemaEnv) return callValidate(schOrEnv);
+      return inlineRefSchema(schOrEnv);
+      function callRootRef() {
+        if (env === root) return callRef(cxt, validateName, env, env.$async);
+        const rootName = gen.scopeValue("root", { ref: root });
+        return callRef(cxt, (0, codegen_1._)`${rootName}.validate`, root, root.$async);
+      }
+      function callValidate(sch) {
+        callRef(cxt, getValidate(cxt, sch), sch, sch.$async);
+      }
+      function inlineRefSchema(sch) {
+        const schName = gen.scopeValue("schema", opts.code.source === true ? {
+          ref: sch,
+          code: (0, codegen_1.stringify)(sch)
+        } : { ref: sch });
+        const valid = gen.name("valid");
+        const schCxt = cxt.subschema({
+          schema: sch,
+          dataTypes: [],
+          schemaPath: codegen_1.nil,
+          topSchemaRef: schName,
+          errSchemaPath: $ref
+        }, valid);
+        cxt.mergeEvaluated(schCxt);
+        cxt.ok(valid);
+      }
+    }
+  };
+  function getValidate(cxt, sch) {
+    const { gen } = cxt;
+    return sch.validate ? gen.scopeValue("validate", { ref: sch.validate }) : (0, codegen_1._)`${gen.scopeValue("wrapper", { ref: sch })}.validate`;
+  }
+  exports.getValidate = getValidate;
+  function callRef(cxt, v, sch, $async) {
+    const { gen, it } = cxt;
+    const { allErrors, schemaEnv: env, opts } = it;
+    const passCxt = opts.passContext ? names_1.default.this : codegen_1.nil;
+    if ($async) callAsyncRef();
+    else callSyncRef();
+    function callAsyncRef() {
+      if (!env.$async) throw new Error("async schema referenced by sync schema");
+      const valid = gen.let("valid");
+      gen.try(() => {
+        gen.code((0, codegen_1._)`await ${(0, code_1.callValidateCode)(cxt, v, passCxt)}`);
+        addEvaluatedFrom(v);
+        if (!allErrors) gen.assign(valid, true);
+      }, (e) => {
+        gen.if((0, codegen_1._)`!(${e} instanceof ${it.ValidationError})`, () => gen.throw(e));
+        addErrorsFrom(e);
+        if (!allErrors) gen.assign(valid, false);
+      });
+      cxt.ok(valid);
+    }
+    function callSyncRef() {
+      cxt.result((0, code_1.callValidateCode)(cxt, v, passCxt), () => addEvaluatedFrom(v), () => addErrorsFrom(v));
+    }
+    function addErrorsFrom(source) {
+      const errs = (0, codegen_1._)`${source}.errors`;
+      gen.assign(names_1.default.vErrors, (0, codegen_1._)`${names_1.default.vErrors} === null ? ${errs} : ${names_1.default.vErrors}.concat(${errs})`);
+      gen.assign(names_1.default.errors, (0, codegen_1._)`${names_1.default.vErrors}.length`);
+    }
+    function addEvaluatedFrom(source) {
+      var _a3;
+      if (!it.opts.unevaluated) return;
+      const schEvaluated = (_a3 = sch === null || sch === void 0 ? void 0 : sch.validate) === null || _a3 === void 0 ? void 0 : _a3.evaluated;
+      if (it.props !== true) if (schEvaluated && !schEvaluated.dynamicProps) {
+        if (schEvaluated.props !== void 0) it.props = util_1.mergeEvaluated.props(gen, schEvaluated.props, it.props);
+      } else {
+        const props = gen.var("props", (0, codegen_1._)`${source}.evaluated.props`);
+        it.props = util_1.mergeEvaluated.props(gen, props, it.props, codegen_1.Name);
+      }
+      if (it.items !== true) if (schEvaluated && !schEvaluated.dynamicItems) {
+        if (schEvaluated.items !== void 0) it.items = util_1.mergeEvaluated.items(gen, schEvaluated.items, it.items);
+      } else {
+        const items = gen.var("items", (0, codegen_1._)`${source}.evaluated.items`);
+        it.items = util_1.mergeEvaluated.items(gen, items, it.items, codegen_1.Name);
+      }
+    }
+  }
+  exports.callRef = callRef;
+  exports.default = def;
+}));
+var require_core$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const id_1 = require_id2();
+  const ref_1 = require_ref2();
+  const core = [
+    "$schema",
+    "$id",
+    "$defs",
+    "$vocabulary",
+    { keyword: "$comment" },
+    "definitions",
+    id_1.default,
+    ref_1.default
+  ];
+  exports.default = core;
+}));
+var require_limitNumber2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const ops = codegen_1.operators;
+  const KWDs = {
+    maximum: {
+      okStr: "<=",
+      ok: ops.LTE,
+      fail: ops.GT
+    },
+    minimum: {
+      okStr: ">=",
+      ok: ops.GTE,
+      fail: ops.LT
+    },
+    exclusiveMaximum: {
+      okStr: "<",
+      ok: ops.LT,
+      fail: ops.GTE
+    },
+    exclusiveMinimum: {
+      okStr: ">",
+      ok: ops.GT,
+      fail: ops.LTE
+    }
+  };
+  const def = {
+    keyword: Object.keys(KWDs),
+    type: "number",
+    schemaType: "number",
+    $data: true,
+    error: {
+      message: ({ keyword, schemaCode }) => (0, codegen_1.str)`must be ${KWDs[keyword].okStr} ${schemaCode}`,
+      params: ({ keyword, schemaCode }) => (0, codegen_1._)`{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { keyword, data, schemaCode } = cxt;
+      cxt.fail$data((0, codegen_1._)`${data} ${KWDs[keyword].fail} ${schemaCode} || isNaN(${data})`);
+    }
+  };
+  exports.default = def;
+}));
+var require_multipleOf2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const def = {
+    keyword: "multipleOf",
+    type: "number",
+    schemaType: "number",
+    $data: true,
+    error: {
+      message: ({ schemaCode }) => (0, codegen_1.str)`must be multiple of ${schemaCode}`,
+      params: ({ schemaCode }) => (0, codegen_1._)`{multipleOf: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { gen, data, schemaCode, it } = cxt;
+      const prec = it.opts.multipleOfPrecision;
+      const res = gen.let("res");
+      const invalid = prec ? (0, codegen_1._)`Math.abs(Math.round(${res}) - ${res}) > 1e-${prec}` : (0, codegen_1._)`${res} !== parseInt(${res})`;
+      cxt.fail$data((0, codegen_1._)`(${schemaCode} === 0 || (${res} = ${data}/${schemaCode}, ${invalid}))`);
+    }
+  };
+  exports.default = def;
+}));
+var require_ucs2length2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  function ucs2length(str) {
+    const len = str.length;
+    let length = 0;
+    let pos = 0;
+    let value;
+    while (pos < len) {
+      length++;
+      value = str.charCodeAt(pos++);
+      if (value >= 55296 && value <= 56319 && pos < len) {
+        value = str.charCodeAt(pos);
+        if ((value & 64512) === 56320) pos++;
+      }
+    }
+    return length;
+  }
+  exports.default = ucs2length;
+  ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default';
+}));
+var require_limitLength2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const ucs2length_1 = require_ucs2length2();
+  const def = {
+    keyword: ["maxLength", "minLength"],
+    type: "string",
+    schemaType: "number",
+    $data: true,
+    error: {
+      message({ keyword, schemaCode }) {
+        const comp = keyword === "maxLength" ? "more" : "fewer";
+        return (0, codegen_1.str)`must NOT have ${comp} than ${schemaCode} characters`;
+      },
+      params: ({ schemaCode }) => (0, codegen_1._)`{limit: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { keyword, data, schemaCode, it } = cxt;
+      const op = keyword === "maxLength" ? codegen_1.operators.GT : codegen_1.operators.LT;
+      const len = it.opts.unicode === false ? (0, codegen_1._)`${data}.length` : (0, codegen_1._)`${(0, util_1.useFunc)(cxt.gen, ucs2length_1.default)}(${data})`;
+      cxt.fail$data((0, codegen_1._)`${len} ${op} ${schemaCode}`);
+    }
+  };
+  exports.default = def;
+}));
+var require_pattern2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const code_1 = require_code3();
+  const util_1 = require_util2();
+  const codegen_1 = require_codegen2();
+  const def = {
+    keyword: "pattern",
+    type: "string",
+    schemaType: "string",
+    $data: true,
+    error: {
+      message: ({ schemaCode }) => (0, codegen_1.str)`must match pattern "${schemaCode}"`,
+      params: ({ schemaCode }) => (0, codegen_1._)`{pattern: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { gen, data, $data, schema, schemaCode, it } = cxt;
+      const u = it.opts.unicodeRegExp ? "u" : "";
+      if ($data) {
+        const { regExp } = it.opts.code;
+        const regExpCode = regExp.code === "new RegExp" ? (0, codegen_1._)`new RegExp` : (0, util_1.useFunc)(gen, regExp);
+        const valid = gen.let("valid");
+        gen.try(() => gen.assign(valid, (0, codegen_1._)`${regExpCode}(${schemaCode}, ${u}).test(${data})`), () => gen.assign(valid, false));
+        cxt.fail$data((0, codegen_1._)`!${valid}`);
+      } else {
+        const regExp = (0, code_1.usePattern)(cxt, schema);
+        cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_limitProperties2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const def = {
+    keyword: ["maxProperties", "minProperties"],
+    type: "object",
+    schemaType: "number",
+    $data: true,
+    error: {
+      message({ keyword, schemaCode }) {
+        const comp = keyword === "maxProperties" ? "more" : "fewer";
+        return (0, codegen_1.str)`must NOT have ${comp} than ${schemaCode} properties`;
+      },
+      params: ({ schemaCode }) => (0, codegen_1._)`{limit: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { keyword, data, schemaCode } = cxt;
+      const op = keyword === "maxProperties" ? codegen_1.operators.GT : codegen_1.operators.LT;
+      cxt.fail$data((0, codegen_1._)`Object.keys(${data}).length ${op} ${schemaCode}`);
+    }
+  };
+  exports.default = def;
+}));
+var require_required2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const code_1 = require_code3();
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "required",
+    type: "object",
+    schemaType: "array",
+    $data: true,
+    error: {
+      message: ({ params: { missingProperty } }) => (0, codegen_1.str)`must have required property '${missingProperty}'`,
+      params: ({ params: { missingProperty } }) => (0, codegen_1._)`{missingProperty: ${missingProperty}}`
+    },
+    code(cxt) {
+      const { gen, schema, schemaCode, data, $data, it } = cxt;
+      const { opts } = it;
+      if (!$data && schema.length === 0) return;
+      const useLoop = schema.length >= opts.loopRequired;
+      if (it.allErrors) allErrorsMode();
+      else exitOnErrorMode();
+      if (opts.strictRequired) {
+        const props = cxt.parentSchema.properties;
+        const { definedProperties } = cxt.it;
+        for (const requiredKey of schema) if ((props === null || props === void 0 ? void 0 : props[requiredKey]) === void 0 && !definedProperties.has(requiredKey)) {
+          const msg = `required property "${requiredKey}" is not defined at "${it.schemaEnv.baseId + it.errSchemaPath}" (strictRequired)`;
+          (0, util_1.checkStrictMode)(it, msg, it.opts.strictRequired);
+        }
+      }
+      function allErrorsMode() {
+        if (useLoop || $data) cxt.block$data(codegen_1.nil, loopAllRequired);
+        else for (const prop of schema) (0, code_1.checkReportMissingProp)(cxt, prop);
+      }
+      function exitOnErrorMode() {
+        const missing = gen.let("missing");
+        if (useLoop || $data) {
+          const valid = gen.let("valid", true);
+          cxt.block$data(valid, () => loopUntilMissing(missing, valid));
+          cxt.ok(valid);
+        } else {
+          gen.if((0, code_1.checkMissingProp)(cxt, schema, missing));
+          (0, code_1.reportMissingProp)(cxt, missing);
+          gen.else();
+        }
+      }
+      function loopAllRequired() {
+        gen.forOf("prop", schemaCode, (prop) => {
+          cxt.setParams({ missingProperty: prop });
+          gen.if((0, code_1.noPropertyInData)(gen, data, prop, opts.ownProperties), () => cxt.error());
+        });
+      }
+      function loopUntilMissing(missing, valid) {
+        cxt.setParams({ missingProperty: missing });
+        gen.forOf(missing, schemaCode, () => {
+          gen.assign(valid, (0, code_1.propertyInData)(gen, data, missing, opts.ownProperties));
+          gen.if((0, codegen_1.not)(valid), () => {
+            cxt.error();
+            gen.break();
+          });
+        }, codegen_1.nil);
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_limitItems2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const def = {
+    keyword: ["maxItems", "minItems"],
+    type: "array",
+    schemaType: "number",
+    $data: true,
+    error: {
+      message({ keyword, schemaCode }) {
+        const comp = keyword === "maxItems" ? "more" : "fewer";
+        return (0, codegen_1.str)`must NOT have ${comp} than ${schemaCode} items`;
+      },
+      params: ({ schemaCode }) => (0, codegen_1._)`{limit: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { keyword, data, schemaCode } = cxt;
+      const op = keyword === "maxItems" ? codegen_1.operators.GT : codegen_1.operators.LT;
+      cxt.fail$data((0, codegen_1._)`${data}.length ${op} ${schemaCode}`);
+    }
+  };
+  exports.default = def;
+}));
+var require_equal2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const equal = require_fast_deep_equal2();
+  equal.code = 'require("ajv/dist/runtime/equal").default';
+  exports.default = equal;
+}));
+var require_uniqueItems2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dataType_1 = require_dataType2();
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const equal_1 = require_equal2();
+  const def = {
+    keyword: "uniqueItems",
+    type: "array",
+    schemaType: "boolean",
+    $data: true,
+    error: {
+      message: ({ params: { i, j } }) => (0, codegen_1.str)`must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
+      params: ({ params: { i, j } }) => (0, codegen_1._)`{i: ${i}, j: ${j}}`
+    },
+    code(cxt) {
+      const { gen, data, $data, schema, parentSchema, schemaCode, it } = cxt;
+      if (!$data && !schema) return;
+      const valid = gen.let("valid");
+      const itemTypes = parentSchema.items ? (0, dataType_1.getSchemaTypes)(parentSchema.items) : [];
+      cxt.block$data(valid, validateUniqueItems, (0, codegen_1._)`${schemaCode} === false`);
+      cxt.ok(valid);
+      function validateUniqueItems() {
+        const i = gen.let("i", (0, codegen_1._)`${data}.length`);
+        const j = gen.let("j");
+        cxt.setParams({
+          i,
+          j
+        });
+        gen.assign(valid, true);
+        gen.if((0, codegen_1._)`${i} > 1`, () => (canOptimize() ? loopN : loopN2)(i, j));
+      }
+      function canOptimize() {
+        return itemTypes.length > 0 && !itemTypes.some((t) => t === "object" || t === "array");
+      }
+      function loopN(i, j) {
+        const item = gen.name("item");
+        const wrongType = (0, dataType_1.checkDataTypes)(itemTypes, item, it.opts.strictNumbers, dataType_1.DataType.Wrong);
+        const indices = gen.const("indices", (0, codegen_1._)`{}`);
+        gen.for((0, codegen_1._)`;${i}--;`, () => {
+          gen.let(item, (0, codegen_1._)`${data}[${i}]`);
+          gen.if(wrongType, (0, codegen_1._)`continue`);
+          if (itemTypes.length > 1) gen.if((0, codegen_1._)`typeof ${item} == "string"`, (0, codegen_1._)`${item} += "_"`);
+          gen.if((0, codegen_1._)`typeof ${indices}[${item}] == "number"`, () => {
+            gen.assign(j, (0, codegen_1._)`${indices}[${item}]`);
+            cxt.error();
+            gen.assign(valid, false).break();
+          }).code((0, codegen_1._)`${indices}[${item}] = ${i}`);
+        });
+      }
+      function loopN2(i, j) {
+        const eql = (0, util_1.useFunc)(gen, equal_1.default);
+        const outer = gen.name("outer");
+        gen.label(outer).for((0, codegen_1._)`;${i}--;`, () => gen.for((0, codegen_1._)`${j} = ${i}; ${j}--;`, () => gen.if((0, codegen_1._)`${eql}(${data}[${i}], ${data}[${j}])`, () => {
+          cxt.error();
+          gen.assign(valid, false).break(outer);
+        })));
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_const2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const equal_1 = require_equal2();
+  const def = {
+    keyword: "const",
+    $data: true,
+    error: {
+      message: "must be equal to constant",
+      params: ({ schemaCode }) => (0, codegen_1._)`{allowedValue: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { gen, data, $data, schemaCode, schema } = cxt;
+      if ($data || schema && typeof schema == "object") cxt.fail$data((0, codegen_1._)`!${(0, util_1.useFunc)(gen, equal_1.default)}(${data}, ${schemaCode})`);
+      else cxt.fail((0, codegen_1._)`${schema} !== ${data}`);
+    }
+  };
+  exports.default = def;
+}));
+var require_enum2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const equal_1 = require_equal2();
+  const def = {
+    keyword: "enum",
+    schemaType: "array",
+    $data: true,
+    error: {
+      message: "must be equal to one of the allowed values",
+      params: ({ schemaCode }) => (0, codegen_1._)`{allowedValues: ${schemaCode}}`
+    },
+    code(cxt) {
+      const { gen, data, $data, schema, schemaCode, it } = cxt;
+      if (!$data && schema.length === 0) throw new Error("enum must have non-empty array");
+      const useLoop = schema.length >= it.opts.loopEnum;
+      let eql;
+      const getEql = () => eql !== null && eql !== void 0 ? eql : eql = (0, util_1.useFunc)(gen, equal_1.default);
+      let valid;
+      if (useLoop || $data) {
+        valid = gen.let("valid");
+        cxt.block$data(valid, loopEnum);
+      } else {
+        if (!Array.isArray(schema)) throw new Error("ajv implementation error");
+        const vSchema = gen.const("vSchema", schemaCode);
+        valid = (0, codegen_1.or)(...schema.map((_x, i) => equalCode(vSchema, i)));
+      }
+      cxt.pass(valid);
+      function loopEnum() {
+        gen.assign(valid, false);
+        gen.forOf("v", schemaCode, (v) => gen.if((0, codegen_1._)`${getEql()}(${data}, ${v})`, () => gen.assign(valid, true).break()));
+      }
+      function equalCode(vSchema, i) {
+        const sch = schema[i];
+        return typeof sch === "object" && sch !== null ? (0, codegen_1._)`${getEql()}(${data}, ${vSchema}[${i}])` : (0, codegen_1._)`${data} === ${sch}`;
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_validation$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const limitNumber_1 = require_limitNumber2();
+  const multipleOf_1 = require_multipleOf2();
+  const limitLength_1 = require_limitLength2();
+  const pattern_1 = require_pattern2();
+  const limitProperties_1 = require_limitProperties2();
+  const required_1 = require_required2();
+  const limitItems_1 = require_limitItems2();
+  const uniqueItems_1 = require_uniqueItems2();
+  const const_1 = require_const2();
+  const enum_1 = require_enum2();
+  const validation = [
+    limitNumber_1.default,
+    multipleOf_1.default,
+    limitLength_1.default,
+    pattern_1.default,
+    limitProperties_1.default,
+    required_1.default,
+    limitItems_1.default,
+    uniqueItems_1.default,
+    {
+      keyword: "type",
+      schemaType: ["string", "array"]
+    },
+    {
+      keyword: "nullable",
+      schemaType: "boolean"
+    },
+    const_1.default,
+    enum_1.default
+  ];
+  exports.default = validation;
+}));
+var require_additionalItems2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.validateAdditionalItems = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "additionalItems",
+    type: "array",
+    schemaType: ["boolean", "object"],
+    before: "uniqueItems",
+    error: {
+      message: ({ params: { len } }) => (0, codegen_1.str)`must NOT have more than ${len} items`,
+      params: ({ params: { len } }) => (0, codegen_1._)`{limit: ${len}}`
+    },
+    code(cxt) {
+      const { parentSchema, it } = cxt;
+      const { items } = parentSchema;
+      if (!Array.isArray(items)) {
+        (0, util_1.checkStrictMode)(it, '"additionalItems" is ignored when "items" is not an array of schemas');
+        return;
+      }
+      validateAdditionalItems(cxt, items);
+    }
+  };
+  function validateAdditionalItems(cxt, items) {
+    const { gen, schema, data, keyword, it } = cxt;
+    it.items = true;
+    const len = gen.const("len", (0, codegen_1._)`${data}.length`);
+    if (schema === false) {
+      cxt.setParams({ len: items.length });
+      cxt.pass((0, codegen_1._)`${len} <= ${items.length}`);
+    } else if (typeof schema == "object" && !(0, util_1.alwaysValidSchema)(it, schema)) {
+      const valid = gen.var("valid", (0, codegen_1._)`${len} <= ${items.length}`);
+      gen.if((0, codegen_1.not)(valid), () => validateItems(valid));
+      cxt.ok(valid);
+    }
+    function validateItems(valid) {
+      gen.forRange("i", items.length, len, (i) => {
+        cxt.subschema({
+          keyword,
+          dataProp: i,
+          dataPropType: util_1.Type.Num
+        }, valid);
+        if (!it.allErrors) gen.if((0, codegen_1.not)(valid), () => gen.break());
+      });
+    }
+  }
+  exports.validateAdditionalItems = validateAdditionalItems;
+  exports.default = def;
+}));
+var require_items2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.validateTuple = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const code_1 = require_code3();
+  const def = {
+    keyword: "items",
+    type: "array",
+    schemaType: [
+      "object",
+      "array",
+      "boolean"
+    ],
+    before: "uniqueItems",
+    code(cxt) {
+      const { schema, it } = cxt;
+      if (Array.isArray(schema)) return validateTuple(cxt, "additionalItems", schema);
+      it.items = true;
+      if ((0, util_1.alwaysValidSchema)(it, schema)) return;
+      cxt.ok((0, code_1.validateArray)(cxt));
+    }
+  };
+  function validateTuple(cxt, extraItems, schArr = cxt.schema) {
+    const { gen, parentSchema, data, keyword, it } = cxt;
+    checkStrictTuple(parentSchema);
+    if (it.opts.unevaluated && schArr.length && it.items !== true) it.items = util_1.mergeEvaluated.items(gen, schArr.length, it.items);
+    const valid = gen.name("valid");
+    const len = gen.const("len", (0, codegen_1._)`${data}.length`);
+    schArr.forEach((sch, i) => {
+      if ((0, util_1.alwaysValidSchema)(it, sch)) return;
+      gen.if((0, codegen_1._)`${len} > ${i}`, () => cxt.subschema({
+        keyword,
+        schemaProp: i,
+        dataProp: i
+      }, valid));
+      cxt.ok(valid);
+    });
+    function checkStrictTuple(sch) {
+      const { opts, errSchemaPath } = it;
+      const l = schArr.length;
+      const fullTuple = l === sch.minItems && (l === sch.maxItems || sch[extraItems] === false);
+      if (opts.strictTuples && !fullTuple) {
+        const msg = `"${keyword}" is ${l}-tuple, but minItems or maxItems/${extraItems} are not specified or different at path "${errSchemaPath}"`;
+        (0, util_1.checkStrictMode)(it, msg, opts.strictTuples);
+      }
+    }
+  }
+  exports.validateTuple = validateTuple;
+  exports.default = def;
+}));
+var require_prefixItems2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const items_1 = require_items2();
+  const def = {
+    keyword: "prefixItems",
+    type: "array",
+    schemaType: ["array"],
+    before: "uniqueItems",
+    code: (cxt) => (0, items_1.validateTuple)(cxt, "items")
+  };
+  exports.default = def;
+}));
+var require_items20202 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const code_1 = require_code3();
+  const additionalItems_1 = require_additionalItems2();
+  const def = {
+    keyword: "items",
+    type: "array",
+    schemaType: ["object", "boolean"],
+    before: "uniqueItems",
+    error: {
+      message: ({ params: { len } }) => (0, codegen_1.str)`must NOT have more than ${len} items`,
+      params: ({ params: { len } }) => (0, codegen_1._)`{limit: ${len}}`
+    },
+    code(cxt) {
+      const { schema, parentSchema, it } = cxt;
+      const { prefixItems } = parentSchema;
+      it.items = true;
+      if ((0, util_1.alwaysValidSchema)(it, schema)) return;
+      if (prefixItems) (0, additionalItems_1.validateAdditionalItems)(cxt, prefixItems);
+      else cxt.ok((0, code_1.validateArray)(cxt));
+    }
+  };
+  exports.default = def;
+}));
+var require_contains2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "contains",
+    type: "array",
+    schemaType: ["object", "boolean"],
+    before: "uniqueItems",
+    trackErrors: true,
+    error: {
+      message: ({ params: { min, max } }) => max === void 0 ? (0, codegen_1.str)`must contain at least ${min} valid item(s)` : (0, codegen_1.str)`must contain at least ${min} and no more than ${max} valid item(s)`,
+      params: ({ params: { min, max } }) => max === void 0 ? (0, codegen_1._)`{minContains: ${min}}` : (0, codegen_1._)`{minContains: ${min}, maxContains: ${max}}`
+    },
+    code(cxt) {
+      const { gen, schema, parentSchema, data, it } = cxt;
+      let min;
+      let max;
+      const { minContains, maxContains } = parentSchema;
+      if (it.opts.next) {
+        min = minContains === void 0 ? 1 : minContains;
+        max = maxContains;
+      } else min = 1;
+      const len = gen.const("len", (0, codegen_1._)`${data}.length`);
+      cxt.setParams({
+        min,
+        max
+      });
+      if (max === void 0 && min === 0) {
+        (0, util_1.checkStrictMode)(it, `"minContains" == 0 without "maxContains": "contains" keyword ignored`);
+        return;
+      }
+      if (max !== void 0 && min > max) {
+        (0, util_1.checkStrictMode)(it, `"minContains" > "maxContains" is always invalid`);
+        cxt.fail();
+        return;
+      }
+      if ((0, util_1.alwaysValidSchema)(it, schema)) {
+        let cond = (0, codegen_1._)`${len} >= ${min}`;
+        if (max !== void 0) cond = (0, codegen_1._)`${cond} && ${len} <= ${max}`;
+        cxt.pass(cond);
+        return;
+      }
+      it.items = true;
+      const valid = gen.name("valid");
+      if (max === void 0 && min === 1) validateItems(valid, () => gen.if(valid, () => gen.break()));
+      else if (min === 0) {
+        gen.let(valid, true);
+        if (max !== void 0) gen.if((0, codegen_1._)`${data}.length > 0`, validateItemsWithCount);
+      } else {
+        gen.let(valid, false);
+        validateItemsWithCount();
+      }
+      cxt.result(valid, () => cxt.reset());
+      function validateItemsWithCount() {
+        const schValid = gen.name("_valid");
+        const count = gen.let("count", 0);
+        validateItems(schValid, () => gen.if(schValid, () => checkLimits(count)));
+      }
+      function validateItems(_valid, block) {
+        gen.forRange("i", 0, len, (i) => {
+          cxt.subschema({
+            keyword: "contains",
+            dataProp: i,
+            dataPropType: util_1.Type.Num,
+            compositeRule: true
+          }, _valid);
+          block();
+        });
+      }
+      function checkLimits(count) {
+        gen.code((0, codegen_1._)`${count}++`);
+        if (max === void 0) gen.if((0, codegen_1._)`${count} >= ${min}`, () => gen.assign(valid, true).break());
+        else {
+          gen.if((0, codegen_1._)`${count} > ${max}`, () => gen.assign(valid, false).break());
+          if (min === 1) gen.assign(valid, true);
+          else gen.if((0, codegen_1._)`${count} >= ${min}`, () => gen.assign(valid, true));
+        }
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_dependencies2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const code_1 = require_code3();
+  exports.error = {
+    message: ({ params: { property, depsCount, deps } }) => {
+      const property_ies = depsCount === 1 ? "property" : "properties";
+      return (0, codegen_1.str)`must have ${property_ies} ${deps} when property ${property} is present`;
+    },
+    params: ({ params: { property, depsCount, deps, missingProperty } }) => (0, codegen_1._)`{property: ${property},
+    missingProperty: ${missingProperty},
+    depsCount: ${depsCount},
+    deps: ${deps}}`
+  };
+  const def = {
+    keyword: "dependencies",
+    type: "object",
+    schemaType: "object",
+    error: exports.error,
+    code(cxt) {
+      const [propDeps, schDeps] = splitDependencies(cxt);
+      validatePropertyDeps(cxt, propDeps);
+      validateSchemaDeps(cxt, schDeps);
+    }
+  };
+  function splitDependencies({ schema }) {
+    const propertyDeps = {};
+    const schemaDeps = {};
+    for (const key in schema) {
+      if (key === "__proto__") continue;
+      const deps = Array.isArray(schema[key]) ? propertyDeps : schemaDeps;
+      deps[key] = schema[key];
+    }
+    return [propertyDeps, schemaDeps];
+  }
+  function validatePropertyDeps(cxt, propertyDeps = cxt.schema) {
+    const { gen, data, it } = cxt;
+    if (Object.keys(propertyDeps).length === 0) return;
+    const missing = gen.let("missing");
+    for (const prop in propertyDeps) {
+      const deps = propertyDeps[prop];
+      if (deps.length === 0) continue;
+      const hasProperty = (0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties);
+      cxt.setParams({
+        property: prop,
+        depsCount: deps.length,
+        deps: deps.join(", ")
+      });
+      if (it.allErrors) gen.if(hasProperty, () => {
+        for (const depProp of deps) (0, code_1.checkReportMissingProp)(cxt, depProp);
+      });
+      else {
+        gen.if((0, codegen_1._)`${hasProperty} && (${(0, code_1.checkMissingProp)(cxt, deps, missing)})`);
+        (0, code_1.reportMissingProp)(cxt, missing);
+        gen.else();
+      }
+    }
+  }
+  exports.validatePropertyDeps = validatePropertyDeps;
+  function validateSchemaDeps(cxt, schemaDeps = cxt.schema) {
+    const { gen, data, keyword, it } = cxt;
+    const valid = gen.name("valid");
+    for (const prop in schemaDeps) {
+      if ((0, util_1.alwaysValidSchema)(it, schemaDeps[prop])) continue;
+      gen.if((0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties), () => {
+        const schCxt = cxt.subschema({
+          keyword,
+          schemaProp: prop
+        }, valid);
+        cxt.mergeValidEvaluated(schCxt, valid);
+      }, () => gen.var(valid, true));
+      cxt.ok(valid);
+    }
+  }
+  exports.validateSchemaDeps = validateSchemaDeps;
+  exports.default = def;
+}));
+var require_propertyNames2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "propertyNames",
+    type: "object",
+    schemaType: ["object", "boolean"],
+    error: {
+      message: "property name must be valid",
+      params: ({ params }) => (0, codegen_1._)`{propertyName: ${params.propertyName}}`
+    },
+    code(cxt) {
+      const { gen, schema, data, it } = cxt;
+      if ((0, util_1.alwaysValidSchema)(it, schema)) return;
+      const valid = gen.name("valid");
+      gen.forIn("key", data, (key) => {
+        cxt.setParams({ propertyName: key });
+        cxt.subschema({
+          keyword: "propertyNames",
+          data: key,
+          dataTypes: ["string"],
+          propertyName: key,
+          compositeRule: true
+        }, valid);
+        gen.if((0, codegen_1.not)(valid), () => {
+          cxt.error(true);
+          if (!it.allErrors) gen.break();
+        });
+      });
+      cxt.ok(valid);
+    }
+  };
+  exports.default = def;
+}));
+var require_additionalProperties2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const code_1 = require_code3();
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "additionalProperties",
+    type: ["object"],
+    schemaType: ["boolean", "object"],
+    allowUndefined: true,
+    trackErrors: true,
+    error: {
+      message: "must NOT have additional properties",
+      params: ({ params }) => (0, codegen_1._)`{additionalProperty: ${params.additionalProperty}}`
+    },
+    code(cxt) {
+      const { gen, schema, parentSchema, data, errsCount, it } = cxt;
+      if (!errsCount) throw new Error("ajv implementation error");
+      const { allErrors, opts } = it;
+      it.props = true;
+      if (opts.removeAdditional !== "all" && (0, util_1.alwaysValidSchema)(it, schema)) return;
+      const props = (0, code_1.allSchemaProperties)(parentSchema.properties);
+      const patProps = (0, code_1.allSchemaProperties)(parentSchema.patternProperties);
+      checkAdditionalProperties();
+      cxt.ok((0, codegen_1._)`${errsCount} === ${names_1.default.errors}`);
+      function checkAdditionalProperties() {
+        gen.forIn("key", data, (key) => {
+          if (!props.length && !patProps.length) additionalPropertyCode(key);
+          else gen.if(isAdditional(key), () => additionalPropertyCode(key));
+        });
+      }
+      function isAdditional(key) {
+        let definedProp;
+        if (props.length > 8) {
+          const propsSchema = (0, util_1.schemaRefOrVal)(it, parentSchema.properties, "properties");
+          definedProp = (0, code_1.isOwnProperty)(gen, propsSchema, key);
+        } else if (props.length) definedProp = (0, codegen_1.or)(...props.map((p) => (0, codegen_1._)`${key} === ${p}`));
+        else definedProp = codegen_1.nil;
+        if (patProps.length) definedProp = (0, codegen_1.or)(definedProp, ...patProps.map((p) => (0, codegen_1._)`${(0, code_1.usePattern)(cxt, p)}.test(${key})`));
+        return (0, codegen_1.not)(definedProp);
+      }
+      function deleteAdditional(key) {
+        gen.code((0, codegen_1._)`delete ${data}[${key}]`);
+      }
+      function additionalPropertyCode(key) {
+        if (opts.removeAdditional === "all" || opts.removeAdditional && schema === false) {
+          deleteAdditional(key);
+          return;
+        }
+        if (schema === false) {
+          cxt.setParams({ additionalProperty: key });
+          cxt.error();
+          if (!allErrors) gen.break();
+          return;
+        }
+        if (typeof schema == "object" && !(0, util_1.alwaysValidSchema)(it, schema)) {
+          const valid = gen.name("valid");
+          if (opts.removeAdditional === "failing") {
+            applyAdditionalSchema(key, valid, false);
+            gen.if((0, codegen_1.not)(valid), () => {
+              cxt.reset();
+              deleteAdditional(key);
+            });
+          } else {
+            applyAdditionalSchema(key, valid);
+            if (!allErrors) gen.if((0, codegen_1.not)(valid), () => gen.break());
+          }
+        }
+      }
+      function applyAdditionalSchema(key, valid, errors) {
+        const subschema = {
+          keyword: "additionalProperties",
+          dataProp: key,
+          dataPropType: util_1.Type.Str
+        };
+        if (errors === false) Object.assign(subschema, {
+          compositeRule: true,
+          createErrors: false,
+          allErrors: false
+        });
+        cxt.subschema(subschema, valid);
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_properties2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const validate_1 = require_validate2();
+  const code_1 = require_code3();
+  const util_1 = require_util2();
+  const additionalProperties_1 = require_additionalProperties2();
+  const def = {
+    keyword: "properties",
+    type: "object",
+    schemaType: "object",
+    code(cxt) {
+      const { gen, schema, parentSchema, data, it } = cxt;
+      if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === void 0) additionalProperties_1.default.code(new validate_1.KeywordCxt(it, additionalProperties_1.default, "additionalProperties"));
+      const allProps = (0, code_1.allSchemaProperties)(schema);
+      for (const prop of allProps) it.definedProperties.add(prop);
+      if (it.opts.unevaluated && allProps.length && it.props !== true) it.props = util_1.mergeEvaluated.props(gen, (0, util_1.toHash)(allProps), it.props);
+      const properties = allProps.filter((p) => !(0, util_1.alwaysValidSchema)(it, schema[p]));
+      if (properties.length === 0) return;
+      const valid = gen.name("valid");
+      for (const prop of properties) {
+        if (hasDefault(prop)) applyPropertySchema(prop);
+        else {
+          gen.if((0, code_1.propertyInData)(gen, data, prop, it.opts.ownProperties));
+          applyPropertySchema(prop);
+          if (!it.allErrors) gen.else().var(valid, true);
+          gen.endIf();
+        }
+        cxt.it.definedProperties.add(prop);
+        cxt.ok(valid);
+      }
+      function hasDefault(prop) {
+        return it.opts.useDefaults && !it.compositeRule && schema[prop].default !== void 0;
+      }
+      function applyPropertySchema(prop) {
+        cxt.subschema({
+          keyword: "properties",
+          schemaProp: prop,
+          dataProp: prop
+        }, valid);
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_patternProperties2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const code_1 = require_code3();
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const util_2 = require_util2();
+  const def = {
+    keyword: "patternProperties",
+    type: "object",
+    schemaType: "object",
+    code(cxt) {
+      const { gen, schema, data, parentSchema, it } = cxt;
+      const { opts } = it;
+      const patterns = (0, code_1.allSchemaProperties)(schema);
+      const alwaysValidPatterns = patterns.filter((p) => (0, util_1.alwaysValidSchema)(it, schema[p]));
+      if (patterns.length === 0 || alwaysValidPatterns.length === patterns.length && (!it.opts.unevaluated || it.props === true)) return;
+      const checkProperties = opts.strictSchema && !opts.allowMatchingProperties && parentSchema.properties;
+      const valid = gen.name("valid");
+      if (it.props !== true && !(it.props instanceof codegen_1.Name)) it.props = (0, util_2.evaluatedPropsToName)(gen, it.props);
+      const { props } = it;
+      validatePatternProperties();
+      function validatePatternProperties() {
+        for (const pat of patterns) {
+          if (checkProperties) checkMatchingProperties(pat);
+          if (it.allErrors) validateProperties(pat);
+          else {
+            gen.var(valid, true);
+            validateProperties(pat);
+            gen.if(valid);
+          }
+        }
+      }
+      function checkMatchingProperties(pat) {
+        for (const prop in checkProperties) if (new RegExp(pat).test(prop)) (0, util_1.checkStrictMode)(it, `property ${prop} matches pattern ${pat} (use allowMatchingProperties)`);
+      }
+      function validateProperties(pat) {
+        gen.forIn("key", data, (key) => {
+          gen.if((0, codegen_1._)`${(0, code_1.usePattern)(cxt, pat)}.test(${key})`, () => {
+            const alwaysValid = alwaysValidPatterns.includes(pat);
+            if (!alwaysValid) cxt.subschema({
+              keyword: "patternProperties",
+              schemaProp: pat,
+              dataProp: key,
+              dataPropType: util_2.Type.Str
+            }, valid);
+            if (it.opts.unevaluated && props !== true) gen.assign((0, codegen_1._)`${props}[${key}]`, true);
+            else if (!alwaysValid && !it.allErrors) gen.if((0, codegen_1.not)(valid), () => gen.break());
+          });
+        });
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_not2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const util_1 = require_util2();
+  const def = {
+    keyword: "not",
+    schemaType: ["object", "boolean"],
+    trackErrors: true,
+    code(cxt) {
+      const { gen, schema, it } = cxt;
+      if ((0, util_1.alwaysValidSchema)(it, schema)) {
+        cxt.fail();
+        return;
+      }
+      const valid = gen.name("valid");
+      cxt.subschema({
+        keyword: "not",
+        compositeRule: true,
+        createErrors: false,
+        allErrors: false
+      }, valid);
+      cxt.failResult(valid, () => cxt.reset(), () => cxt.error());
+    },
+    error: { message: "must NOT be valid" }
+  };
+  exports.default = def;
+}));
+var require_anyOf2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const def = {
+    keyword: "anyOf",
+    schemaType: "array",
+    trackErrors: true,
+    code: require_code3().validateUnion,
+    error: { message: "must match a schema in anyOf" }
+  };
+  exports.default = def;
+}));
+var require_oneOf2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "oneOf",
+    schemaType: "array",
+    trackErrors: true,
+    error: {
+      message: "must match exactly one schema in oneOf",
+      params: ({ params }) => (0, codegen_1._)`{passingSchemas: ${params.passing}}`
+    },
+    code(cxt) {
+      const { gen, schema, parentSchema, it } = cxt;
+      if (!Array.isArray(schema)) throw new Error("ajv implementation error");
+      if (it.opts.discriminator && parentSchema.discriminator) return;
+      const schArr = schema;
+      const valid = gen.let("valid", false);
+      const passing = gen.let("passing", null);
+      const schValid = gen.name("_valid");
+      cxt.setParams({ passing });
+      gen.block(validateOneOf);
+      cxt.result(valid, () => cxt.reset(), () => cxt.error(true));
+      function validateOneOf() {
+        schArr.forEach((sch, i) => {
+          let schCxt;
+          if ((0, util_1.alwaysValidSchema)(it, sch)) gen.var(schValid, true);
+          else schCxt = cxt.subschema({
+            keyword: "oneOf",
+            schemaProp: i,
+            compositeRule: true
+          }, schValid);
+          if (i > 0) gen.if((0, codegen_1._)`${schValid} && ${valid}`).assign(valid, false).assign(passing, (0, codegen_1._)`[${passing}, ${i}]`).else();
+          gen.if(schValid, () => {
+            gen.assign(valid, true);
+            gen.assign(passing, i);
+            if (schCxt) cxt.mergeEvaluated(schCxt, codegen_1.Name);
+          });
+        });
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_allOf2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const util_1 = require_util2();
+  const def = {
+    keyword: "allOf",
+    schemaType: "array",
+    code(cxt) {
+      const { gen, schema, it } = cxt;
+      if (!Array.isArray(schema)) throw new Error("ajv implementation error");
+      const valid = gen.name("valid");
+      schema.forEach((sch, i) => {
+        if ((0, util_1.alwaysValidSchema)(it, sch)) return;
+        const schCxt = cxt.subschema({
+          keyword: "allOf",
+          schemaProp: i
+        }, valid);
+        cxt.ok(valid);
+        cxt.mergeEvaluated(schCxt);
+      });
+    }
+  };
+  exports.default = def;
+}));
+var require_if2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "if",
+    schemaType: ["object", "boolean"],
+    trackErrors: true,
+    error: {
+      message: ({ params }) => (0, codegen_1.str)`must match "${params.ifClause}" schema`,
+      params: ({ params }) => (0, codegen_1._)`{failingKeyword: ${params.ifClause}}`
+    },
+    code(cxt) {
+      const { gen, parentSchema, it } = cxt;
+      if (parentSchema.then === void 0 && parentSchema.else === void 0) (0, util_1.checkStrictMode)(it, '"if" without "then" and "else" is ignored');
+      const hasThen = hasSchema(it, "then");
+      const hasElse = hasSchema(it, "else");
+      if (!hasThen && !hasElse) return;
+      const valid = gen.let("valid", true);
+      const schValid = gen.name("_valid");
+      validateIf();
+      cxt.reset();
+      if (hasThen && hasElse) {
+        const ifClause = gen.let("ifClause");
+        cxt.setParams({ ifClause });
+        gen.if(schValid, validateClause("then", ifClause), validateClause("else", ifClause));
+      } else if (hasThen) gen.if(schValid, validateClause("then"));
+      else gen.if((0, codegen_1.not)(schValid), validateClause("else"));
+      cxt.pass(valid, () => cxt.error(true));
+      function validateIf() {
+        const schCxt = cxt.subschema({
+          keyword: "if",
+          compositeRule: true,
+          createErrors: false,
+          allErrors: false
+        }, schValid);
+        cxt.mergeEvaluated(schCxt);
+      }
+      function validateClause(keyword, ifClause) {
+        return () => {
+          const schCxt = cxt.subschema({ keyword }, schValid);
+          gen.assign(valid, schValid);
+          cxt.mergeValidEvaluated(schCxt, valid);
+          if (ifClause) gen.assign(ifClause, (0, codegen_1._)`${keyword}`);
+          else cxt.setParams({ ifClause: keyword });
+        };
+      }
+    }
+  };
+  function hasSchema(it, keyword) {
+    const schema = it.schema[keyword];
+    return schema !== void 0 && !(0, util_1.alwaysValidSchema)(it, schema);
+  }
+  exports.default = def;
+}));
+var require_thenElse2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const util_1 = require_util2();
+  const def = {
+    keyword: ["then", "else"],
+    schemaType: ["object", "boolean"],
+    code({ keyword, parentSchema, it }) {
+      if (parentSchema.if === void 0) (0, util_1.checkStrictMode)(it, `"${keyword}" without "if" is ignored`);
+    }
+  };
+  exports.default = def;
+}));
+var require_applicator$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const additionalItems_1 = require_additionalItems2();
+  const prefixItems_1 = require_prefixItems2();
+  const items_1 = require_items2();
+  const items2020_1 = require_items20202();
+  const contains_1 = require_contains2();
+  const dependencies_1 = require_dependencies2();
+  const propertyNames_1 = require_propertyNames2();
+  const additionalProperties_1 = require_additionalProperties2();
+  const properties_1 = require_properties2();
+  const patternProperties_1 = require_patternProperties2();
+  const not_1 = require_not2();
+  const anyOf_1 = require_anyOf2();
+  const oneOf_1 = require_oneOf2();
+  const allOf_1 = require_allOf2();
+  const if_1 = require_if2();
+  const thenElse_1 = require_thenElse2();
+  function getApplicator(draft2020 = false) {
+    const applicator = [
+      not_1.default,
+      anyOf_1.default,
+      oneOf_1.default,
+      allOf_1.default,
+      if_1.default,
+      thenElse_1.default,
+      propertyNames_1.default,
+      additionalProperties_1.default,
+      dependencies_1.default,
+      properties_1.default,
+      patternProperties_1.default
+    ];
+    if (draft2020) applicator.push(prefixItems_1.default, items2020_1.default);
+    else applicator.push(additionalItems_1.default, items_1.default);
+    applicator.push(contains_1.default);
+    return applicator;
+  }
+  exports.default = getApplicator;
+}));
+var require_format$2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const def = {
+    keyword: "format",
+    type: ["number", "string"],
+    schemaType: "string",
+    $data: true,
+    error: {
+      message: ({ schemaCode }) => (0, codegen_1.str)`must match format "${schemaCode}"`,
+      params: ({ schemaCode }) => (0, codegen_1._)`{format: ${schemaCode}}`
+    },
+    code(cxt, ruleType) {
+      const { gen, data, $data, schema, schemaCode, it } = cxt;
+      const { opts, errSchemaPath, schemaEnv, self } = it;
+      if (!opts.validateFormats) return;
+      if ($data) validate$DataFormat();
+      else validateFormat();
+      function validate$DataFormat() {
+        const fmts = gen.scopeValue("formats", {
+          ref: self.formats,
+          code: opts.code.formats
+        });
+        const fDef = gen.const("fDef", (0, codegen_1._)`${fmts}[${schemaCode}]`);
+        const fType = gen.let("fType");
+        const format = gen.let("format");
+        gen.if((0, codegen_1._)`typeof ${fDef} == "object" && !(${fDef} instanceof RegExp)`, () => gen.assign(fType, (0, codegen_1._)`${fDef}.type || "string"`).assign(format, (0, codegen_1._)`${fDef}.validate`), () => gen.assign(fType, (0, codegen_1._)`"string"`).assign(format, fDef));
+        cxt.fail$data((0, codegen_1.or)(unknownFmt(), invalidFmt()));
+        function unknownFmt() {
+          if (opts.strictSchema === false) return codegen_1.nil;
+          return (0, codegen_1._)`${schemaCode} && !${format}`;
+        }
+        function invalidFmt() {
+          const callFormat = schemaEnv.$async ? (0, codegen_1._)`(${fDef}.async ? await ${format}(${data}) : ${format}(${data}))` : (0, codegen_1._)`${format}(${data})`;
+          const validData = (0, codegen_1._)`(typeof ${format} == "function" ? ${callFormat} : ${format}.test(${data}))`;
+          return (0, codegen_1._)`${format} && ${format} !== true && ${fType} === ${ruleType} && !${validData}`;
+        }
+      }
+      function validateFormat() {
+        const formatDef = self.formats[schema];
+        if (!formatDef) {
+          unknownFormat();
+          return;
+        }
+        if (formatDef === true) return;
+        const [fmtType, format, fmtRef] = getFormat(formatDef);
+        if (fmtType === ruleType) cxt.pass(validCondition());
+        function unknownFormat() {
+          if (opts.strictSchema === false) {
+            self.logger.warn(unknownMsg());
+            return;
+          }
+          throw new Error(unknownMsg());
+          function unknownMsg() {
+            return `unknown format "${schema}" ignored in schema at path "${errSchemaPath}"`;
+          }
+        }
+        function getFormat(fmtDef) {
+          const code = fmtDef instanceof RegExp ? (0, codegen_1.regexpCode)(fmtDef) : opts.code.formats ? (0, codegen_1._)`${opts.code.formats}${(0, codegen_1.getProperty)(schema)}` : void 0;
+          const fmt = gen.scopeValue("formats", {
+            key: schema,
+            ref: fmtDef,
+            code
+          });
+          if (typeof fmtDef == "object" && !(fmtDef instanceof RegExp)) return [
+            fmtDef.type || "string",
+            fmtDef.validate,
+            (0, codegen_1._)`${fmt}.validate`
+          ];
+          return [
+            "string",
+            fmtDef,
+            fmt
+          ];
+        }
+        function validCondition() {
+          if (typeof formatDef == "object" && !(formatDef instanceof RegExp) && formatDef.async) {
+            if (!schemaEnv.$async) throw new Error("async format in sync schema");
+            return (0, codegen_1._)`await ${fmtRef}(${data})`;
+          }
+          return typeof format == "function" ? (0, codegen_1._)`${fmtRef}(${data})` : (0, codegen_1._)`${fmtRef}.test(${data})`;
+        }
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_format$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const format = [require_format$2().default];
+  exports.default = format;
+}));
+var require_metadata2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.contentVocabulary = exports.metadataVocabulary = void 0;
+  exports.metadataVocabulary = [
+    "title",
+    "description",
+    "default",
+    "deprecated",
+    "readOnly",
+    "writeOnly",
+    "examples"
+  ];
+  exports.contentVocabulary = [
+    "contentMediaType",
+    "contentEncoding",
+    "contentSchema"
+  ];
+}));
+var require_draft72 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const core_1 = require_core$2();
+  const validation_1 = require_validation$2();
+  const applicator_1 = require_applicator$2();
+  const format_1 = require_format$1();
+  const metadata_1 = require_metadata2();
+  const draft7Vocabularies = [
+    core_1.default,
+    validation_1.default,
+    (0, applicator_1.default)(),
+    format_1.default,
+    metadata_1.metadataVocabulary,
+    metadata_1.contentVocabulary
+  ];
+  exports.default = draft7Vocabularies;
+}));
+var require_types2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.DiscrError = void 0;
+  var DiscrError;
+  (function(DiscrError2) {
+    DiscrError2["Tag"] = "tag";
+    DiscrError2["Mapping"] = "mapping";
+  })(DiscrError || (exports.DiscrError = DiscrError = {}));
+}));
+var require_discriminator2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const types_1 = require_types2();
+  const compile_1 = require_compile2();
+  const ref_error_1 = require_ref_error2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "discriminator",
+    type: "object",
+    schemaType: "object",
+    error: {
+      message: ({ params: { discrError, tagName } }) => discrError === types_1.DiscrError.Tag ? `tag "${tagName}" must be string` : `value of tag "${tagName}" must be in oneOf`,
+      params: ({ params: { discrError, tag, tagName } }) => (0, codegen_1._)`{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`
+    },
+    code(cxt) {
+      const { gen, data, schema, parentSchema, it } = cxt;
+      const { oneOf } = parentSchema;
+      if (!it.opts.discriminator) throw new Error("discriminator: requires discriminator option");
+      const tagName = schema.propertyName;
+      if (typeof tagName != "string") throw new Error("discriminator: requires propertyName");
+      if (schema.mapping) throw new Error("discriminator: mapping is not supported");
+      if (!oneOf) throw new Error("discriminator: requires oneOf keyword");
+      const valid = gen.let("valid", false);
+      const tag = gen.const("tag", (0, codegen_1._)`${data}${(0, codegen_1.getProperty)(tagName)}`);
+      gen.if((0, codegen_1._)`typeof ${tag} == "string"`, () => validateMapping(), () => cxt.error(false, {
+        discrError: types_1.DiscrError.Tag,
+        tag,
+        tagName
+      }));
+      cxt.ok(valid);
+      function validateMapping() {
+        const mapping = getMapping();
+        gen.if(false);
+        for (const tagValue in mapping) {
+          gen.elseIf((0, codegen_1._)`${tag} === ${tagValue}`);
+          gen.assign(valid, applyTagSchema(mapping[tagValue]));
+        }
+        gen.else();
+        cxt.error(false, {
+          discrError: types_1.DiscrError.Mapping,
+          tag,
+          tagName
+        });
+        gen.endIf();
+      }
+      function applyTagSchema(schemaProp) {
+        const _valid = gen.name("valid");
+        const schCxt = cxt.subschema({
+          keyword: "oneOf",
+          schemaProp
+        }, _valid);
+        cxt.mergeEvaluated(schCxt, codegen_1.Name);
+        return _valid;
+      }
+      function getMapping() {
+        var _a3;
+        const oneOfMapping = {};
+        const topRequired = hasRequired(parentSchema);
+        let tagRequired = true;
+        for (let i = 0; i < oneOf.length; i++) {
+          let sch = oneOf[i];
+          if ((sch === null || sch === void 0 ? void 0 : sch.$ref) && !(0, util_1.schemaHasRulesButRef)(sch, it.self.RULES)) {
+            const ref = sch.$ref;
+            sch = compile_1.resolveRef.call(it.self, it.schemaEnv.root, it.baseId, ref);
+            if (sch instanceof compile_1.SchemaEnv) sch = sch.schema;
+            if (sch === void 0) throw new ref_error_1.default(it.opts.uriResolver, it.baseId, ref);
+          }
+          const propSch = (_a3 = sch === null || sch === void 0 ? void 0 : sch.properties) === null || _a3 === void 0 ? void 0 : _a3[tagName];
+          if (typeof propSch != "object") throw new Error(`discriminator: oneOf subschemas (or referenced schemas) must have "properties/${tagName}"`);
+          tagRequired = tagRequired && (topRequired || hasRequired(sch));
+          addMappings(propSch, i);
+        }
+        if (!tagRequired) throw new Error(`discriminator: "${tagName}" must be required`);
+        return oneOfMapping;
+        function hasRequired({ required: required2 }) {
+          return Array.isArray(required2) && required2.includes(tagName);
+        }
+        function addMappings(sch, i) {
+          if (sch.const) addMapping(sch.const, i);
+          else if (sch.enum) for (const tagValue of sch.enum) addMapping(tagValue, i);
+          else throw new Error(`discriminator: "properties/${tagName}" must have "const" or "enum"`);
+        }
+        function addMapping(tagValue, i) {
+          if (typeof tagValue != "string" || tagValue in oneOfMapping) throw new Error(`discriminator: "${tagName}" values must be unique strings`);
+          oneOfMapping[tagValue] = i;
+        }
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_json_schema_draft_072 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+      "schemaArray": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#" }
+      },
+      "nonNegativeInteger": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "nonNegativeIntegerDefault0": { "allOf": [{ "$ref": "#/definitions/nonNegativeInteger" }, { "default": 0 }] },
+      "simpleTypes": { "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ] },
+      "stringArray": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true,
+        "default": []
+      }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+      "$id": {
+        "type": "string",
+        "format": "uri-reference"
+      },
+      "$schema": {
+        "type": "string",
+        "format": "uri"
+      },
+      "$ref": {
+        "type": "string",
+        "format": "uri-reference"
+      },
+      "$comment": { "type": "string" },
+      "title": { "type": "string" },
+      "description": { "type": "string" },
+      "default": true,
+      "readOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "examples": {
+        "type": "array",
+        "items": true
+      },
+      "multipleOf": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "maximum": { "type": "number" },
+      "exclusiveMaximum": { "type": "number" },
+      "minimum": { "type": "number" },
+      "exclusiveMinimum": { "type": "number" },
+      "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+      "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+      "pattern": {
+        "type": "string",
+        "format": "regex"
+      },
+      "additionalItems": { "$ref": "#" },
+      "items": {
+        "anyOf": [{ "$ref": "#" }, { "$ref": "#/definitions/schemaArray" }],
+        "default": true
+      },
+      "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+      "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+      "uniqueItems": {
+        "type": "boolean",
+        "default": false
+      },
+      "contains": { "$ref": "#" },
+      "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+      "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+      "required": { "$ref": "#/definitions/stringArray" },
+      "additionalProperties": { "$ref": "#" },
+      "definitions": {
+        "type": "object",
+        "additionalProperties": { "$ref": "#" },
+        "default": {}
+      },
+      "properties": {
+        "type": "object",
+        "additionalProperties": { "$ref": "#" },
+        "default": {}
+      },
+      "patternProperties": {
+        "type": "object",
+        "additionalProperties": { "$ref": "#" },
+        "propertyNames": { "format": "regex" },
+        "default": {}
+      },
+      "dependencies": {
+        "type": "object",
+        "additionalProperties": { "anyOf": [{ "$ref": "#" }, { "$ref": "#/definitions/stringArray" }] }
+      },
+      "propertyNames": { "$ref": "#" },
+      "const": true,
+      "enum": {
+        "type": "array",
+        "items": true,
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "type": { "anyOf": [{ "$ref": "#/definitions/simpleTypes" }, {
+        "type": "array",
+        "items": { "$ref": "#/definitions/simpleTypes" },
+        "minItems": 1,
+        "uniqueItems": true
+      }] },
+      "format": { "type": "string" },
+      "contentMediaType": { "type": "string" },
+      "contentEncoding": { "type": "string" },
+      "if": { "$ref": "#" },
+      "then": { "$ref": "#" },
+      "else": { "$ref": "#" },
+      "allOf": { "$ref": "#/definitions/schemaArray" },
+      "anyOf": { "$ref": "#/definitions/schemaArray" },
+      "oneOf": { "$ref": "#/definitions/schemaArray" },
+      "not": { "$ref": "#" }
+    },
+    "default": true
+  };
+}));
+var require_ajv2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
+  const core_1 = require_core$3();
+  const draft7_1 = require_draft72();
+  const discriminator_1 = require_discriminator2();
+  const draft7MetaSchema = require_json_schema_draft_072();
+  const META_SUPPORT_DATA = ["/properties"];
+  const META_SCHEMA_ID = "http://json-schema.org/draft-07/schema";
+  var Ajv3 = class extends core_1.default {
+    _addVocabularies() {
+      super._addVocabularies();
+      draft7_1.default.forEach((v) => this.addVocabulary(v));
+      if (this.opts.discriminator) this.addKeyword(discriminator_1.default);
+    }
+    _addDefaultMetaSchema() {
+      super._addDefaultMetaSchema();
+      if (!this.opts.meta) return;
+      const metaSchema = this.opts.$data ? this.$dataMetaSchema(draft7MetaSchema, META_SUPPORT_DATA) : draft7MetaSchema;
+      this.addMetaSchema(metaSchema, META_SCHEMA_ID, false);
+      this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
+    }
+    defaultMeta() {
+      return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
+    }
+  };
+  exports.Ajv = Ajv3;
+  module.exports = exports = Ajv3;
+  module.exports.Ajv = Ajv3;
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.default = Ajv3;
+  var validate_1 = require_validate2();
+  Object.defineProperty(exports, "KeywordCxt", {
+    enumerable: true,
+    get: function() {
+      return validate_1.KeywordCxt;
+    }
+  });
+  var codegen_1 = require_codegen2();
+  Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
+      return codegen_1._;
+    }
+  });
+  Object.defineProperty(exports, "str", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.str;
+    }
+  });
+  Object.defineProperty(exports, "stringify", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.stringify;
+    }
+  });
+  Object.defineProperty(exports, "nil", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.nil;
+    }
+  });
+  Object.defineProperty(exports, "Name", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.Name;
+    }
+  });
+  Object.defineProperty(exports, "CodeGen", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.CodeGen;
+    }
+  });
+  var validation_error_1 = require_validation_error2();
+  Object.defineProperty(exports, "ValidationError", {
+    enumerable: true,
+    get: function() {
+      return validation_error_1.default;
+    }
+  });
+  var ref_error_1 = require_ref_error2();
+  Object.defineProperty(exports, "MissingRefError", {
+    enumerable: true,
+    get: function() {
+      return ref_error_1.default;
+    }
+  });
+}));
+var require_dynamicAnchor = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.dynamicAnchor = void 0;
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const compile_1 = require_compile2();
+  const ref_1 = require_ref2();
+  const def = {
+    keyword: "$dynamicAnchor",
+    schemaType: "string",
+    code: (cxt) => dynamicAnchor(cxt, cxt.schema)
+  };
+  function dynamicAnchor(cxt, anchor2) {
+    const { gen, it } = cxt;
+    it.schemaEnv.root.dynamicAnchors[anchor2] = true;
+    const v = (0, codegen_1._)`${names_1.default.dynamicAnchors}${(0, codegen_1.getProperty)(anchor2)}`;
+    const validate2 = it.errSchemaPath === "#" ? it.validateName : _getValidate(cxt);
+    gen.if((0, codegen_1._)`!${v}`, () => gen.assign(v, validate2));
+  }
+  exports.dynamicAnchor = dynamicAnchor;
+  function _getValidate(cxt) {
+    const { schemaEnv, schema, self } = cxt.it;
+    const { root, baseId, localRefs, meta: meta2 } = schemaEnv.root;
+    const { schemaId } = self.opts;
+    const sch = new compile_1.SchemaEnv({
+      schema,
+      schemaId,
+      root,
+      baseId,
+      localRefs,
+      meta: meta2
+    });
+    compile_1.compileSchema.call(self, sch);
+    return (0, ref_1.getValidate)(cxt, sch);
+  }
+  exports.default = def;
+}));
+var require_dynamicRef = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.dynamicRef = void 0;
+  const codegen_1 = require_codegen2();
+  const names_1 = require_names2();
+  const ref_1 = require_ref2();
+  const def = {
+    keyword: "$dynamicRef",
+    schemaType: "string",
+    code: (cxt) => dynamicRef(cxt, cxt.schema)
+  };
+  function dynamicRef(cxt, ref) {
+    const { gen, keyword, it } = cxt;
+    if (ref[0] !== "#") throw new Error(`"${keyword}" only supports hash fragment reference`);
+    const anchor2 = ref.slice(1);
+    if (it.allErrors) _dynamicRef();
+    else {
+      const valid = gen.let("valid", false);
+      _dynamicRef(valid);
+      cxt.ok(valid);
+    }
+    function _dynamicRef(valid) {
+      if (it.schemaEnv.root.dynamicAnchors[anchor2]) {
+        const v = gen.let("_v", (0, codegen_1._)`${names_1.default.dynamicAnchors}${(0, codegen_1.getProperty)(anchor2)}`);
+        gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid));
+      } else _callRef(it.validateName, valid)();
+    }
+    function _callRef(validate2, valid) {
+      return valid ? () => gen.block(() => {
+        (0, ref_1.callRef)(cxt, validate2);
+        gen.let(valid, true);
+      }) : () => (0, ref_1.callRef)(cxt, validate2);
+    }
+  }
+  exports.dynamicRef = dynamicRef;
+  exports.default = def;
+}));
+var require_recursiveAnchor = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dynamicAnchor_1 = require_dynamicAnchor();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "$recursiveAnchor",
+    schemaType: "boolean",
+    code(cxt) {
+      if (cxt.schema) (0, dynamicAnchor_1.dynamicAnchor)(cxt, "");
+      else (0, util_1.checkStrictMode)(cxt.it, "$recursiveAnchor: false is ignored");
+    }
+  };
+  exports.default = def;
+}));
+var require_recursiveRef = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dynamicRef_1 = require_dynamicRef();
+  const def = {
+    keyword: "$recursiveRef",
+    schemaType: "string",
+    code: (cxt) => (0, dynamicRef_1.dynamicRef)(cxt, cxt.schema)
+  };
+  exports.default = def;
+}));
+var require_dynamic = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dynamicAnchor_1 = require_dynamicAnchor();
+  const dynamicRef_1 = require_dynamicRef();
+  const recursiveAnchor_1 = require_recursiveAnchor();
+  const recursiveRef_1 = require_recursiveRef();
+  const dynamic = [
+    dynamicAnchor_1.default,
+    dynamicRef_1.default,
+    recursiveAnchor_1.default,
+    recursiveRef_1.default
+  ];
+  exports.default = dynamic;
+}));
+var require_dependentRequired = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dependencies_1 = require_dependencies2();
+  const def = {
+    keyword: "dependentRequired",
+    type: "object",
+    schemaType: "object",
+    error: dependencies_1.error,
+    code: (cxt) => (0, dependencies_1.validatePropertyDeps)(cxt)
+  };
+  exports.default = def;
+}));
+var require_dependentSchemas = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dependencies_1 = require_dependencies2();
+  const def = {
+    keyword: "dependentSchemas",
+    type: "object",
+    schemaType: "object",
+    code: (cxt) => (0, dependencies_1.validateSchemaDeps)(cxt)
+  };
+  exports.default = def;
+}));
+var require_limitContains = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const util_1 = require_util2();
+  const def = {
+    keyword: ["maxContains", "minContains"],
+    type: "array",
+    schemaType: "number",
+    code({ keyword, parentSchema, it }) {
+      if (parentSchema.contains === void 0) (0, util_1.checkStrictMode)(it, `"${keyword}" without "contains" is ignored`);
+    }
+  };
+  exports.default = def;
+}));
+var require_next = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const dependentRequired_1 = require_dependentRequired();
+  const dependentSchemas_1 = require_dependentSchemas();
+  const limitContains_1 = require_limitContains();
+  const next = [
+    dependentRequired_1.default,
+    dependentSchemas_1.default,
+    limitContains_1.default
+  ];
+  exports.default = next;
+}));
+var require_unevaluatedProperties = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const names_1 = require_names2();
+  const def = {
+    keyword: "unevaluatedProperties",
+    type: "object",
+    schemaType: ["boolean", "object"],
+    trackErrors: true,
+    error: {
+      message: "must NOT have unevaluated properties",
+      params: ({ params }) => (0, codegen_1._)`{unevaluatedProperty: ${params.unevaluatedProperty}}`
+    },
+    code(cxt) {
+      const { gen, schema, data, errsCount, it } = cxt;
+      if (!errsCount) throw new Error("ajv implementation error");
+      const { allErrors, props } = it;
+      if (props instanceof codegen_1.Name) gen.if((0, codegen_1._)`${props} !== true`, () => gen.forIn("key", data, (key) => gen.if(unevaluatedDynamic(props, key), () => unevaluatedPropCode(key))));
+      else if (props !== true) gen.forIn("key", data, (key) => props === void 0 ? unevaluatedPropCode(key) : gen.if(unevaluatedStatic(props, key), () => unevaluatedPropCode(key)));
+      it.props = true;
+      cxt.ok((0, codegen_1._)`${errsCount} === ${names_1.default.errors}`);
+      function unevaluatedPropCode(key) {
+        if (schema === false) {
+          cxt.setParams({ unevaluatedProperty: key });
+          cxt.error();
+          if (!allErrors) gen.break();
+          return;
+        }
+        if (!(0, util_1.alwaysValidSchema)(it, schema)) {
+          const valid = gen.name("valid");
+          cxt.subschema({
+            keyword: "unevaluatedProperties",
+            dataProp: key,
+            dataPropType: util_1.Type.Str
+          }, valid);
+          if (!allErrors) gen.if((0, codegen_1.not)(valid), () => gen.break());
+        }
+      }
+      function unevaluatedDynamic(evaluatedProps, key) {
+        return (0, codegen_1._)`!${evaluatedProps} || !${evaluatedProps}[${key}]`;
+      }
+      function unevaluatedStatic(evaluatedProps, key) {
+        const ps = [];
+        for (const p in evaluatedProps) if (evaluatedProps[p] === true) ps.push((0, codegen_1._)`${key} !== ${p}`);
+        return (0, codegen_1.and)(...ps);
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_unevaluatedItems = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const codegen_1 = require_codegen2();
+  const util_1 = require_util2();
+  const def = {
+    keyword: "unevaluatedItems",
+    type: "array",
+    schemaType: ["boolean", "object"],
+    error: {
+      message: ({ params: { len } }) => (0, codegen_1.str)`must NOT have more than ${len} items`,
+      params: ({ params: { len } }) => (0, codegen_1._)`{limit: ${len}}`
+    },
+    code(cxt) {
+      const { gen, schema, data, it } = cxt;
+      const items = it.items || 0;
+      if (items === true) return;
+      const len = gen.const("len", (0, codegen_1._)`${data}.length`);
+      if (schema === false) {
+        cxt.setParams({ len: items });
+        cxt.fail((0, codegen_1._)`${len} > ${items}`);
+      } else if (typeof schema == "object" && !(0, util_1.alwaysValidSchema)(it, schema)) {
+        const valid = gen.var("valid", (0, codegen_1._)`${len} <= ${items}`);
+        gen.if((0, codegen_1.not)(valid), () => validateItems(valid, items));
+        cxt.ok(valid);
+      }
+      it.items = true;
+      function validateItems(valid, from) {
+        gen.forRange("i", from, len, (i) => {
+          cxt.subschema({
+            keyword: "unevaluatedItems",
+            dataProp: i,
+            dataPropType: util_1.Type.Num
+          }, valid);
+          if (!it.allErrors) gen.if((0, codegen_1.not)(valid), () => gen.break());
+        });
+      }
+    }
+  };
+  exports.default = def;
+}));
+var require_unevaluated$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const unevaluatedProperties_1 = require_unevaluatedProperties();
+  const unevaluatedItems_1 = require_unevaluatedItems();
+  const unevaluated = [unevaluatedProperties_1.default, unevaluatedItems_1.default];
+  exports.default = unevaluated;
+}));
+var require_schema$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+      "https://json-schema.org/draft/2019-09/vocab/validation": true,
+      "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+      "https://json-schema.org/draft/2019-09/vocab/format": false,
+      "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+      { "$ref": "meta/core" },
+      { "$ref": "meta/applicator" },
+      { "$ref": "meta/validation" },
+      { "$ref": "meta/meta-data" },
+      { "$ref": "meta/format" },
+      { "$ref": "meta/content" }
+    ],
+    "type": ["object", "boolean"],
+    "properties": {
+      "definitions": {
+        "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+        "type": "object",
+        "additionalProperties": { "$recursiveRef": "#" },
+        "default": {}
+      },
+      "dependencies": {
+        "$comment": '"dependencies" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to "dependentSchemas" and "dependentRequired"',
+        "type": "object",
+        "additionalProperties": { "anyOf": [{ "$recursiveRef": "#" }, { "$ref": "meta/validation#/$defs/stringArray" }] }
+      }
+    }
+  };
+}));
+var require_applicator$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/applicator",
+    "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/applicator": true },
+    "$recursiveAnchor": true,
+    "title": "Applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "additionalItems": { "$recursiveRef": "#" },
+      "unevaluatedItems": { "$recursiveRef": "#" },
+      "items": { "anyOf": [{ "$recursiveRef": "#" }, { "$ref": "#/$defs/schemaArray" }] },
+      "contains": { "$recursiveRef": "#" },
+      "additionalProperties": { "$recursiveRef": "#" },
+      "unevaluatedProperties": { "$recursiveRef": "#" },
+      "properties": {
+        "type": "object",
+        "additionalProperties": { "$recursiveRef": "#" },
+        "default": {}
+      },
+      "patternProperties": {
+        "type": "object",
+        "additionalProperties": { "$recursiveRef": "#" },
+        "propertyNames": { "format": "regex" },
+        "default": {}
+      },
+      "dependentSchemas": {
+        "type": "object",
+        "additionalProperties": { "$recursiveRef": "#" }
+      },
+      "propertyNames": { "$recursiveRef": "#" },
+      "if": { "$recursiveRef": "#" },
+      "then": { "$recursiveRef": "#" },
+      "else": { "$recursiveRef": "#" },
+      "allOf": { "$ref": "#/$defs/schemaArray" },
+      "anyOf": { "$ref": "#/$defs/schemaArray" },
+      "oneOf": { "$ref": "#/$defs/schemaArray" },
+      "not": { "$recursiveRef": "#" }
+    },
+    "$defs": { "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$recursiveRef": "#" }
+    } }
+  };
+}));
+var require_content$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/content",
+    "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/content": true },
+    "$recursiveAnchor": true,
+    "title": "Content vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "contentMediaType": { "type": "string" },
+      "contentEncoding": { "type": "string" },
+      "contentSchema": { "$recursiveRef": "#" }
+    }
+  };
+}));
+var require_core$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/core",
+    "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true },
+    "$recursiveAnchor": true,
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "$id": {
+        "type": "string",
+        "format": "uri-reference",
+        "$comment": "Non-empty fragments not allowed.",
+        "pattern": "^[^#]*#?$"
+      },
+      "$schema": {
+        "type": "string",
+        "format": "uri"
+      },
+      "$anchor": {
+        "type": "string",
+        "pattern": "^[A-Za-z][-A-Za-z0-9.:_]*$"
+      },
+      "$ref": {
+        "type": "string",
+        "format": "uri-reference"
+      },
+      "$recursiveRef": {
+        "type": "string",
+        "format": "uri-reference"
+      },
+      "$recursiveAnchor": {
+        "type": "boolean",
+        "default": false
+      },
+      "$vocabulary": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string",
+          "format": "uri"
+        },
+        "additionalProperties": { "type": "boolean" }
+      },
+      "$comment": { "type": "string" },
+      "$defs": {
+        "type": "object",
+        "additionalProperties": { "$recursiveRef": "#" },
+        "default": {}
+      }
+    }
+  };
+}));
+var require_format3 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/format",
+    "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/format": true },
+    "$recursiveAnchor": true,
+    "title": "Format vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": { "format": { "type": "string" } }
+  };
+}));
+var require_meta_data$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/meta-data",
+    "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/meta-data": true },
+    "$recursiveAnchor": true,
+    "title": "Meta-data vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "title": { "type": "string" },
+      "description": { "type": "string" },
+      "default": true,
+      "deprecated": {
+        "type": "boolean",
+        "default": false
+      },
+      "readOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "writeOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "examples": {
+        "type": "array",
+        "items": true
+      }
+    }
+  };
+}));
+var require_validation$1 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/meta/validation",
+    "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/validation": true },
+    "$recursiveAnchor": true,
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "multipleOf": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "maximum": { "type": "number" },
+      "exclusiveMaximum": { "type": "number" },
+      "minimum": { "type": "number" },
+      "exclusiveMinimum": { "type": "number" },
+      "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+      "pattern": {
+        "type": "string",
+        "format": "regex"
+      },
+      "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+      "uniqueItems": {
+        "type": "boolean",
+        "default": false
+      },
+      "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minContains": {
+        "$ref": "#/$defs/nonNegativeInteger",
+        "default": 1
+      },
+      "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+      "required": { "$ref": "#/$defs/stringArray" },
+      "dependentRequired": {
+        "type": "object",
+        "additionalProperties": { "$ref": "#/$defs/stringArray" }
+      },
+      "const": true,
+      "enum": {
+        "type": "array",
+        "items": true
+      },
+      "type": { "anyOf": [{ "$ref": "#/$defs/simpleTypes" }, {
+        "type": "array",
+        "items": { "$ref": "#/$defs/simpleTypes" },
+        "minItems": 1,
+        "uniqueItems": true
+      }] }
+    },
+    "$defs": {
+      "nonNegativeInteger": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "nonNegativeIntegerDefault0": {
+        "$ref": "#/$defs/nonNegativeInteger",
+        "default": 0
+      },
+      "simpleTypes": { "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ] },
+      "stringArray": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true,
+        "default": []
+      }
+    }
+  };
+}));
+var require_json_schema_2019_09 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const metaSchema = require_schema$1();
+  const applicator = require_applicator$1();
+  const content = require_content$1();
+  const core = require_core$1();
+  const format = require_format3();
+  const metadata = require_meta_data$1();
+  const validation = require_validation$1();
+  const META_SUPPORT_DATA = ["/properties"];
+  function addMetaSchema2019($data) {
+    [
+      metaSchema,
+      applicator,
+      content,
+      core,
+      with$data(this, format),
+      metadata,
+      with$data(this, validation)
+    ].forEach((sch) => this.addMetaSchema(sch, void 0, false));
+    return this;
+    function with$data(ajv, sch) {
+      return $data ? ajv.$dataMetaSchema(sch, META_SUPPORT_DATA) : sch;
+    }
+  }
+  exports.default = addMetaSchema2019;
+}));
+var require__2019 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv2019 = void 0;
+  const core_1 = require_core$3();
+  const draft7_1 = require_draft72();
+  const dynamic_1 = require_dynamic();
+  const next_1 = require_next();
+  const unevaluated_1 = require_unevaluated$1();
+  const discriminator_1 = require_discriminator2();
+  const json_schema_2019_09_1 = require_json_schema_2019_09();
+  const META_SCHEMA_ID = "https://json-schema.org/draft/2019-09/schema";
+  var Ajv2019 = class extends core_1.default {
+    constructor(opts = {}) {
+      super({
+        ...opts,
+        dynamicRef: true,
+        next: true,
+        unevaluated: true
+      });
+    }
+    _addVocabularies() {
+      super._addVocabularies();
+      this.addVocabulary(dynamic_1.default);
+      draft7_1.default.forEach((v) => this.addVocabulary(v));
+      this.addVocabulary(next_1.default);
+      this.addVocabulary(unevaluated_1.default);
+      if (this.opts.discriminator) this.addKeyword(discriminator_1.default);
+    }
+    _addDefaultMetaSchema() {
+      super._addDefaultMetaSchema();
+      const { $data, meta: meta2 } = this.opts;
+      if (!meta2) return;
+      json_schema_2019_09_1.default.call(this, $data);
+      this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
+    }
+    defaultMeta() {
+      return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
+    }
+  };
+  exports.Ajv2019 = Ajv2019;
+  module.exports = exports = Ajv2019;
+  module.exports.Ajv2019 = Ajv2019;
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.default = Ajv2019;
+  var validate_1 = require_validate2();
+  Object.defineProperty(exports, "KeywordCxt", {
+    enumerable: true,
+    get: function() {
+      return validate_1.KeywordCxt;
+    }
+  });
+  var codegen_1 = require_codegen2();
+  Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
+      return codegen_1._;
+    }
+  });
+  Object.defineProperty(exports, "str", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.str;
+    }
+  });
+  Object.defineProperty(exports, "stringify", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.stringify;
+    }
+  });
+  Object.defineProperty(exports, "nil", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.nil;
+    }
+  });
+  Object.defineProperty(exports, "Name", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.Name;
+    }
+  });
+  Object.defineProperty(exports, "CodeGen", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.CodeGen;
+    }
+  });
+  var validation_error_1 = require_validation_error2();
+  Object.defineProperty(exports, "ValidationError", {
+    enumerable: true,
+    get: function() {
+      return validation_error_1.default;
+    }
+  });
+  var ref_error_1 = require_ref_error2();
+  Object.defineProperty(exports, "MissingRefError", {
+    enumerable: true,
+    get: function() {
+      return ref_error_1.default;
+    }
+  });
+}));
+var require_draft2020 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const core_1 = require_core$2();
+  const validation_1 = require_validation$2();
+  const applicator_1 = require_applicator$2();
+  const dynamic_1 = require_dynamic();
+  const next_1 = require_next();
+  const unevaluated_1 = require_unevaluated$1();
+  const format_1 = require_format$1();
+  const metadata_1 = require_metadata2();
+  const draft2020Vocabularies = [
+    dynamic_1.default,
+    core_1.default,
+    validation_1.default,
+    (0, applicator_1.default)(true),
+    format_1.default,
+    metadata_1.metadataVocabulary,
+    metadata_1.contentVocabulary,
+    next_1.default,
+    unevaluated_1.default
+  ];
+  exports.default = draft2020Vocabularies;
+}));
+var require_schema = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true,
+      "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+      "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+      "https://json-schema.org/draft/2020-12/vocab/content": true
+    },
+    "$dynamicAnchor": "meta",
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+      { "$ref": "meta/core" },
+      { "$ref": "meta/applicator" },
+      { "$ref": "meta/unevaluated" },
+      { "$ref": "meta/validation" },
+      { "$ref": "meta/meta-data" },
+      { "$ref": "meta/format-annotation" },
+      { "$ref": "meta/content" }
+    ],
+    "type": ["object", "boolean"],
+    "$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
+    "properties": {
+      "definitions": {
+        "$comment": '"definitions" has been replaced by "$defs".',
+        "type": "object",
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "deprecated": true,
+        "default": {}
+      },
+      "dependencies": {
+        "$comment": '"dependencies" has been split and replaced by "dependentSchemas" and "dependentRequired" in order to serve their differing semantics.',
+        "type": "object",
+        "additionalProperties": { "anyOf": [{ "$dynamicRef": "#meta" }, { "$ref": "meta/validation#/$defs/stringArray" }] },
+        "deprecated": true,
+        "default": {}
+      },
+      "$recursiveAnchor": {
+        "$comment": '"$recursiveAnchor" has been replaced by "$dynamicAnchor".',
+        "$ref": "meta/core#/$defs/anchorString",
+        "deprecated": true
+      },
+      "$recursiveRef": {
+        "$comment": '"$recursiveRef" has been replaced by "$dynamicRef".',
+        "$ref": "meta/core#/$defs/uriReferenceString",
+        "deprecated": true
+      }
+    }
+  };
+}));
+var require_applicator2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/applicator",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/applicator": true },
+    "$dynamicAnchor": "meta",
+    "title": "Applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "prefixItems": { "$ref": "#/$defs/schemaArray" },
+      "items": { "$dynamicRef": "#meta" },
+      "contains": { "$dynamicRef": "#meta" },
+      "additionalProperties": { "$dynamicRef": "#meta" },
+      "properties": {
+        "type": "object",
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "default": {}
+      },
+      "patternProperties": {
+        "type": "object",
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "propertyNames": { "format": "regex" },
+        "default": {}
+      },
+      "dependentSchemas": {
+        "type": "object",
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "default": {}
+      },
+      "propertyNames": { "$dynamicRef": "#meta" },
+      "if": { "$dynamicRef": "#meta" },
+      "then": { "$dynamicRef": "#meta" },
+      "else": { "$dynamicRef": "#meta" },
+      "allOf": { "$ref": "#/$defs/schemaArray" },
+      "anyOf": { "$ref": "#/$defs/schemaArray" },
+      "oneOf": { "$ref": "#/$defs/schemaArray" },
+      "not": { "$dynamicRef": "#meta" }
+    },
+    "$defs": { "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$dynamicRef": "#meta" }
+    } }
+  };
+}));
+var require_unevaluated = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/unevaluated",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/unevaluated": true },
+    "$dynamicAnchor": "meta",
+    "title": "Unevaluated applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "unevaluatedItems": { "$dynamicRef": "#meta" },
+      "unevaluatedProperties": { "$dynamicRef": "#meta" }
+    }
+  };
+}));
+var require_content = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/content",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/content": true },
+    "$dynamicAnchor": "meta",
+    "title": "Content vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "contentEncoding": { "type": "string" },
+      "contentMediaType": { "type": "string" },
+      "contentSchema": { "$dynamicRef": "#meta" }
+    }
+  };
+}));
+var require_core3 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/core",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true },
+    "$dynamicAnchor": "meta",
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "$id": {
+        "$ref": "#/$defs/uriReferenceString",
+        "$comment": "Non-empty fragments not allowed.",
+        "pattern": "^[^#]*#?$"
+      },
+      "$schema": { "$ref": "#/$defs/uriString" },
+      "$ref": { "$ref": "#/$defs/uriReferenceString" },
+      "$anchor": { "$ref": "#/$defs/anchorString" },
+      "$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+      "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
+      "$vocabulary": {
+        "type": "object",
+        "propertyNames": { "$ref": "#/$defs/uriString" },
+        "additionalProperties": { "type": "boolean" }
+      },
+      "$comment": { "type": "string" },
+      "$defs": {
+        "type": "object",
+        "additionalProperties": { "$dynamicRef": "#meta" }
+      }
+    },
+    "$defs": {
+      "anchorString": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+      },
+      "uriString": {
+        "type": "string",
+        "format": "uri"
+      },
+      "uriReferenceString": {
+        "type": "string",
+        "format": "uri-reference"
+      }
+    }
+  };
+}));
+var require_format_annotation = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/format-annotation": true },
+    "$dynamicAnchor": "meta",
+    "title": "Format vocabulary meta-schema for annotation results",
+    "type": ["object", "boolean"],
+    "properties": { "format": { "type": "string" } }
+  };
+}));
+var require_meta_data = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/meta-data",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/meta-data": true },
+    "$dynamicAnchor": "meta",
+    "title": "Meta-data vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "title": { "type": "string" },
+      "description": { "type": "string" },
+      "default": true,
+      "deprecated": {
+        "type": "boolean",
+        "default": false
+      },
+      "readOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "writeOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "examples": {
+        "type": "array",
+        "items": true
+      }
+    }
+  };
+}));
+var require_validation2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  module.exports = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/validation",
+    "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/validation": true },
+    "$dynamicAnchor": "meta",
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+      "type": { "anyOf": [{ "$ref": "#/$defs/simpleTypes" }, {
+        "type": "array",
+        "items": { "$ref": "#/$defs/simpleTypes" },
+        "minItems": 1,
+        "uniqueItems": true
+      }] },
+      "const": true,
+      "enum": {
+        "type": "array",
+        "items": true
+      },
+      "multipleOf": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "maximum": { "type": "number" },
+      "exclusiveMaximum": { "type": "number" },
+      "minimum": { "type": "number" },
+      "exclusiveMinimum": { "type": "number" },
+      "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+      "pattern": {
+        "type": "string",
+        "format": "regex"
+      },
+      "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+      "uniqueItems": {
+        "type": "boolean",
+        "default": false
+      },
+      "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minContains": {
+        "$ref": "#/$defs/nonNegativeInteger",
+        "default": 1
+      },
+      "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+      "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+      "required": { "$ref": "#/$defs/stringArray" },
+      "dependentRequired": {
+        "type": "object",
+        "additionalProperties": { "$ref": "#/$defs/stringArray" }
+      }
+    },
+    "$defs": {
+      "nonNegativeInteger": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "nonNegativeIntegerDefault0": {
+        "$ref": "#/$defs/nonNegativeInteger",
+        "default": 0
+      },
+      "simpleTypes": { "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ] },
+      "stringArray": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true,
+        "default": []
+      }
+    }
+  };
+}));
+var require_json_schema_2020_12 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const metaSchema = require_schema();
+  const applicator = require_applicator2();
+  const unevaluated = require_unevaluated();
+  const content = require_content();
+  const core = require_core3();
+  const format = require_format_annotation();
+  const metadata = require_meta_data();
+  const validation = require_validation2();
+  const META_SUPPORT_DATA = ["/properties"];
+  function addMetaSchema2020($data) {
+    [
+      metaSchema,
+      applicator,
+      unevaluated,
+      content,
+      core,
+      with$data(this, format),
+      metadata,
+      with$data(this, validation)
+    ].forEach((sch) => this.addMetaSchema(sch, void 0, false));
+    return this;
+    function with$data(ajv, sch) {
+      return $data ? ajv.$dataMetaSchema(sch, META_SUPPORT_DATA) : sch;
+    }
+  }
+  exports.default = addMetaSchema2020;
+}));
+var require__2020 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv2020 = void 0;
+  const core_1 = require_core$3();
+  const draft2020_1 = require_draft2020();
+  const discriminator_1 = require_discriminator2();
+  const json_schema_2020_12_1 = require_json_schema_2020_12();
+  const META_SCHEMA_ID = "https://json-schema.org/draft/2020-12/schema";
+  var Ajv2020 = class extends core_1.default {
+    constructor(opts = {}) {
+      super({
+        ...opts,
+        dynamicRef: true,
+        next: true,
+        unevaluated: true
+      });
+    }
+    _addVocabularies() {
+      super._addVocabularies();
+      draft2020_1.default.forEach((v) => this.addVocabulary(v));
+      if (this.opts.discriminator) this.addKeyword(discriminator_1.default);
+    }
+    _addDefaultMetaSchema() {
+      super._addDefaultMetaSchema();
+      const { $data, meta: meta2 } = this.opts;
+      if (!meta2) return;
+      json_schema_2020_12_1.default.call(this, $data);
+      this.refs["http://json-schema.org/schema"] = META_SCHEMA_ID;
+    }
+    defaultMeta() {
+      return this.opts.defaultMeta = super.defaultMeta() || (this.getSchema(META_SCHEMA_ID) ? META_SCHEMA_ID : void 0);
+    }
+  };
+  exports.Ajv2020 = Ajv2020;
+  module.exports = exports = Ajv2020;
+  module.exports.Ajv2020 = Ajv2020;
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.default = Ajv2020;
+  var validate_1 = require_validate2();
+  Object.defineProperty(exports, "KeywordCxt", {
+    enumerable: true,
+    get: function() {
+      return validate_1.KeywordCxt;
+    }
+  });
+  var codegen_1 = require_codegen2();
+  Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
+      return codegen_1._;
+    }
+  });
+  Object.defineProperty(exports, "str", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.str;
+    }
+  });
+  Object.defineProperty(exports, "stringify", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.stringify;
+    }
+  });
+  Object.defineProperty(exports, "nil", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.nil;
+    }
+  });
+  Object.defineProperty(exports, "Name", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.Name;
+    }
+  });
+  Object.defineProperty(exports, "CodeGen", {
+    enumerable: true,
+    get: function() {
+      return codegen_1.CodeGen;
+    }
+  });
+  var validation_error_1 = require_validation_error2();
+  Object.defineProperty(exports, "ValidationError", {
+    enumerable: true,
+    get: function() {
+      return validation_error_1.default;
+    }
+  });
+  var ref_error_1 = require_ref_error2();
+  Object.defineProperty(exports, "MissingRefError", {
+    enumerable: true,
+    get: function() {
+      return ref_error_1.default;
+    }
+  });
+}));
+var require_formats2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
+  function fmtDef(validate2, compare) {
+    return {
+      validate: validate2,
+      compare
+    };
+  }
+  exports.fullFormats = {
+    date: fmtDef(date4, compareDate),
+    time: fmtDef(getTime(true), compareTime),
+    "date-time": fmtDef(getDateTime(true), compareDateTime),
+    "iso-time": fmtDef(getTime(), compareIsoTime),
+    "iso-date-time": fmtDef(getDateTime(), compareIsoDateTime),
+    duration: /^P(?!$)((\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?|(\d+W)?)$/,
+    uri,
+    "uri-reference": /^(?:[a-z][a-z0-9+\-.]*:)?(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'"()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'"()*+,;=:@]|%[0-9a-f]{2})*)*)?(?:\?(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\-._~!$&'"()*+,;=:@/?]|%[0-9a-f]{2})*)?$/i,
+    "uri-template": /^(?:(?:[^\x00-\x20"'<>%\\^`{|}]|%[0-9a-f]{2})|\{[+#./;?&=,!@|]?(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\*)?(?:,(?:[a-z0-9_]|%[0-9a-f]{2})+(?::[1-9][0-9]{0,3}|\*)?)*\})*$/i,
+    url: /^(?:https?|ftp):\/\/(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u{00a1}-\u{ffff}]+-)*[a-z0-9\u{00a1}-\u{ffff}]+)(?:\.(?:[a-z0-9\u{00a1}-\u{ffff}]+-)*[a-z0-9\u{00a1}-\u{ffff}]+)*(?:\.(?:[a-z\u{00a1}-\u{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$/iu,
+    email: /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i,
+    hostname: /^(?=.{1,253}\.?$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[-0-9a-z]{0,61}[0-9a-z])?)*\.?$/i,
+    ipv4: /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/,
+    ipv6: /^((([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9a-f]{1,4}:){5}(((:[0-9a-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9a-f]{1,4}:){4}(((:[0-9a-f]{1,4}){1,3})|((:[0-9a-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))$/i,
+    regex,
+    uuid: /^(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i,
+    "json-pointer": /^(?:\/(?:[^~/]|~0|~1)*)*$/,
+    "json-pointer-uri-fragment": /^#(?:\/(?:[a-z0-9_\-.!$&'()*+,;:=@]|%[0-9a-f]{2}|~0|~1)*)*$/i,
+    "relative-json-pointer": /^(?:0|[1-9][0-9]*)(?:#|(?:\/(?:[^~/]|~0|~1)*)*)$/,
+    byte,
+    int32: {
+      type: "number",
+      validate: validateInt32
+    },
+    int64: {
+      type: "number",
+      validate: validateInt64
+    },
+    float: {
+      type: "number",
+      validate: validateNumber
+    },
+    double: {
+      type: "number",
+      validate: validateNumber
+    },
+    password: true,
+    binary: true
+  };
+  exports.fastFormats = {
+    ...exports.fullFormats,
+    date: fmtDef(/^\d\d\d\d-[0-1]\d-[0-3]\d$/, compareDate),
+    time: fmtDef(/^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i, compareTime),
+    "date-time": fmtDef(/^\d\d\d\d-[0-1]\d-[0-3]\dt(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i, compareDateTime),
+    "iso-time": fmtDef(/^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)?$/i, compareIsoTime),
+    "iso-date-time": fmtDef(/^\d\d\d\d-[0-1]\d-[0-3]\d[t\s](?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)?$/i, compareIsoDateTime),
+    uri: /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/i,
+    "uri-reference": /^(?:(?:[a-z][a-z0-9+\-.]*:)?\/?\/)?(?:[^\\\s#][^\s#]*)?(?:#[^\\\s]*)?$/i,
+    email: /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i
+  };
+  exports.formatNames = Object.keys(exports.fullFormats);
+  function isLeapYear(year) {
+    return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  }
+  const DATE = /^(\d\d\d\d)-(\d\d)-(\d\d)$/;
+  const DAYS = [
+    0,
+    31,
+    28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31
+  ];
+  function date4(str) {
+    const matches = DATE.exec(str);
+    if (!matches) return false;
+    const year = +matches[1];
+    const month = +matches[2];
+    const day = +matches[3];
+    return month >= 1 && month <= 12 && day >= 1 && day <= (month === 2 && isLeapYear(year) ? 29 : DAYS[month]);
+  }
+  function compareDate(d1, d2) {
+    if (!(d1 && d2)) return void 0;
+    if (d1 > d2) return 1;
+    if (d1 < d2) return -1;
+    return 0;
+  }
+  const TIME = /^(\d\d):(\d\d):(\d\d(?:\.\d+)?)(z|([+-])(\d\d)(?::?(\d\d))?)?$/i;
+  function getTime(strictTimeZone) {
+    return function time3(str) {
+      const matches = TIME.exec(str);
+      if (!matches) return false;
+      const hr = +matches[1];
+      const min = +matches[2];
+      const sec = +matches[3];
+      const tz = matches[4];
+      const tzSign = matches[5] === "-" ? -1 : 1;
+      const tzH = +(matches[6] || 0);
+      const tzM = +(matches[7] || 0);
+      if (tzH > 23 || tzM > 59 || strictTimeZone && !tz) return false;
+      if (hr <= 23 && min <= 59 && sec < 60) return true;
+      const utcMin = min - tzM * tzSign;
+      const utcHr = hr - tzH * tzSign - (utcMin < 0 ? 1 : 0);
+      return (utcHr === 23 || utcHr === -1) && (utcMin === 59 || utcMin === -1) && sec < 61;
+    };
+  }
+  function compareTime(s1, s2) {
+    if (!(s1 && s2)) return void 0;
+    const t1 = (/* @__PURE__ */ new Date("2020-01-01T" + s1)).valueOf();
+    const t2 = (/* @__PURE__ */ new Date("2020-01-01T" + s2)).valueOf();
+    if (!(t1 && t2)) return void 0;
+    return t1 - t2;
+  }
+  function compareIsoTime(t1, t2) {
+    if (!(t1 && t2)) return void 0;
+    const a1 = TIME.exec(t1);
+    const a2 = TIME.exec(t2);
+    if (!(a1 && a2)) return void 0;
+    t1 = a1[1] + a1[2] + a1[3];
+    t2 = a2[1] + a2[2] + a2[3];
+    if (t1 > t2) return 1;
+    if (t1 < t2) return -1;
+    return 0;
+  }
+  const DATE_TIME_SEPARATOR = /t|\s/i;
+  function getDateTime(strictTimeZone) {
+    const time3 = getTime(strictTimeZone);
+    return function date_time(str) {
+      const dateTime = str.split(DATE_TIME_SEPARATOR);
+      return dateTime.length === 2 && date4(dateTime[0]) && time3(dateTime[1]);
+    };
+  }
+  function compareDateTime(dt1, dt2) {
+    if (!(dt1 && dt2)) return void 0;
+    const d1 = new Date(dt1).valueOf();
+    const d2 = new Date(dt2).valueOf();
+    if (!(d1 && d2)) return void 0;
+    return d1 - d2;
+  }
+  function compareIsoDateTime(dt1, dt2) {
+    if (!(dt1 && dt2)) return void 0;
+    const [d1, t1] = dt1.split(DATE_TIME_SEPARATOR);
+    const [d2, t2] = dt2.split(DATE_TIME_SEPARATOR);
+    const res = compareDate(d1, d2);
+    if (res === void 0) return void 0;
+    return res || compareTime(t1, t2);
+  }
+  const NOT_URI_FRAGMENT = /\/|:/;
+  const URI = /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:]|%[0-9a-f]{2})*@)?(?:\[(?:(?:(?:(?:[0-9a-f]{1,4}:){6}|::(?:[0-9a-f]{1,4}:){5}|(?:[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){4}|(?:(?:[0-9a-f]{1,4}:){0,1}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){3}|(?:(?:[0-9a-f]{1,4}:){0,2}[0-9a-f]{1,4})?::(?:[0-9a-f]{1,4}:){2}|(?:(?:[0-9a-f]{1,4}:){0,3}[0-9a-f]{1,4})?::[0-9a-f]{1,4}:|(?:(?:[0-9a-f]{1,4}:){0,4}[0-9a-f]{1,4})?::)(?:[0-9a-f]{1,4}:[0-9a-f]{1,4}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))|(?:(?:[0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4})?::[0-9a-f]{1,4}|(?:(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4})?::)|[Vv][0-9a-f]+\.[a-z0-9\-._~!$&'()*+,;=:]+)\]|(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)|(?:[a-z0-9\-._~!$&'()*+,;=]|%[0-9a-f]{2})*)(?::\d*)?(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*|\/(?:(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)?|(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})+(?:\/(?:[a-z0-9\-._~!$&'()*+,;=:@]|%[0-9a-f]{2})*)*)(?:\?(?:[a-z0-9\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?(?:#(?:[a-z0-9\-._~!$&'()*+,;=:@/?]|%[0-9a-f]{2})*)?$/i;
+  function uri(str) {
+    return NOT_URI_FRAGMENT.test(str) && URI.test(str);
+  }
+  const BYTE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/gm;
+  function byte(str) {
+    BYTE.lastIndex = 0;
+    return BYTE.test(str);
+  }
+  const MIN_INT32 = -(2 ** 31);
+  const MAX_INT32 = 2 ** 31 - 1;
+  function validateInt32(value) {
+    return Number.isInteger(value) && value <= MAX_INT32 && value >= MIN_INT32;
+  }
+  function validateInt64(value) {
+    return Number.isInteger(value);
+  }
+  function validateNumber() {
+    return true;
+  }
+  const Z_ANCHOR = /[^\\]\\Z/;
+  function regex(str) {
+    if (Z_ANCHOR.test(str)) return false;
+    try {
+      new RegExp(str);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}));
+var require_limit2 = /* @__PURE__ */ __commonJSMin(((exports) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.formatLimitDefinition = void 0;
+  const ajv_1 = require_ajv2();
+  const codegen_1 = require_codegen2();
+  const ops = codegen_1.operators;
+  const KWDs = {
+    formatMaximum: {
+      okStr: "<=",
+      ok: ops.LTE,
+      fail: ops.GT
+    },
+    formatMinimum: {
+      okStr: ">=",
+      ok: ops.GTE,
+      fail: ops.LT
+    },
+    formatExclusiveMaximum: {
+      okStr: "<",
+      ok: ops.LT,
+      fail: ops.GTE
+    },
+    formatExclusiveMinimum: {
+      okStr: ">",
+      ok: ops.GT,
+      fail: ops.LTE
+    }
+  };
+  const error2 = {
+    message: ({ keyword, schemaCode }) => (0, codegen_1.str)`should be ${KWDs[keyword].okStr} ${schemaCode}`,
+    params: ({ keyword, schemaCode }) => (0, codegen_1._)`{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`
+  };
+  exports.formatLimitDefinition = {
+    keyword: Object.keys(KWDs),
+    type: "string",
+    schemaType: "string",
+    $data: true,
+    error: error2,
+    code(cxt) {
+      const { gen, data, schemaCode, keyword, it } = cxt;
+      const { opts, self } = it;
+      if (!opts.validateFormats) return;
+      const fCxt = new ajv_1.KeywordCxt(it, self.RULES.all.format.definition, "format");
+      if (fCxt.$data) validate$DataFormat();
+      else validateFormat();
+      function validate$DataFormat() {
+        const fmts = gen.scopeValue("formats", {
+          ref: self.formats,
+          code: opts.code.formats
+        });
+        const fmt = gen.const("fmt", (0, codegen_1._)`${fmts}[${fCxt.schemaCode}]`);
+        cxt.fail$data((0, codegen_1.or)((0, codegen_1._)`typeof ${fmt} != "object"`, (0, codegen_1._)`${fmt} instanceof RegExp`, (0, codegen_1._)`typeof ${fmt}.compare != "function"`, compareCode(fmt)));
+      }
+      function validateFormat() {
+        const format = fCxt.schema;
+        const fmtDef = self.formats[format];
+        if (!fmtDef || fmtDef === true) return;
+        if (typeof fmtDef != "object" || fmtDef instanceof RegExp || typeof fmtDef.compare != "function") throw new Error(`"${keyword}": format "${format}" does not define "compare" function`);
+        const fmt = gen.scopeValue("formats", {
+          key: format,
+          ref: fmtDef,
+          code: opts.code.formats ? (0, codegen_1._)`${opts.code.formats}${(0, codegen_1.getProperty)(format)}` : void 0
+        });
+        cxt.fail$data(compareCode(fmt));
+      }
+      function compareCode(fmt) {
+        return (0, codegen_1._)`${fmt}.compare(${data}, ${schemaCode}) ${KWDs[keyword].fail} 0`;
+      }
+    },
+    dependencies: ["format"]
+  };
+  const formatLimitPlugin = (ajv) => {
+    ajv.addKeyword(exports.formatLimitDefinition);
+    return ajv;
+  };
+  exports.default = formatLimitPlugin;
+}));
+var require_dist2 = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+  Object.defineProperty(exports, "__esModule", { value: true });
+  const formats_1 = require_formats2();
+  const limit_1 = require_limit2();
+  const codegen_1 = require_codegen2();
+  const fullName = new codegen_1.Name("fullFormats");
+  const fastName = new codegen_1.Name("fastFormats");
+  const formatsPlugin = (ajv, opts = { keywords: true }) => {
+    if (Array.isArray(opts)) {
+      addFormats2(ajv, opts, formats_1.fullFormats, fullName);
+      return ajv;
+    }
+    const [formats, exportName] = opts.mode === "fast" ? [formats_1.fastFormats, fastName] : [formats_1.fullFormats, fullName];
+    addFormats2(ajv, opts.formats || formats_1.formatNames, formats, exportName);
+    if (opts.keywords) (0, limit_1.default)(ajv);
+    return ajv;
+  };
+  formatsPlugin.get = (name, mode = "full") => {
+    const f = (mode === "fast" ? formats_1.fastFormats : formats_1.fullFormats)[name];
+    if (!f) throw new Error(`Unknown format "${name}"`);
+    return f;
+  };
+  function addFormats2(ajv, list, fs11, exportName) {
+    var _a3;
+    var _b;
+    (_a3 = (_b = ajv.opts.code).formats) !== null && _a3 !== void 0 || (_b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`);
+    for (const f of list) ajv.addFormat(f, fs11[f]);
+  }
+  module.exports = exports = formatsPlugin;
+  Object.defineProperty(exports, "__esModule", { value: true });
+  exports.default = formatsPlugin;
+}));
+var import_ajv2 = require_ajv2();
+var import__2019 = require__2019();
+var import__2020 = require__2020();
+var import_dist = /* @__PURE__ */ __toESM2(require_dist2(), 1);
+var addFormats = import_dist.default;
+function createDefaultAjvInstance2(engineClass) {
+  const ajv = new engineClass({
+    strict: false,
+    validateFormats: true,
+    validateSchema: false,
+    allErrors: true
+  });
+  addFormats(ajv);
+  return ajv;
+}
+var AjvJsonSchemaValidator2 = class {
+  _ajv;
+  /** Lazy classic (draft-07) engine, built on the first draft-07/draft-06-declared schema. */
+  _ajvDraft7;
+  /** Lazy 2019-09 engine, built on the first 2019-09-declared schema. */
+  _ajv2019;
+  /** True iff the constructor received a caller-supplied engine; the `$schema` dispatch is skipped. */
+  _userAjv;
+  /**
+  * @param ajv - Optional pre-configured AJV-compatible instance. When supplied, this instance is
+  * used for **every** schema regardless of its declared `$schema` (the caller owns dialect
+  * choice). When omitted, the provider constructs per-dialect engines (`Ajv2020`, `Ajv2019`,
+  * and the classic draft-07 `Ajv` for draft-07/06-declared schemas) with
+  * `strict: false`, `validateFormats: true`, `validateSchema: false`, `allErrors: true`, and
+  * `ajv-formats` registered — **lazily, on the first {@linkcode getValidator} call needing each**, so
+  * constructing the provider (e.g. as the default validator of a `Client`/`Server` that never
+  * validates a JSON Schema) does not pay the ajv + ajv-formats instantiation cost. The parameter
+  * is typed structurally so consumers who don't pass an instance need not have `ajv` installed.
+  */
+  constructor(ajv) {
+    this._userAjv = ajv !== void 0;
+    this._ajv = ajv;
+  }
+  /** The underlying 2020-12 engine — the default instance is created on first use. */
+  get ajv() {
+    return this._ajv ??= createDefaultAjvInstance2(import__2020.Ajv2020);
+  }
+  /**
+  * Pick the engine for a schema's declared dialect. A caller-supplied engine is used for
+  * every schema — do not second-guess by `$schema` (bring-your-own-validator means
+  * bring-your-own-dialect). Otherwise: no `$schema` or 2020-12 → `Ajv2020`; 2019-09 →
+  * `Ajv2019`; draft-07 or draft-06 → classic `Ajv`; anything else → `Error`.
+  */
+  _engineFor(schema) {
+    if (this._userAjv) return this.ajv;
+    const dialect = declaredDialect(schema, "pass a pre-configured Ajv instance to AjvJsonSchemaValidator(ajv) to validate other dialects.");
+    if (dialect === "2020-12") return this.ajv;
+    if (dialect === "2019-09") return this._ajv2019 ??= createDefaultAjvInstance2(import__2019.Ajv2019);
+    return this._ajvDraft7 ??= createDefaultAjvInstance2(import_ajv2.Ajv);
+  }
+  getValidator(schema) {
+    const engine = this._engineFor(schema);
+    const ajvValidator = "$id" in schema && typeof schema.$id === "string" ? engine.getSchema(schema.$id) ?? engine.compile(schema) : engine.compile(schema);
+    return (input) => {
+      return ajvValidator(input) ? {
+        valid: true,
+        data: input,
+        errorMessage: void 0
+      } : {
+        valid: false,
+        data: void 0,
+        errorMessage: engine.errorsText(ajvValidator.errors)
+      };
+    };
+  }
+};
+var Ajv2 = import_ajv2.Ajv;
+
+// node_modules/@modelcontextprotocol/client/dist/shimsNode.mjs
+var CORS_IS_POSSIBLE = false;
+
+// node_modules/pkce-challenge/dist/index.node.js
+var crypto;
+crypto = globalThis.crypto?.webcrypto ?? // Node.js [18-16] REPL
+globalThis.crypto ?? // Node.js >18
+import("node:crypto").then((m) => m.webcrypto);
+async function getRandomValues(size) {
+  return (await crypto).getRandomValues(new Uint8Array(size));
+}
+async function random(size) {
+  const mask = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+  const evenDistCutoff = Math.pow(2, 8) - Math.pow(2, 8) % mask.length;
+  let result = "";
+  while (result.length < size) {
+    const randomBytes = await getRandomValues(size - result.length);
+    for (const randomByte of randomBytes) {
+      if (randomByte < evenDistCutoff) {
+        result += mask[randomByte % mask.length];
+      }
+    }
+  }
+  return result;
+}
+async function generateVerifier(length) {
+  return await random(length);
+}
+async function generateChallenge(code_verifier) {
+  const buffer = await (await crypto).subtle.digest("SHA-256", new TextEncoder().encode(code_verifier));
+  return btoa(String.fromCharCode(...new Uint8Array(buffer))).replace(/\//g, "_").replace(/\+/g, "-").replace(/=/g, "");
+}
+async function pkceChallenge(length) {
+  if (!length)
+    length = 43;
+  if (length < 43 || length > 128) {
+    throw `Expected a length between 43 and 128. Received ${length}.`;
+  }
+  const verifier = await generateVerifier(length);
+  const challenge = await generateChallenge(verifier);
+  return {
+    code_verifier: verifier,
+    code_challenge: challenge
+  };
 }
 
 // node_modules/eventsource-parser/dist/index.js
@@ -24731,341 +37113,3651 @@ var EventSourceParserStream = class extends TransformStream {
   }
 };
 
-// node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js
+// node_modules/@modelcontextprotocol/client/dist/index.mjs
+var OAuthClientFlowError = class extends Error {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.OAuthClientFlowError" });
+  }
+  static [Symbol.hasInstance](value) {
+    return brandedHasInstance(this, value);
+  }
+  /**
+  * Brand-based type guard: equivalent to `value instanceof this`, as an
+  * explicit static predicate (the axios/AWS-SDK `isInstance` style). Reads
+  * the caller's own brand via `this`, so every branded subclass gets a
+  * correctly-scoped guard by inheritance. Must be invoked on the class —
+  * in callback position write `v => SdkError.isInstance(v)`, not
+  * `.filter(SdkError.isInstance)` (detached calls throw rather than
+  * silently matching nothing).
+  */
+  static isInstance(value) {
+    if (typeof this !== "function") throw new TypeError("isInstance must be called on the class (e.g. `SdkError.isInstance(value)`); for callbacks use `v => SdkError.isInstance(v)`");
+    return brandedHasInstance(this, value);
+  }
+  constructor(message) {
+    super(message);
+    this.name = new.target.name;
+    stampErrorBrands(this, new.target);
+  }
+};
+var IssuerMismatchError = class extends OAuthClientFlowError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.IssuerMismatchError" });
+  }
+  /** Which check failed — metadata echo (RFC 8414 §3.3) or authorization-response `iss` (RFC 9207). */
+  kind;
+  /** The issuer the client expected (from validated metadata / discovery input). */
+  expected;
+  /** The issuer value that was received. Attacker-controllable on the `'authorization_response'` path. */
+  received;
+  constructor(kind, expected, received) {
+    super(`Issuer mismatch in ${kind === "metadata" ? "authorization server metadata (RFC 8414 \xA73.3)" : "authorization response (RFC 9207)"}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(received)}`);
+    this.kind = kind;
+    this.expected = expected;
+    this.received = received;
+  }
+};
+var RegistrationRejectedError = class extends OAuthClientFlowError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.RegistrationRejectedError" });
+  }
+  /** HTTP status code returned by the registration endpoint. */
+  status;
+  /** Raw response body text (typically an RFC 7591 error JSON document). */
+  body;
+  /** The exact client metadata that was POSTed (after SDK defaults were applied). */
+  submittedMetadata;
+  constructor(args) {
+    super(`Dynamic Client Registration rejected (HTTP ${args.status}): ${args.body}`);
+    this.status = args.status;
+    this.body = args.body;
+    this.submittedMetadata = args.submittedMetadata;
+  }
+};
+var InsecureTokenEndpointError = class extends OAuthClientFlowError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.InsecureTokenEndpointError" });
+  }
+  /** The token endpoint URL that was rejected. */
+  tokenEndpoint;
+  constructor(tokenEndpoint) {
+    super(`Refusing to send credentials to non-https token endpoint '${tokenEndpoint}'. OAuth token requests MUST use TLS (localhost / 127.0.0.1 / ::1 are exempt).`);
+    this.tokenEndpoint = tokenEndpoint;
+  }
+};
+var AuthorizationServerMismatchError = class extends OAuthClientFlowError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.AuthorizationServerMismatchError" });
+  }
+  constructor(recordedIssuer, currentIssuer) {
+    super(`Authorization server changed between redirect and callback (redirected to ${JSON.stringify(recordedIssuer)}, callback resolved ${JSON.stringify(currentIssuer)}); refusing to send authorization_code/code_verifier to a different token endpoint`);
+    this.recordedIssuer = recordedIssuer;
+    this.currentIssuer = currentIssuer;
+  }
+};
+var InsufficientScopeError = class extends OAuthClientFlowError {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.InsufficientScopeError" });
+  }
+  /** The `scope` value from the `WWW-Authenticate` challenge — the scopes the resource server says are required. */
+  requiredScope;
+  /** The `resource_metadata` URL from the `WWW-Authenticate` challenge, if present. */
+  resourceMetadataUrl;
+  /** The `error_description` from the `WWW-Authenticate` challenge, if present. */
+  errorDescription;
+  constructor(init) {
+    super(`Insufficient scope${init.requiredScope ? `: required "${init.requiredScope}"` : ""}`);
+    this.requiredScope = init.requiredScope;
+    this.resourceMetadataUrl = init.resourceMetadataUrl;
+    this.errorDescription = init.errorDescription;
+  }
+};
+function discardIfIssuerMismatch(stored, issuer, opts) {
+  if (stored === void 0) return void 0;
+  if (stored.issuer === void 0) {
+    if (opts?.canPersistStamp !== false) console.warn("[mcp-sdk] SEP-2352: stored OAuth credential has no 'issuer' stamp (pre-upgrade storage or provider not round-tripping the value). SEP-2352 isolation is inactive for this read; ensure your provider round-trips the issuer field.");
+    return stored;
+  }
+  return issuersMatch(stored.issuer, issuer) ? stored : void 0;
+}
+function issuersMatch(a, b) {
+  return a === b || a.endsWith("/") && a.slice(0, -1) === b || b.endsWith("/") && b.slice(0, -1) === a;
+}
+function isOAuthClientProvider(provider) {
+  if (provider == null) return false;
+  const p = provider;
+  return typeof p.tokens === "function" && typeof p.clientInformation === "function";
+}
+async function handleOAuthUnauthorized(provider, ctx, extraAuthOptions) {
+  const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(ctx.response);
+  if (await auth(provider, {
+    serverUrl: ctx.serverUrl,
+    resourceMetadataUrl,
+    scope,
+    fetchFn: ctx.fetchFn,
+    ...extraAuthOptions
+  }) !== "AUTHORIZED") throw new UnauthorizedError();
+}
+function adaptOAuthProvider(provider, extraAuthOptions) {
+  return {
+    token: async () => {
+      return (await provider.tokens())?.access_token;
+    },
+    onUnauthorized: async (ctx) => handleOAuthUnauthorized(provider, ctx, extraAuthOptions)
+  };
+}
+var UnauthorizedError = class extends Error {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.UnauthorizedError" });
+  }
+  static [Symbol.hasInstance](value) {
+    return brandedHasInstance(this, value);
+  }
+  /**
+  * Brand-based type guard: equivalent to `value instanceof this`, as an
+  * explicit static predicate (the axios/AWS-SDK `isInstance` style). Reads
+  * the caller's own brand via `this`, so every branded subclass gets a
+  * correctly-scoped guard by inheritance. Must be invoked on the class —
+  * in callback position write `v => SdkError.isInstance(v)`, not
+  * `.filter(SdkError.isInstance)` (detached calls throw rather than
+  * silently matching nothing).
+  */
+  static isInstance(value) {
+    if (typeof this !== "function") throw new TypeError("isInstance must be called on the class (e.g. `SdkError.isInstance(value)`); for callbacks use `v => SdkError.isInstance(v)`");
+    return brandedHasInstance(this, value);
+  }
+  constructor(message) {
+    super(message ?? "Unauthorized");
+    this.name = "UnauthorizedError";
+    stampErrorBrands(this, new.target);
+  }
+};
+function isIssParameterSupported(metadata) {
+  return metadata?.authorization_response_iss_parameter_supported === true;
+}
+function validateAuthorizationResponseIssuer({ iss, expectedIssuer, issParameterSupported }) {
+  if (expectedIssuer === void 0) return;
+  if (iss === void 0) {
+    if (issParameterSupported) throw new IssuerMismatchError("authorization_response", expectedIssuer, void 0);
+    return;
+  }
+  if (iss !== expectedIssuer) throw new IssuerMismatchError("authorization_response", expectedIssuer, iss);
+}
+function computeScopeUnion(...scopes) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const scope of scopes) {
+    if (!scope) continue;
+    for (const token of scope.split(/\s+/)) if (token) seen.add(token);
+  }
+  return seen.size > 0 ? [...seen].join(" ") : void 0;
+}
+function isStrictScopeSuperset(union2, current) {
+  if (!union2) return false;
+  const currentSet = new Set((current ?? "").split(/\s+/).filter(Boolean));
+  for (const token of union2.split(/\s+/)) if (token && !currentSet.has(token)) return true;
+  return false;
+}
+async function resolveAuthorizationCallbackParams(codeOrParams, iss, provider, serverUrl, opts) {
+  if (typeof codeOrParams === "string") return {
+    authorizationCode: codeOrParams,
+    iss
+  };
+  const issParam = codeOrParams.get("iss") ?? void 0;
+  const code = codeOrParams.get("code");
+  if (code) return {
+    authorizationCode: code,
+    iss: issParam
+  };
+  let metadata = (await provider.discoveryState?.())?.authorizationServerMetadata;
+  if (!metadata) try {
+    metadata = (await discoverOAuthServerInfo(serverUrl, opts)).authorizationServerMetadata;
+  } catch {
+    metadata = void 0;
+  }
+  if (!metadata) throw new UnauthorizedError("Authorization callback failed and the issuer could not be verified");
+  validateAuthorizationResponseIssuer({
+    iss: issParam,
+    expectedIssuer: metadata.issuer,
+    issParameterSupported: isIssParameterSupported(metadata)
+  });
+  const error2 = codeOrParams.get("error");
+  if (error2) throw new OAuthError(error2, codeOrParams.get("error_description") ?? error2, codeOrParams.get("error_uri") ?? void 0);
+  throw new UnauthorizedError("Authorization callback contained neither `code` nor `error`");
+}
+function isClientAuthMethod(method) {
+  return [
+    "client_secret_basic",
+    "client_secret_post",
+    "none"
+  ].includes(method);
+}
+var AUTHORIZATION_CODE_RESPONSE_TYPE = "code";
+var AUTHORIZATION_CODE_CHALLENGE_METHOD = "S256";
+function selectClientAuthMethod(clientInformation, supportedMethods) {
+  const hasClientSecret = clientInformation.client_secret !== void 0;
+  if ("token_endpoint_auth_method" in clientInformation && clientInformation.token_endpoint_auth_method && isClientAuthMethod(clientInformation.token_endpoint_auth_method) && (supportedMethods.length === 0 || supportedMethods.includes(clientInformation.token_endpoint_auth_method))) return clientInformation.token_endpoint_auth_method;
+  if (supportedMethods.length === 0) return hasClientSecret ? "client_secret_basic" : "none";
+  if (hasClientSecret && supportedMethods.includes("client_secret_basic")) return "client_secret_basic";
+  if (hasClientSecret && supportedMethods.includes("client_secret_post")) return "client_secret_post";
+  if (supportedMethods.includes("none")) return "none";
+  return hasClientSecret ? "client_secret_post" : "none";
+}
+function applyClientAuthentication(method, clientInformation, headers, params) {
+  const { client_id, client_secret } = clientInformation;
+  switch (method) {
+    case "client_secret_basic":
+      applyBasicAuth(client_id, client_secret, headers);
+      return;
+    case "client_secret_post":
+      applyPostAuth(client_id, client_secret, params);
+      return;
+    case "none":
+      applyPublicAuth(client_id, params);
+      return;
+    default:
+      throw new Error(`Unsupported client authentication method: ${method}`);
+  }
+}
+function applyBasicAuth(clientId, clientSecret, headers) {
+  if (!clientSecret) throw new Error("client_secret_basic authentication requires a client_secret");
+  const credentials = btoa(`${clientId}:${clientSecret}`);
+  headers.set("Authorization", `Basic ${credentials}`);
+}
+function applyPostAuth(clientId, clientSecret, params) {
+  params.set("client_id", clientId);
+  if (clientSecret) params.set("client_secret", clientSecret);
+}
+function applyPublicAuth(clientId, params) {
+  params.set("client_id", clientId);
+}
+function isLoopbackHost(hostname) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+function assertSecureTokenEndpoint(tokenEndpoint) {
+  const url2 = new URL(String(tokenEndpoint));
+  if (url2.protocol !== "https:" && !isLoopbackHost(url2.hostname)) throw new InsecureTokenEndpointError(url2.href);
+  return url2;
+}
+function deriveApplicationType(redirectUris) {
+  for (const raw of redirectUris ?? []) {
+    let url2;
+    try {
+      url2 = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (url2.protocol !== "http:" && url2.protocol !== "https:") return "native";
+    if (isLoopbackHost(url2.hostname)) return "native";
+  }
+  return "web";
+}
+function resolveClientMetadata(provider) {
+  const clientMetadata = provider.clientMetadata;
+  return {
+    ...clientMetadata,
+    grant_types: clientMetadata.grant_types ?? (provider.redirectUrl === void 0 ? void 0 : ["authorization_code", "refresh_token"]),
+    application_type: clientMetadata.application_type ?? deriveApplicationType(clientMetadata.redirect_uris)
+  };
+}
+async function parseErrorResponse(input) {
+  const statusCode = input instanceof Response ? input.status : void 0;
+  const body = input instanceof Response ? await input.text() : input;
+  try {
+    const result = OAuthErrorResponseSchema.parse(JSON.parse(body));
+    return OAuthError.fromResponse(result);
+  } catch (error2) {
+    const errorMessage = `${statusCode ? `HTTP ${statusCode}: ` : ""}Invalid OAuth error response: ${error2}. Raw body: ${body}`;
+    return new OAuthError(OAuthErrorCode.ServerError, errorMessage);
+  }
+}
+async function auth(provider, options) {
+  try {
+    return await authInternal(provider, options);
+  } catch (error2) {
+    if (error2 instanceof OAuthError) {
+      if (error2.code === OAuthErrorCode.InvalidClient || error2.code === OAuthErrorCode.UnauthorizedClient) {
+        await provider.invalidateCredentials?.("client");
+        await provider.invalidateCredentials?.("tokens");
+        return await authInternal(provider, options);
+      } else if (error2.code === OAuthErrorCode.InvalidGrant) {
+        await provider.invalidateCredentials?.("tokens");
+        return await authInternal(provider, options);
+      }
+    }
+    throw error2;
+  }
+}
+function determineScope(options) {
+  const { requestedScope, resourceMetadata, authServerMetadata, clientMetadata } = options;
+  let effectiveScope = requestedScope || resourceMetadata?.scopes_supported?.join(" ") || clientMetadata.scope;
+  if (effectiveScope && authServerMetadata?.scopes_supported?.includes("offline_access") && !effectiveScope.split(" ").includes("offline_access") && clientMetadata.grant_types?.includes("refresh_token")) effectiveScope = `${effectiveScope} offline_access`;
+  return effectiveScope;
+}
+async function authInternal(provider, { serverUrl, authorizationCode, iss, scope, resourceMetadataUrl, fetchFn, skipIssuerMetadataValidation, forceReauthorization }) {
+  const clientMetadata = resolveClientMetadata(provider);
+  const cachedState = await provider.discoveryState?.();
+  let resourceMetadata;
+  let authorizationServerUrl;
+  let metadata;
+  let freshDiscoveryState;
+  let effectiveResourceMetadataUrl = resourceMetadataUrl;
+  if (!effectiveResourceMetadataUrl && cachedState?.resourceMetadataUrl) effectiveResourceMetadataUrl = new URL(cachedState.resourceMetadataUrl);
+  if (cachedState?.authorizationServerUrl) {
+    authorizationServerUrl = cachedState.authorizationServerUrl;
+    resourceMetadata = cachedState.resourceMetadata;
+    metadata = cachedState.authorizationServerMetadata ?? await discoverAuthorizationServerMetadata(authorizationServerUrl, {
+      fetchFn,
+      skipIssuerValidation: skipIssuerMetadataValidation
+    });
+    if (!resourceMetadata) try {
+      resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl: effectiveResourceMetadataUrl }, fetchFn);
+    } catch (error2) {
+      if (error2 instanceof TypeError) throw error2;
+    }
+    if (metadata !== cachedState.authorizationServerMetadata || resourceMetadata !== cachedState.resourceMetadata) await provider.saveDiscoveryState?.({
+      authorizationServerUrl: String(authorizationServerUrl),
+      resourceMetadataUrl: effectiveResourceMetadataUrl?.toString(),
+      resourceMetadata,
+      authorizationServerMetadata: metadata
+    });
+  } else {
+    const serverInfo = await discoverOAuthServerInfo(serverUrl, {
+      resourceMetadataUrl: effectiveResourceMetadataUrl,
+      fetchFn,
+      skipIssuerMetadataValidation
+    });
+    authorizationServerUrl = serverInfo.authorizationServerUrl;
+    metadata = serverInfo.authorizationServerMetadata;
+    resourceMetadata = serverInfo.resourceMetadata;
+    freshDiscoveryState = {
+      authorizationServerUrl: String(authorizationServerUrl),
+      resourceMetadataUrl: effectiveResourceMetadataUrl?.toString(),
+      resourceMetadata,
+      authorizationServerMetadata: metadata
+    };
+  }
+  const issuer = metadata?.issuer ?? String(authorizationServerUrl);
+  const infoCtx = { issuer };
+  await provider.saveAuthorizationServerUrl?.(issuer);
+  if (authorizationCode !== void 0) {
+    const recordedIssuer = cachedState?.authorizationServerMetadata?.issuer ?? cachedState?.authorizationServerUrl;
+    if (recordedIssuer === void 0) {
+      if (provider.saveDiscoveryState !== void 0) throw new AuthorizationServerMismatchError("discoveryState was not available on the callback leg; ensure your provider persists discoveryState alongside codeVerifier", issuer);
+      console.warn("[mcp-sdk] OAuthClientProvider does not implement saveDiscoveryState()/discoveryState(); the SEP-2352 callback-leg authorization-server binding cannot be checked. Implement discoveryState (persist alongside codeVerifier) \u2014 see docs/migration/upgrade-to-v2.md \xA7SEP-2352.");
+    } else if (!issuersMatch(recordedIssuer, issuer)) throw new AuthorizationServerMismatchError(recordedIssuer, issuer);
+  }
+  if (freshDiscoveryState) await provider.saveDiscoveryState?.(freshDiscoveryState);
+  const resource = await selectResourceURL(serverUrl, provider, resourceMetadata);
+  if (resource) await provider.saveResourceUrl?.(String(resource));
+  const resolvedScope = determineScope({
+    requestedScope: scope,
+    resourceMetadata,
+    authServerMetadata: metadata,
+    clientMetadata: provider.clientMetadata
+  });
+  const rawClientInfo = await Promise.resolve(provider.clientInformation(infoCtx));
+  let clientInformation = discardIfIssuerMismatch(rawClientInfo, issuer, { canPersistStamp: provider.saveClientInformation !== void 0 });
+  if (clientInformation === void 0 && rawClientInfo?.issuer && provider.saveClientInformation === void 0) throw new AuthorizationServerMismatchError(rawClientInfo.issuer, issuer);
+  if (clientInformation && clientInformation.issuer === void 0) {
+    clientInformation = {
+      ...clientInformation,
+      issuer
+    };
+    await provider.saveClientInformation?.(clientInformation, infoCtx);
+  }
+  if (!clientInformation) {
+    if (authorizationCode !== void 0) throw new Error("Existing OAuth client information is required when exchanging an authorization code");
+    const supportsUrlBasedClientId = metadata?.client_id_metadata_document_supported === true;
+    const clientMetadataUrl = provider.clientMetadataUrl;
+    if (clientMetadataUrl && !isHttpsUrl(clientMetadataUrl)) throw new OAuthError(OAuthErrorCode.InvalidClientMetadata, `clientMetadataUrl must be a valid HTTPS URL with a non-root pathname, got: ${clientMetadataUrl}`);
+    if (supportsUrlBasedClientId && clientMetadataUrl) {
+      clientInformation = {
+        client_id: clientMetadataUrl,
+        issuer
+      };
+      await provider.saveClientInformation?.(clientInformation, infoCtx);
+    } else {
+      if (!provider.saveClientInformation) throw new Error("OAuth client information must be saveable for dynamic registration");
+      clientInformation = {
+        ...await registerClient(authorizationServerUrl, {
+          metadata,
+          clientMetadata,
+          scope: resolvedScope,
+          fetchFn
+        }),
+        issuer
+      };
+      await provider.saveClientInformation(clientInformation, infoCtx);
+    }
+  }
+  const nonInteractiveFlow = !provider.redirectUrl;
+  if (authorizationCode !== void 0 || nonInteractiveFlow) {
+    if (authorizationCode !== void 0) validateAuthorizationResponseIssuer({
+      iss,
+      expectedIssuer: metadata?.issuer,
+      issParameterSupported: isIssParameterSupported(metadata)
+    });
+    const tokens$1 = await fetchToken(provider, authorizationServerUrl, {
+      metadata,
+      resource,
+      authorizationCode,
+      iss,
+      scope: resolvedScope,
+      fetchFn
+    });
+    await provider.saveTokens({
+      ...tokens$1,
+      issuer
+    }, infoCtx);
+    return "AUTHORIZED";
+  }
+  let tokens = discardIfIssuerMismatch(await provider.tokens(infoCtx), issuer);
+  if (tokens && tokens.issuer === void 0) {
+    tokens = {
+      ...tokens,
+      issuer
+    };
+    await provider.saveTokens(tokens, infoCtx);
+  }
+  if (tokens?.refresh_token && !forceReauthorization) try {
+    const newTokens = await refreshAuthorization(authorizationServerUrl, {
+      metadata,
+      clientInformation,
+      refreshToken: tokens.refresh_token,
+      resource,
+      addClientAuthentication: provider.addClientAuthentication,
+      fetchFn
+    });
+    await provider.saveTokens({
+      ...newTokens,
+      issuer
+    }, infoCtx);
+    return "AUTHORIZED";
+  } catch (error2) {
+    if (error2 instanceof InsecureTokenEndpointError) throw error2;
+    if (!(error2 instanceof OAuthError) || error2.code === OAuthErrorCode.ServerError) {
+    } else throw error2;
+  }
+  const state = provider.state ? await provider.state() : void 0;
+  const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
+    metadata,
+    clientInformation,
+    state,
+    redirectUrl: provider.redirectUrl,
+    scope: resolvedScope,
+    resource
+  });
+  await provider.saveCodeVerifier(codeVerifier);
+  await provider.redirectToAuthorization(authorizationUrl);
+  return "REDIRECT";
+}
+function isHttpsUrl(value) {
+  if (!value) return false;
+  try {
+    const url2 = new URL(value);
+    return url2.protocol === "https:" && url2.pathname !== "/";
+  } catch {
+    return false;
+  }
+}
+async function selectResourceURL(serverUrl, provider, resourceMetadata) {
+  const defaultResource = resourceUrlFromServerUrl(serverUrl);
+  if (provider.validateResourceURL) return await provider.validateResourceURL(defaultResource, resourceMetadata?.resource);
+  if (!resourceMetadata) return;
+  if (!checkResourceAllowed({
+    requestedResource: defaultResource,
+    configuredResource: resourceMetadata.resource
+  })) throw new Error(`Protected resource ${resourceMetadata.resource} does not match expected ${defaultResource} (or origin)`);
+  return new URL(resourceMetadata.resource);
+}
+function extractWWWAuthenticateParams(res) {
+  const authenticateHeader = res.headers.get("WWW-Authenticate");
+  if (!authenticateHeader) return {};
+  const [type, scheme] = authenticateHeader.split(" ");
+  if (type?.toLowerCase() !== "bearer" || !scheme) return {};
+  const resourceMetadataMatch = extractFieldFromWwwAuth(res, "resource_metadata") || void 0;
+  let resourceMetadataUrl;
+  if (resourceMetadataMatch) try {
+    resourceMetadataUrl = new URL(resourceMetadataMatch);
+  } catch {
+  }
+  const scope = extractFieldFromWwwAuth(res, "scope") || void 0;
+  const error2 = extractFieldFromWwwAuth(res, "error") || void 0;
+  const errorDescription = extractFieldFromWwwAuth(res, "error_description") || void 0;
+  return {
+    resourceMetadataUrl,
+    scope,
+    error: error2,
+    errorDescription
+  };
+}
+function extractFieldFromWwwAuth(response, fieldName) {
+  const wwwAuthHeader = response.headers.get("WWW-Authenticate");
+  if (!wwwAuthHeader) return null;
+  const pattern = new RegExp(String.raw`${fieldName}=(?:"([^"]+)"|([^\s,]+))`);
+  const match = wwwAuthHeader.match(pattern);
+  if (match) {
+    const result = match[1] || match[2];
+    if (result) return result;
+  }
+  return null;
+}
+async function discoverOAuthProtectedResourceMetadata(serverUrl, opts, fetchFn = fetch) {
+  const response = await discoverMetadataWithFallback(serverUrl, "oauth-protected-resource", fetchFn, {
+    protocolVersion: opts?.protocolVersion,
+    metadataUrl: opts?.resourceMetadataUrl
+  });
+  if (!response || response.status === 404) {
+    await response?.text?.().catch(() => {
+    });
+    throw new Error(`Resource server does not implement OAuth 2.0 Protected Resource Metadata.`);
+  }
+  if (!response.ok) {
+    await response.text?.().catch(() => {
+    });
+    throw new Error(`HTTP ${response.status} trying to load well-known OAuth protected resource metadata.`);
+  }
+  return OAuthProtectedResourceMetadataSchema.parse(await response.json());
+}
+async function fetchWithCorsRetry(url2, headers, fetchFn = fetch) {
+  try {
+    return await fetchFn(url2, { headers });
+  } catch (error2) {
+    if (!(error2 instanceof TypeError) || !CORS_IS_POSSIBLE) throw error2;
+    if (headers) try {
+      return await fetchFn(url2, {});
+    } catch (retryError) {
+      if (!(retryError instanceof TypeError)) throw retryError;
+      return;
+    }
+    return;
+  }
+}
+function buildWellKnownPath(wellKnownPrefix, pathname = "", options = {}) {
+  if (pathname.endsWith("/")) pathname = pathname.slice(0, -1);
+  return options.prependPathname ? `${pathname}/.well-known/${wellKnownPrefix}` : `/.well-known/${wellKnownPrefix}${pathname}`;
+}
+async function tryMetadataDiscovery(url2, protocolVersion2, fetchFn = fetch) {
+  return await fetchWithCorsRetry(url2, { "MCP-Protocol-Version": protocolVersion2 }, fetchFn);
+}
+function shouldAttemptFallback(response, pathname) {
+  if (!response) return true;
+  if (pathname === "/") return false;
+  return response.status >= 400 && response.status < 500 || response.status === 502;
+}
+async function discoverMetadataWithFallback(serverUrl, wellKnownType, fetchFn, opts) {
+  const issuer = new URL(serverUrl);
+  const protocolVersion2 = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION2;
+  let url2;
+  if (opts?.metadataUrl) url2 = new URL(opts.metadataUrl);
+  else {
+    const wellKnownPath = buildWellKnownPath(wellKnownType, issuer.pathname);
+    url2 = new URL(wellKnownPath, opts?.metadataServerUrl ?? issuer);
+    url2.search = issuer.search;
+  }
+  let response = await tryMetadataDiscovery(url2, protocolVersion2, fetchFn);
+  if (!opts?.metadataUrl && shouldAttemptFallback(response, issuer.pathname)) response = await tryMetadataDiscovery(new URL(`/.well-known/${wellKnownType}`, issuer), protocolVersion2, fetchFn);
+  return response;
+}
+function buildDiscoveryUrls(authorizationServerUrl) {
+  const url2 = typeof authorizationServerUrl === "string" ? new URL(authorizationServerUrl) : authorizationServerUrl;
+  const hasPath = url2.pathname !== "/";
+  const urlsToTry = [];
+  if (!hasPath) {
+    urlsToTry.push({
+      url: new URL("/.well-known/oauth-authorization-server", url2.origin),
+      type: "oauth"
+    }, {
+      url: new URL(`/.well-known/openid-configuration`, url2.origin),
+      type: "oidc"
+    });
+    return urlsToTry;
+  }
+  let pathname = url2.pathname;
+  if (pathname.endsWith("/")) pathname = pathname.slice(0, -1);
+  urlsToTry.push({
+    url: new URL(`/.well-known/oauth-authorization-server${pathname}`, url2.origin),
+    type: "oauth"
+  }, {
+    url: new URL(`/.well-known/openid-configuration${pathname}`, url2.origin),
+    type: "oidc"
+  }, {
+    url: new URL(`${pathname}/.well-known/openid-configuration`, url2.origin),
+    type: "oidc"
+  });
+  return urlsToTry;
+}
+async function discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn = fetch, protocolVersion: protocolVersion2 = LATEST_PROTOCOL_VERSION2, skipIssuerValidation = false } = {}) {
+  const headers = {
+    "MCP-Protocol-Version": protocolVersion2,
+    Accept: "application/json"
+  };
+  const urlsToTry = buildDiscoveryUrls(authorizationServerUrl);
+  for (const { url: endpointUrl, type } of urlsToTry) {
+    const response = await fetchWithCorsRetry(endpointUrl, headers, fetchFn);
+    if (!response)
+      continue;
+    if (!response.ok) {
+      await response.text?.().catch(() => {
+      });
+      if (response.status >= 400 && response.status < 500 || response.status === 502) continue;
+      throw new Error(`HTTP ${response.status} trying to load ${type === "oauth" ? "OAuth" : "OpenID provider"} metadata from ${endpointUrl}`);
+    }
+    const parsed = type === "oauth" ? OAuthMetadataSchema.parse(await response.json()) : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
+    if (!skipIssuerValidation) {
+      const expectedIssuer = typeof authorizationServerUrl === "string" ? authorizationServerUrl : authorizationServerUrl.href;
+      if (!(parsed.issuer === expectedIssuer || expectedIssuer.endsWith("/") && parsed.issuer === expectedIssuer.slice(0, -1))) throw new IssuerMismatchError("metadata", expectedIssuer, parsed.issuer);
+    }
+    return parsed;
+  }
+}
+async function discoverOAuthServerInfo(serverUrl, opts) {
+  let resourceMetadata;
+  let authorizationServerUrl;
+  try {
+    resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl: opts?.resourceMetadataUrl }, opts?.fetchFn);
+    if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) authorizationServerUrl = resourceMetadata.authorization_servers[0];
+  } catch (error2) {
+    if (error2 instanceof TypeError) throw error2;
+  }
+  if (!authorizationServerUrl) authorizationServerUrl = String(new URL("/", serverUrl));
+  const authorizationServerMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl, {
+    fetchFn: opts?.fetchFn,
+    skipIssuerValidation: opts?.skipIssuerMetadataValidation
+  });
+  return {
+    authorizationServerUrl,
+    authorizationServerMetadata,
+    resourceMetadata
+  };
+}
+async function startAuthorization(authorizationServerUrl, { metadata, clientInformation, redirectUrl, scope, state, resource }) {
+  let authorizationUrl;
+  if (metadata) {
+    authorizationUrl = new URL(metadata.authorization_endpoint);
+    if (!metadata.response_types_supported.includes(AUTHORIZATION_CODE_RESPONSE_TYPE)) throw new Error(`Incompatible auth server: does not support response type ${AUTHORIZATION_CODE_RESPONSE_TYPE}`);
+    if (metadata.code_challenge_methods_supported && !metadata.code_challenge_methods_supported.includes(AUTHORIZATION_CODE_CHALLENGE_METHOD)) throw new Error(`Incompatible auth server: does not support code challenge method ${AUTHORIZATION_CODE_CHALLENGE_METHOD}`);
+  } else authorizationUrl = new URL("/authorize", authorizationServerUrl);
+  const challenge = await pkceChallenge();
+  const codeVerifier = challenge.code_verifier;
+  const codeChallenge = challenge.code_challenge;
+  authorizationUrl.searchParams.set("response_type", AUTHORIZATION_CODE_RESPONSE_TYPE);
+  authorizationUrl.searchParams.set("client_id", clientInformation.client_id);
+  authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizationUrl.searchParams.set("code_challenge_method", AUTHORIZATION_CODE_CHALLENGE_METHOD);
+  authorizationUrl.searchParams.set("redirect_uri", String(redirectUrl));
+  if (state) authorizationUrl.searchParams.set("state", state);
+  if (scope) authorizationUrl.searchParams.set("scope", scope);
+  if (scope?.split(" ").includes("offline_access")) authorizationUrl.searchParams.append("prompt", "consent");
+  if (resource) authorizationUrl.searchParams.set("resource", resource.href);
+  return {
+    authorizationUrl,
+    codeVerifier
+  };
+}
+function prepareAuthorizationCodeRequest(authorizationCode, codeVerifier, redirectUri) {
+  return new URLSearchParams({
+    grant_type: "authorization_code",
+    code: authorizationCode,
+    code_verifier: codeVerifier,
+    redirect_uri: String(redirectUri)
+  });
+}
+async function executeTokenRequest(authorizationServerUrl, { metadata, tokenRequestParams, clientInformation, addClientAuthentication, resource, fetchFn }) {
+  const tokenUrl = assertSecureTokenEndpoint(metadata?.token_endpoint ?? new URL("/token", authorizationServerUrl));
+  const headers = new Headers({
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json"
+  });
+  if (resource) tokenRequestParams.set("resource", resource.href);
+  if (addClientAuthentication) await addClientAuthentication(headers, tokenRequestParams, tokenUrl, metadata);
+  else if (clientInformation) applyClientAuthentication(selectClientAuthMethod(clientInformation, metadata?.token_endpoint_auth_methods_supported ?? []), clientInformation, headers, tokenRequestParams);
+  const response = await (fetchFn ?? fetch)(tokenUrl, {
+    method: "POST",
+    headers,
+    body: tokenRequestParams
+  });
+  if (!response.ok) throw await parseErrorResponse(response);
+  const json = await response.json();
+  try {
+    return OAuthTokensSchema.parse(json);
+  } catch (parseError) {
+    if (typeof json === "object" && json !== null && "error" in json) throw await parseErrorResponse(JSON.stringify(json));
+    throw parseError;
+  }
+}
+async function refreshAuthorization(authorizationServerUrl, { metadata, clientInformation, refreshToken, resource, addClientAuthentication, fetchFn }) {
+  return {
+    refresh_token: refreshToken,
+    ...await executeTokenRequest(authorizationServerUrl, {
+      metadata,
+      tokenRequestParams: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken
+      }),
+      clientInformation,
+      addClientAuthentication,
+      resource,
+      fetchFn
+    })
+  };
+}
+async function fetchToken(provider, authorizationServerUrl, { metadata, resource, authorizationCode, iss, scope, fetchFn } = {}) {
+  if (authorizationCode !== void 0) validateAuthorizationResponseIssuer({
+    iss,
+    expectedIssuer: metadata?.issuer,
+    issParameterSupported: isIssParameterSupported(metadata)
+  });
+  const effectiveScope = scope ?? provider.clientMetadata.scope;
+  let tokenRequestParams;
+  if (provider.prepareTokenRequest) tokenRequestParams = await provider.prepareTokenRequest(effectiveScope);
+  if (!tokenRequestParams) {
+    if (!authorizationCode) throw new Error("Either provider.prepareTokenRequest() or authorizationCode is required");
+    if (!provider.redirectUrl) throw new Error("redirectUrl is required for authorization_code flow");
+    tokenRequestParams = prepareAuthorizationCodeRequest(authorizationCode, await provider.codeVerifier(), provider.redirectUrl);
+  }
+  const clientInformation = await provider.clientInformation({ issuer: metadata?.issuer ?? String(authorizationServerUrl) });
+  return executeTokenRequest(authorizationServerUrl, {
+    metadata,
+    tokenRequestParams,
+    clientInformation: clientInformation ?? void 0,
+    addClientAuthentication: provider.addClientAuthentication,
+    resource,
+    fetchFn
+  });
+}
+async function registerClient(authorizationServerUrl, { metadata, clientMetadata, scope, fetchFn }) {
+  let registrationUrl;
+  if (metadata) {
+    if (!metadata.registration_endpoint) throw new Error("Incompatible auth server: does not support dynamic client registration");
+    registrationUrl = new URL(metadata.registration_endpoint);
+  } else registrationUrl = new URL("/register", authorizationServerUrl);
+  const submittedMetadata = {
+    ...clientMetadata,
+    ...scope === void 0 ? {} : { scope }
+  };
+  const response = await (fetchFn ?? fetch)(registrationUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(submittedMetadata)
+  });
+  if (!response.ok) throw new RegistrationRejectedError({
+    status: response.status,
+    body: await response.text(),
+    submittedMetadata
+  });
+  return OAuthClientInformationFullSchema.parse(await response.json());
+}
+var CAP_EXEMPT_METHODS = /* @__PURE__ */ new Set([
+  "tools/list",
+  "prompts/list",
+  "resources/list",
+  "resources/templates/list",
+  "server/discover"
+]);
+var InMemoryResponseCacheStore = class {
+  _entries = /* @__PURE__ */ new Map();
+  _maxEntries;
+  _stamp = 0;
+  /** Count of held entries that are subject to the cap (i.e. not in {@linkcode CAP_EXEMPT_METHODS}). */
+  _cappedSize = 0;
+  constructor(options) {
+    this._maxEntries = options?.maxEntries ?? 512;
+  }
+  /** Number of held entries (for diagnostics / bounding tests). */
+  get size() {
+    return this._entries.size;
+  }
+  get(key) {
+    return this._entries.get(keyOf(key));
+  }
+  set(key, entry) {
+    const k = keyOf(key);
+    const exempt = CAP_EXEMPT_METHODS.has(key.method);
+    const isNew = !this._entries.has(k);
+    if (!exempt && isNew && this._maxEntries > 0 && this._cappedSize >= this._maxEntries) {
+      for (const oldKey of this._entries.keys()) if (!CAP_EXEMPT_METHODS.has(oldKey.slice(0, oldKey.indexOf("\0")))) {
+        this._entries.delete(oldKey);
+        this._cappedSize--;
+        break;
+      }
+    }
+    const stamp = ++this._stamp;
+    this._entries.set(k, {
+      ...entry,
+      stamp
+    });
+    if (isNew && !exempt) this._cappedSize++;
+    return stamp;
+  }
+  delete(key) {
+    if (this._entries.delete(keyOf(key)) && !CAP_EXEMPT_METHODS.has(key.method)) this._cappedSize--;
+  }
+  evict(method) {
+    const prefix = `${method}\0`;
+    const exempt = CAP_EXEMPT_METHODS.has(method);
+    for (const k of this._entries.keys()) if (k.startsWith(prefix)) {
+      this._entries.delete(k);
+      if (!exempt) this._cappedSize--;
+    }
+  }
+  clear() {
+    this._entries.clear();
+    this._cappedSize = 0;
+  }
+};
+function keyOf(key) {
+  return `${key.method}\0${JSON.stringify([key.partition ?? "", key.params ?? ""])}`;
+}
+function genKey(method, params) {
+  return params === void 0 ? method : `${method}\0${params}`;
+}
+var MAX_CACHE_TTL_MS = 864e5;
+var ClientResponseCache = class {
+  /**
+  * Per-logical-key eviction-generation counter. {@linkcode evict} (whole
+  * method) and {@linkcode evictKey} (single `{method, params}`) bump it
+  * before touching the store; {@linkcode captureGeneration} reads it before
+  * the request; {@linkcode write} skips when it moved — so a `list_changed`
+  * arriving mid-walk, or a `resources/updated` arriving while a
+  * `readResource()` for the same URI is in flight, is not overwritten by
+  * the in-flight request's stale write. The map key is `method` for the
+  * list singletons and `` `${method}\0${params}` `` for per-URI keys.
+  *
+  * Growth is bounded by keys the CLIENT has issued a `captureGeneration`
+  * for: {@linkcode captureGeneration} records the key (so an interleaved
+  * {@linkcode evictKey} sees there is an in-flight write to suppress);
+  * {@linkcode evictKey} only bumps a key that is already recorded — a
+  * server streaming `notifications/resources/updated` for URIs the client
+  * has never read therefore cannot grow this map.
+  */
+  _evictionGeneration = /* @__PURE__ */ new Map();
+  /**
+  * `name → Tool` index derived from the cached `tools/list` entry, memoized
+  * against the entry's `stamp` so it re-derives only when the backing entry
+  * changes (mcp.d's `cachedTool` pattern).
+  */
+  _toolIndex;
+  /**
+  * `name → compiled output-schema validator` derived from the cached
+  * `tools/list` entry; same stamp-keyed memoization as `_toolIndex`. Typed
+  * `unknown` so this class stays free of any validator-provider dependency
+  * — the compile callback supplied to {@linkcode outputValidator} owns the
+  * concrete type.
+  */
+  _toolOutputValidatorIndex;
+  /**
+  * The connected server's identity (`serverInfo.name@version`, the
+  * transport's `sessionId`, or a client-generated per-connection
+  * surrogate). Set by the `Client` immediately after a successful connect;
+  * `''` is the pre-connect sentinel. Every storage partition is derived
+  * from this (see `_partitionFor`), so two clients sharing one store but
+  * connected to different servers never collide on `tools/list` and a
+  * server cannot read another server's `'public'` entries.
+  */
+  _serverIdentity = "";
+  constructor(_store, _isUserSupplied, _reportError = () => {
+  }, _cachePartition = "", _now = Date.now) {
+    this._store = _store;
+    this._isUserSupplied = _isUserSupplied;
+    this._reportError = _reportError;
+    this._cachePartition = _cachePartition;
+    this._now = _now;
+  }
+  /** The clock used for every freshness computation and check. */
+  now() {
+    return this._now();
+  }
+  /**
+  * Record the connected server's identity. Called by `Client` immediately
+  * after a successful connect: `serverInfo.name@version` when the server
+  * identified itself, else the transport's `sessionId`, else a
+  * client-generated per-connection surrogate (`serverInfo` is a spec
+  * SHOULD on 2026-07-28, so anonymous servers exist). Surrogate-keyed
+  * partitions are NOT stable across reconnects — no identity means no
+  * cross-connection cache reuse, and a shared long-lived store should
+  * bound its own size accordingly. Every partition derived after this
+  * call is scoped to this identity; entries written under the pre-connect
+  * `''` sentinel are no longer reachable.
+  */
+  setServerIdentity(identity) {
+    this._serverIdentity = identity;
+  }
+  /**
+  * Derive the storage partition for `scope`. The encoding is
+  * `JSON.stringify([serverIdentity, principal])` — JSON escaping makes it
+  * collision-free by construction: a malicious server cannot craft a
+  * `serverInfo.name`/`version` whose concatenated form bleeds into another
+  * server's namespace or another principal's slot, regardless of `@` / `|`
+  * / `"` / NUL in the server-controlled strings. `'public'` →
+  * `[serverIdentity, '']` (shared within this server); `'private'` →
+  * `[serverIdentity, cachePartition]`. When `cachePartition` is `''` the
+  * two coincide.
+  */
+  _partitionFor(scope) {
+    return JSON.stringify([this._serverIdentity, scope === "public" ? "" : this._cachePartition]);
+  }
+  /**
+  * Two-probe lookup: this client's own (private) partition first, then the
+  * connected server's shared (public) partition. The shared probe is gated
+  * on `entry.scope === 'public'` — a co-tenant client that omits
+  * `cachePartition` writes its `'private'`-scoped entries at the public
+  * partition, and serving those to a correctly-partitioned client would
+  * leak private bodies (mcp.d's `cachedEntry` two-probe order; the scope
+  * gate is defence-in-depth on top of the partition split). When
+  * `cachePartition` is `''` the two partitions are identical and only one
+  * probe is issued.
+  */
+  async _probe(method, params) {
+    const key = {
+      method,
+      params: params ?? ""
+    };
+    const ownPartition = this._partitionFor("private");
+    const own2 = await this._store.get({
+      ...key,
+      partition: ownPartition
+    });
+    if (own2 !== void 0) return own2;
+    const sharedPartition = this._partitionFor("public");
+    if (sharedPartition === ownPartition) return void 0;
+    const shared = await this._store.get({
+      ...key,
+      partition: sharedPartition
+    });
+    return shared?.scope === "public" ? shared : void 0;
+  }
+  /**
+  * Bump the per-method generation (so an in-flight {@linkcode write} for the
+  * same method becomes a no-op) and drop the connected server's two list
+  * singletons (own + shared partition; `params: ''`). The generation bump
+  * is unconditional and FIRST — the {@linkcode write} race guard relies on
+  * the bump, not on the store's deletes completing.
+  *
+  * Eviction is scoped to this client's `[serverIdentity, principal]`
+  * partitions (mirroring {@linkcode evictKey}) — the method-wide
+  * `store.evict()` is NOT called, so on a shared store one server's
+  * `list_changed` cannot wipe a co-tenant's entry. A custom store's
+  * `delete()` may throw or reject; each partition is guarded
+  * independently so a failure on one does not skip the other, the failure
+  * is reported via the constructor's sink, and the call resolves so
+  * dispatch proceeds.
+  */
+  async evict(method) {
+    this._evictionGeneration.set(method, (this._evictionGeneration.get(method) ?? 0) + 1);
+    await this._deleteBoth(method, "");
+  }
+  /**
+  * Guarded two-partition delete of `{method, params}`: each partition's
+  * `delete` is independently wrapped so a custom store's failure on one is
+  * reported and does not skip the other, and the call always resolves.
+  */
+  async _deleteBoth(method, params) {
+    const ownPartition = this._partitionFor("private");
+    const sharedPartition = this._partitionFor("public");
+    try {
+      await this._store.delete({
+        method,
+        params,
+        partition: ownPartition
+      });
+    } catch (error2) {
+      this._reportError(error2);
+    }
+    if (sharedPartition !== ownPartition) try {
+      await this._store.delete({
+        method,
+        params,
+        partition: sharedPartition
+      });
+    } catch (error2) {
+      this._reportError(error2);
+    }
+  }
+  /**
+  * Drop the single logical entry `{method, params}` from BOTH the private
+  * and public partitions for this client's connected server (mcp.d's
+  * `invalidateLogical`). Used for `notifications/resources/updated`'s
+  * per-URI eviction. The per-key generation is bumped FIRST (so an
+  * in-flight {@linkcode write} for the same `{method, params}` becomes a
+  * no-op and cannot re-cache the now-stale body) but only when the key was
+  * already recorded by {@linkcode captureGeneration} — bounding the map to
+  * keys the client has actually read. A custom store's `delete()` may
+  * throw or reject; each partition's delete is guarded independently so a
+  * failure on one does not skip the other, and the call resolves so
+  * dispatch proceeds.
+  */
+  async evictKey(method, params) {
+    const gk = genKey(method, params);
+    const current = this._evictionGeneration.get(gk);
+    if (current !== void 0) this._evictionGeneration.set(gk, current + 1);
+    await this._deleteBoth(method, params);
+  }
+  /**
+  * Snapshot the eviction generation for `{method, params}` before issuing
+  * the request (a list walk's page 1, or a `resources/read` for `params`).
+  * Records the key so an interleaved {@linkcode evictKey} for the same
+  * `{method, params}` knows there is an in-flight write to suppress and
+  * bumps; without the record, `evictKey`'s recorded-only bump would skip
+  * and the stale body would be cached.
+  */
+  captureGeneration(method, params) {
+    const gk = genKey(method, params);
+    const current = this._evictionGeneration.get(gk) ?? 0;
+    this._evictionGeneration.set(gk, current);
+    return current;
+  }
+  /**
+  * Write `value` under `{method}` unless the per-method generation moved
+  * since `capturedGen` was taken — a `list_changed` that landed mid-walk has
+  * already invalidated the result the caller is about to write, and
+  * overwriting the eviction with the stale aggregate would lose the
+  * invalidation.
+  *
+  * The value is stored as its JSON-serialized document; serialization
+  * doubles as the mutation barrier, so a caller mutating the returned
+  * aggregate cannot reach the cache or its derived indices. A value that
+  * is not JSON-serializable (reachable only via in-process transports)
+  * fails the write loudly into the `reportError` sink. A custom store
+  * whose `set()` throws or rejects is routed to the same sink and the
+  * write resolves — cache bookkeeping never costs the caller a result it
+  * already fetched.
+  *
+  * `freshness` carries the client-computed `expiresAt` (absolute ms epoch,
+  * `now + ttlMs`) and the server-reported `cacheScope`. The storage
+  * `partition` is derived from the scope via `_partitionFor`:
+  * `'public'` → `[serverIdentity, '']` (shared within this server);
+  * `'private'` → `[serverIdentity, cachePartition]` (so a shared store
+  * never serves a private entry to another identity). Absent `freshness`
+  * preserves the substrate write (no `expiresAt`, private partition) — the
+  * `tools/list` retain-for-schema posture: never served by
+  * {@linkcode read}'s freshness gate, always readable by
+  * {@linkcode toolDefinition}.
+  *
+  * After storing under the derived partition, the same `{method, params}`
+  * is deleted from the OPPOSITE partition (mirroring {@linkcode evictKey}'s
+  * two-partition posture). A server that flips a result's `cacheScope` for
+  * the same key would otherwise leave the previous entry in the other slot
+  * — and since `_probe` checks own-partition first, a stale private entry
+  * would shadow the fresh public one (or a stale public entry would keep
+  * serving co-tenants). Both store calls are independently guarded so a
+  * custom store's failure on one does not skip the other.
+  */
+  async write(method, value, capturedGen, freshness) {
+    if ((this._evictionGeneration.get(genKey(method, freshness?.params)) ?? 0) !== capturedGen) return;
+    const params = freshness?.params ?? "";
+    const ownPartition = this._partitionFor("private");
+    const sharedPartition = this._partitionFor("public");
+    const partition = (freshness?.scope ?? "private") === "public" ? sharedPartition : ownPartition;
+    try {
+      await this._store.set({
+        method,
+        params,
+        partition
+      }, {
+        value: encodeCacheValue(value),
+        expiresAt: freshness?.expiresAt,
+        scope: freshness?.scope
+      });
+    } catch (error2) {
+      this._reportError(error2);
+    }
+    if (sharedPartition !== ownPartition) try {
+      await this._store.delete({
+        method,
+        params,
+        partition: partition === ownPartition ? sharedPartition : ownPartition
+      });
+    } catch (error2) {
+      this._reportError(error2);
+    }
+  }
+  /**
+  * Serve the fresh cached result for `{method, params}`, or `undefined`.
+  * Lookup is the two-probe order (own-partition then this server's shared
+  * partition, gated on `scope === 'public'`); freshness is
+  * `entry.expiresAt > now()` (a missing `expiresAt` is never fresh),
+  * checked BEFORE decoding so stale entries cost no parse. Every hit is
+  * freshly parsed, so the caller owns the value outright. An entry whose
+  * document does not parse or is not an object (corrupted external
+  * store) is reported,
+  * deleted, and treated as a miss — deleted because a fresh-but-corrupt
+  * entry would otherwise re-parse and re-report on every read until its
+  * `expiresAt` passes.
+  */
+  async read(method, params) {
+    const entry = await this._probe(method, params);
+    if (entry?.expiresAt === void 0 || !(entry.expiresAt > this.now())) return void 0;
+    try {
+      const parsed = JSON.parse(entry.value);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new TypeError("cached document is not an object");
+      return { value: parsed };
+    } catch (error2) {
+      this._reportError(error2);
+      await this._deleteBoth(method, params ?? "");
+      return;
+    }
+  }
+  /**
+  * Connection reset. The per-instance default store IS cleared
+  * (connection-scoped); a user-supplied store is NOT — that would defeat
+  * the only reason to supply one. The generation map and every derived
+  * index are dropped regardless: they are connection-scoped even when the
+  * backing store survives, so the next read re-derives from whatever the
+  * store still holds. The server identity returns to the pre-connect
+  * sentinel. The default impl is synchronous, so the `MaybePromise<void>`
+  * return is a plain void here and the caller need not await.
+  */
+  resetForReconnect() {
+    if (!this._isUserSupplied) this._store.clear();
+    this._evictionGeneration.clear();
+    this._toolIndex = void 0;
+    this._toolOutputValidatorIndex = void 0;
+    this._serverIdentity = "";
+  }
+  /**
+  * The descriptor for tool `name` taken from the cached `tools/list` entry.
+  * The `name → Tool` index is memoized against the entry's `stamp` and
+  * re-derived only when the backing entry changes (mcp.d's `cachedTool`).
+  * Returns `undefined` only when no `tools/list` response is held at all,
+  * or the held list does not contain `name`.
+  *
+  * Consumed by `callTool()`'s SEP-2243 `_resolveXMcpHeaderScan` (mirroring)
+  * and, via {@linkcode outputValidator}, its output-schema validation.
+  */
+  async toolDefinition(name) {
+    const entry = await this._probe("tools/list");
+    if (entry === void 0) {
+      this._toolIndex = void 0;
+      return;
+    }
+    if (this._toolIndex?.stamp !== entry.stamp) {
+      const list = this._decodeListTools(entry);
+      const byName = /* @__PURE__ */ new Map();
+      if (list !== void 0) for (const tool of list.tools) byName.set(tool.name, tool);
+      this._toolIndex = {
+        stamp: entry.stamp,
+        byName
+      };
+    }
+    return this._toolIndex.byName.get(name);
+  }
+  /**
+  * The compiled output-schema validator for tool `name`, derived from the
+  * cached `tools/list` entry — same source and same stamp-keyed
+  * memoization as {@linkcode toolDefinition}. The `name → validator` index
+  * re-derives only when the backing entry's stamp changes (a refetched
+  * `tools/list` recompiles; a `list_changed` eviction drops it). Returns
+  * `undefined` when no `tools/list` is held, the tool is absent, or it has
+  * no `outputSchema`.
+  *
+  * `compile` is the caller-supplied validator-compile callback (the
+  * `Client` passes its `_jsonSchemaValidator` wrapper) so this
+  * class carries no validator-provider dependency. One tool's uncompilable
+  * `outputSchema` (e.g. an invalid `pattern` regex or unresolvable `$ref`)
+  * must not poison every other tool's `callTool` — the callback isolates
+  * that compile error per tool by returning a per-tool error variant which
+  * the index stores alongside the good ones, and `callTool` surfaces it as
+  * a typed `InvalidParams` only for that name. Because the error is held on
+  * this stamp-keyed substrate (not a parallel map), it inherits the
+  * substrate's invalidation lifecycle: a `list_changed` eviction drops it,
+  * a refetched `tools/list` re-derives it, and `resetForReconnect` clears
+  * the lot.
+  */
+  async outputValidator(name, compile2) {
+    const entry = await this._probe("tools/list");
+    if (entry === void 0) {
+      this._toolOutputValidatorIndex = void 0;
+      return;
+    }
+    if (this._toolOutputValidatorIndex?.stamp !== entry.stamp) {
+      const list = this._decodeListTools(entry) ?? { tools: [] };
+      const byName = /* @__PURE__ */ new Map();
+      for (const tool of list.tools) {
+        const compiled = compile2(tool);
+        if (compiled !== void 0) byName.set(tool.name, compiled);
+      }
+      this._toolOutputValidatorIndex = {
+        stamp: entry.stamp,
+        byName
+      };
+    }
+    return this._toolOutputValidatorIndex.byName.get(name);
+  }
+  /** Parse a held `tools/list` document for the index builders; a document
+  * that does not parse OR whose `tools` is not an array of objects
+  * (both mean a corrupted external store) is reported and treated as if
+  * nothing were held. Callers memoize the outcome against the entry's
+  * stamp, so a corrupt document costs one parse + report per stamp, not
+  * per lookup. */
+  _decodeListTools(entry) {
+    try {
+      const parsed = JSON.parse(entry.value);
+      if (!Array.isArray(parsed?.tools) || !parsed.tools.every((t) => t !== null && typeof t === "object")) throw new TypeError("cached tools/list document has a malformed tools array");
+      return parsed;
+    } catch (error2) {
+      this._reportError(error2);
+      return;
+    }
+  }
+};
+function encodeCacheValue(value) {
+  let json;
+  try {
+    json = JSON.stringify(value);
+  } catch (error2) {
+    throw new TypeError(`cache value is not JSON-serializable: ${error2 instanceof Error ? error2.message : String(error2)}`);
+  }
+  if (typeof json !== "string") throw new TypeError("cache value is not JSON-serializable: it has no JSON representation");
+  return json;
+}
+var AUTH_SEAM = /* @__PURE__ */ Symbol.for("mcp.authSeamEscape");
+function markAuthSeamEscape(error2) {
+  if (typeof error2 === "object" && error2 !== null || typeof error2 === "function") try {
+    Object.defineProperty(error2, AUTH_SEAM, {
+      value: true,
+      configurable: true
+    });
+  } catch {
+  }
+  return error2;
+}
+function isAuthSeamEscape(error2) {
+  return (typeof error2 === "object" && error2 !== null || typeof error2 === "function") && error2[AUTH_SEAM] === true;
+}
+var UNSUPPORTED_PROTOCOL_VERSION = -32022;
+var NOT_PROBE_RECOGNIZED = /* @__PURE__ */ new Set([
+  -32001,
+  -32020,
+  -32021
+]);
+function classifyProbeOutcome(outcome, context) {
+  switch (outcome.kind) {
+    case "result":
+      return classifyResult(outcome.result, context);
+    case "rpc-error":
+      return classifyRpcError(outcome, context);
+    case "http-error":
+      return classifyHttpError(outcome, context);
+    case "network-error":
+      return classifyNetworkError(outcome.error, context);
+    case "auth-required":
+      return {
+        kind: "error",
+        error: outcome.error
+      };
+    case "closed":
+      if (context.transportKind === "stdio") return { kind: "legacy" };
+      return classifyNetworkError(/* @__PURE__ */ new Error("Connection closed during the version negotiation probe"), context);
+    case "timeout":
+      if (context.transportKind === "stdio") return { kind: "legacy" };
+      return {
+        kind: "error",
+        error: new SdkError(SdkErrorCode.RequestTimeout, `Version negotiation probe timed out after ${outcome.timeoutMs}ms`, { timeout: outcome.timeoutMs })
+      };
+  }
+}
+function classifyResult(result, context) {
+  const parsed = codecForVersion(MODERN_WIRE_REVISION).validateResult("server/discover", result);
+  if (!parsed.ok) return { kind: "legacy" };
+  const supportedVersions = parsed.value.supportedVersions;
+  const overlap = context.clientModernVersions.find((version2) => supportedVersions.includes(version2));
+  if (overlap !== void 0) return {
+    kind: "modern",
+    version: overlap,
+    discover: parsed.value
+  };
+  if (context.fallbackAvailable) return { kind: "legacy" };
+  return {
+    kind: "error",
+    error: new UnsupportedProtocolVersionError({
+      supported: [...supportedVersions],
+      requested: context.requestedVersion
+    })
+  };
+}
+function classifyRpcError(outcome, context) {
+  const { code, message, data } = outcome;
+  if (code === UNSUPPORTED_PROTOCOL_VERSION) {
+    const supported = parseSupportedList(data);
+    if (supported === void 0) return { kind: "legacy" };
+    const error2 = new UnsupportedProtocolVersionError({
+      supported,
+      requested: parseRequested(data) ?? context.requestedVersion
+    }, message);
+    const supportedModern = modernProtocolVersions(supported);
+    const mutual = context.clientModernVersions.find((version2) => supportedModern.includes(version2));
+    if (mutual !== void 0) return {
+      kind: "corrective",
+      version: mutual,
+      error: error2
+    };
+    if (supportedModern.length > 0) return {
+      kind: "error",
+      error: error2
+    };
+    return context.fallbackAvailable ? { kind: "legacy" } : {
+      kind: "error",
+      error: error2
+    };
+  }
+  if (NOT_PROBE_RECOGNIZED.has(code)) return { kind: "legacy" };
+  return { kind: "legacy" };
+}
+function classifyHttpError(outcome, context) {
+  if (outcome.status === 401 || outcome.status === 403) {
+    const isDenial = outcome.status === 403;
+    return {
+      kind: "error",
+      error: new SdkHttpError(isDenial ? SdkErrorCode.ClientHttpForbidden : SdkErrorCode.ClientHttpAuthentication, `Version negotiation failed: ${isDenial ? "the server denied access (HTTP 403)" : "the server requires authorization (HTTP 401)"}`, {
+        status: outcome.status,
+        statusText: outcome.statusText,
+        text: outcome.body
+      })
+    };
+  }
+  if (outcome.status >= 500) return {
+    kind: "error",
+    error: new SdkHttpError(SdkErrorCode.EraNegotiationFailed, `Version negotiation failed: the server answered the probe with HTTP ${outcome.status}`, {
+      status: outcome.status,
+      statusText: outcome.statusText,
+      text: outcome.body
+    })
+  };
+  const rpcError = parseJsonRpcErrorBody(outcome.body);
+  if (rpcError !== void 0) return classifyRpcError(rpcError, context);
+  return { kind: "legacy" };
+}
+function classifyNetworkError(error2, context) {
+  if (context.environment === "browser" && isOpaqueFetchTypeError(error2)) return { kind: "legacy" };
+  return {
+    kind: "error",
+    error: new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation probe failed: ${describeError(error2)}`, { cause: error2 })
+  };
+}
+function isOpaqueFetchTypeError(error2) {
+  return error2 instanceof TypeError || error2 instanceof Error && error2.name === "TypeError";
+}
+function describeError(error2) {
+  return error2 instanceof Error ? error2.message : String(error2);
+}
+function parseSupportedList(data) {
+  if (typeof data !== "object" || data === null) return void 0;
+  const supported = data.supported;
+  if (!Array.isArray(supported) || supported.length === 0 || !supported.every((v) => typeof v === "string")) return;
+  return supported;
+}
+function parseRequested(data) {
+  if (typeof data !== "object" || data === null) return void 0;
+  const requested = data.requested;
+  return typeof requested === "string" ? requested : void 0;
+}
+function parseJsonRpcErrorBody(body) {
+  if (body === void 0 || body === "") return void 0;
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return;
+  }
+  if (typeof parsed !== "object" || parsed === null) return void 0;
+  const error2 = parsed.error;
+  if (typeof error2 !== "object" || error2 === null) return void 0;
+  const { code, message, data } = error2;
+  if (typeof code !== "number") return void 0;
+  return {
+    code,
+    message: typeof message === "string" ? message : "",
+    data
+  };
+}
+var DEFAULT_VERSION_NEGOTIATION_MODE = "legacy";
+function resolveVersionNegotiation(options, supportedProtocolVersionsOption) {
+  const mode = options?.mode ?? DEFAULT_VERSION_NEGOTIATION_MODE;
+  if (mode === "legacy") return { kind: "legacy" };
+  const probe = options?.probe ?? {};
+  if (typeof mode === "object") {
+    if (!isModernProtocolVersion(mode.pin)) throw new TypeError(`versionNegotiation: { pin: '${mode.pin}' } is not a modern protocol revision \u2014 pinning is for 2026-07-28 and later; omit versionNegotiation (or use mode: 'legacy') for 2025-era servers.`);
+    return {
+      kind: "pin",
+      version: mode.pin,
+      probe
+    };
+  }
+  const explicitModern = supportedProtocolVersionsOption ? modernProtocolVersions(supportedProtocolVersionsOption) : [];
+  return {
+    kind: "auto",
+    modernVersions: explicitModern.length > 0 ? explicitModern : [...SUPPORTED_MODERN_PROTOCOL_VERSIONS],
+    fallbackAvailable: supportedProtocolVersionsOption ? legacyProtocolVersions(supportedProtocolVersionsOption).length > 0 : true,
+    probe
+  };
+}
+function detectProbeEnvironment() {
+  const g = globalThis;
+  return g.window !== void 0 && g.document !== void 0 ? "browser" : "node";
+}
+function detectProbeTransportKind(transport) {
+  return "stderr" in transport && "pid" in transport ? "stdio" : "http";
+}
+var ProbeWindow = class ProbeWindow2 {
+  _pending;
+  _probeCounter = 0;
+  _savedOnMessage;
+  _savedOnError;
+  _savedOnClose;
+  _closeDelivered = false;
+  constructor(_transport) {
+    this._transport = _transport;
+    this._savedOnMessage = _transport.onmessage;
+    this._savedOnError = _transport.onerror;
+    this._savedOnClose = _transport.onclose;
+  }
+  static async open(transport) {
+    const window = new ProbeWindow2(transport);
+    transport.onmessage = (message) => {
+      const pending = window._pending;
+      if (pending !== void 0 && (isJSONRPCResultResponse2(message) || isJSONRPCErrorResponse2(message)) && message.id === pending.id) {
+        window._pending = void 0;
+        if (isJSONRPCResultResponse2(message)) pending.resolve({
+          kind: "response",
+          result: message.result
+        });
+        else pending.resolve({
+          kind: "response",
+          error: message.error
+        });
+        return;
+      }
+    };
+    transport.onerror = (error2) => {
+      window._savedOnError?.(error2);
+    };
+    transport.onclose = () => {
+      const pending = window._pending;
+      if (pending !== void 0) {
+        window._pending = void 0;
+        pending.resolve({ kind: "closed" });
+      }
+      window._closeDelivered = true;
+      window._savedOnClose?.();
+    };
+    try {
+      await transport.start();
+    } catch (error2) {
+      window.detach();
+      throw error2;
+    }
+    return window;
+  }
+  /**
+  * Send one probe request and await its reply. Probe ids are strings, so they
+  * never collide with Protocol's numeric ids (e.g. on a shared stdio pipe).
+  */
+  async exchange(buildRequest, timeoutMs) {
+    const id = `server-discover-probe-${++this._probeCounter}`;
+    return new Promise((resolve) => {
+      let settled = false;
+      const settle = (reply) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (this._pending?.id === id) this._pending = void 0;
+        resolve(reply);
+      };
+      const timer = setTimeout(() => settle({ kind: "timeout" }), timeoutMs);
+      this._pending = {
+        id,
+        resolve: settle
+      };
+      this._transport.send(buildRequest(id)).catch((error2) => settle({
+        kind: "send-error",
+        error: error2
+      }));
+    });
+  }
+  /** Detach the window's handlers, restoring any the caller pre-set, leaving the transport's own `start` untouched. */
+  detach() {
+    this._pending = void 0;
+    this._transport.onmessage = this._savedOnMessage;
+    this._transport.onerror = this._savedOnError;
+    if (this._closeDelivered && this._savedOnClose !== void 0) {
+      const saved = this._savedOnClose;
+      const transport = this._transport;
+      let spent = false;
+      const wrapper = () => {
+        if (!spent) {
+          spent = true;
+          return;
+        }
+        saved();
+      };
+      transport.onclose = wrapper;
+      pendingSpentCloseGuards.set(transport, () => {
+        if (transport.onclose === wrapper) transport.onclose = saved;
+      });
+    } else this._transport.onclose = this._savedOnClose;
+  }
+  /** Detach the handlers and arm the one-shot `start()` pass-through for the `Protocol.connect()` handover. */
+  release() {
+    this.detach();
+    const transport = this._transport;
+    const originalStart = transport.start;
+    let armed = true;
+    transport.start = async function() {
+      if (armed) {
+        armed = false;
+        transport.start = originalStart;
+        return;
+      }
+      return originalStart.call(transport);
+    };
+  }
+};
+var pendingSpentCloseGuards = /* @__PURE__ */ new WeakMap();
+function disarmSpentCloseGuard(transport) {
+  const disarm = pendingSpentCloseGuards.get(transport);
+  pendingSpentCloseGuards.delete(transport);
+  disarm?.();
+}
+function buildProbeRequest(id, protocolVersion2, clientInfo, capabilities) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "server/discover",
+    params: { _meta: codecForVersion(protocolVersion2).outboundEnvelope({
+      protocolVersion: protocolVersion2,
+      clientInfo,
+      clientCapabilities: capabilities
+    }) }
+  };
+}
+function normalizeReply(reply, timeoutMs) {
+  switch (reply.kind) {
+    case "response":
+      return reply.error === void 0 ? {
+        kind: "result",
+        result: reply.result
+      } : {
+        kind: "rpc-error",
+        ...reply.error
+      };
+    case "send-error": {
+      const error2 = reply.error;
+      if (isAuthSeamEscape(error2) || error2 instanceof UnauthorizedError || error2 instanceof Error && error2.name === "UnauthorizedError") return {
+        kind: "auth-required",
+        error: error2
+      };
+      if (error2 instanceof SdkHttpError) {
+        const text = error2.data?.text;
+        return {
+          kind: "http-error",
+          status: error2.data.status,
+          body: typeof text === "string" ? text : void 0,
+          statusText: error2.data.statusText
+        };
+      }
+      return {
+        kind: "network-error",
+        error: error2
+      };
+    }
+    case "closed":
+      return { kind: "closed" };
+    case "timeout":
+      return {
+        kind: "timeout",
+        timeoutMs
+      };
+  }
+}
+async function negotiateEra(negotiation, deps) {
+  const timeoutMs = negotiation.probe.timeoutMs ?? deps.defaultTimeoutMs;
+  const maxRetries = Math.max(0, negotiation.probe.maxRetries ?? 0);
+  const clientModernVersions = negotiation.kind === "pin" ? [negotiation.version] : negotiation.modernVersions;
+  const fallbackAvailable = negotiation.kind === "auto" && negotiation.fallbackAvailable;
+  const window = await ProbeWindow.open(deps.transport);
+  const probe = async () => {
+    let requestedVersion = clientModernVersions[0];
+    let correctiveUsed = false;
+    let timeoutRetriesRemaining = maxRetries;
+    for (; ; ) {
+      const reply = await window.exchange((id) => buildProbeRequest(id, requestedVersion, deps.clientInfo, deps.capabilities), timeoutMs);
+      if (reply.kind === "timeout" && timeoutRetriesRemaining > 0) {
+        timeoutRetriesRemaining--;
+        continue;
+      }
+      const outcome = normalizeReply(reply, timeoutMs);
+      const verdict = classifyProbeOutcome(outcome, {
+        clientModernVersions,
+        requestedVersion,
+        fallbackAvailable,
+        environment: deps.environment,
+        transportKind: deps.transportKind
+      });
+      switch (verdict.kind) {
+        case "modern":
+          return {
+            era: "modern",
+            version: verdict.version,
+            discover: verdict.discover
+          };
+        case "corrective":
+          if (correctiveUsed) throw verdict.error;
+          correctiveUsed = true;
+          requestedVersion = verdict.version;
+          continue;
+        case "legacy": {
+          const closedCause = outcome.kind === "closed" ? "the connection closed during the server/discover probe" : void 0;
+          if (negotiation.kind === "pin") throw new SdkError(SdkErrorCode.EraNegotiationFailed, closedCause === void 0 ? `Version negotiation failed: the server did not offer pinned protocol version ${negotiation.version} via server/discover (no fallback in pin mode)` : `Version negotiation failed: ${closedCause} before the server offered pinned protocol version ${negotiation.version} (no fallback in pin mode)`);
+          if (!negotiation.fallbackAvailable) throw new SdkError(SdkErrorCode.EraNegotiationFailed, closedCause === void 0 ? "Version negotiation failed: the server gave no modern evidence and this client supports no pre-2026-07-28 protocol version to fall back to" : `Version negotiation failed: ${closedCause} and this client supports no pre-2026-07-28 protocol version to fall back to`);
+          if (closedCause !== void 0 && deps.disposableProbe !== true) throw new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation failed: ${closedCause} (this transport probed in place \u2014 the disposable sibling probe requires the SDK's base StdioClientTransport)`);
+          return { era: "legacy" };
+        }
+        case "error":
+          throw verdict.error;
+      }
+    }
+  };
+  let result;
+  try {
+    result = await probe();
+  } catch (error2) {
+    window.detach();
+    throw error2;
+  }
+  window.release();
+  return result;
+}
+function readStdioServerParams(transport) {
+  const proto = Object.getPrototypeOf(transport);
+  if (proto === null || !Object.prototype.hasOwnProperty.call(proto, "_dispose")) return;
+  const params = transport._serverParams;
+  return typeof params === "object" && params !== null && typeof params.command === "string" ? params : void 0;
+}
+async function negotiateStdioViaSibling(negotiation, sessionTransport, params, deps) {
+  const SiblingTransport = sessionTransport.constructor;
+  const sibling = new SiblingTransport({
+    ...params,
+    stderr: "ignore"
+  });
+  const originalClose = sessionTransport.close;
+  let callerClosed = false;
+  let signalClosed;
+  const closedSignal = new Promise((_, reject) => {
+    signalClosed = () => reject(callerCloseAbortError());
+  });
+  sessionTransport.close = async function() {
+    callerClosed = true;
+    signalClosed?.();
+    return originalClose.call(sessionTransport);
+  };
+  let result;
+  try {
+    const negotiated = negotiateEra(negotiation, {
+      ...deps,
+      transport: sibling,
+      transportKind: "stdio",
+      disposableProbe: true
+    });
+    negotiated.catch(() => {
+    });
+    result = await Promise.race([negotiated, closedSignal]);
+  } finally {
+    await disposeSibling(sibling);
+    sessionTransport.close = originalClose;
+  }
+  if (callerClosed) throw callerCloseAbortError();
+  return result;
+}
+function callerCloseAbortError() {
+  return new SdkError(SdkErrorCode.EraNegotiationFailed, "Version negotiation failed: the transport was closed during the server/discover probe");
+}
+async function disposeSibling(sibling) {
+  try {
+    const dispose = sibling._dispose;
+    await (typeof dispose === "function" ? dispose.call(sibling) : sibling.close());
+  } catch {
+  }
+}
+function serverInfoFromDiscover(discover) {
+  const fromMeta = discover._meta?.[SERVER_INFO_META_KEY];
+  return isSpecType.Implementation(fromMeta) ? fromMeta : void 0;
+}
+function applyElicitationDefaults(schema, data) {
+  if (!schema || data === null || typeof data !== "object") return;
+  if (schema.type === "object" && schema.properties && typeof schema.properties === "object") {
+    const obj = data;
+    const props = schema.properties;
+    for (const key of Object.keys(props)) {
+      const propSchema = props[key];
+      if (obj[key] === void 0 && Object.prototype.hasOwnProperty.call(propSchema, "default")) obj[key] = propSchema.default;
+      if (obj[key] !== void 0) applyElicitationDefaults(propSchema, obj[key]);
+    }
+  }
+  if (Array.isArray(schema.anyOf)) {
+    for (const sub of schema.anyOf) if (typeof sub !== "boolean") applyElicitationDefaults(sub, data);
+  }
+  if (Array.isArray(schema.oneOf)) {
+    for (const sub of schema.oneOf) if (typeof sub !== "boolean") applyElicitationDefaults(sub, data);
+  }
+}
+function getSupportedElicitationModes(capabilities) {
+  if (!capabilities) return {
+    supportsFormMode: false,
+    supportsUrlMode: false
+  };
+  const hasFormCapability = capabilities.form !== void 0;
+  const hasUrlCapability = capabilities.url !== void 0;
+  return {
+    supportsFormMode: hasFormCapability || !hasFormCapability && !hasUrlCapability,
+    supportsUrlMode: hasUrlCapability
+  };
+}
+function validatePrior(prior) {
+  if (typeof prior === "object" && prior !== null) {
+    if (prior.kind === "legacy" && !("supportedVersions" in prior) && !("discover" in prior)) return prior;
+    if (prior.kind === "modern" && DiscoverResultSchema.safeParse(prior.discover).success) return prior;
+  }
+  throw new SdkError(SdkErrorCode.EraNegotiationFailed, "connect({ prior }): unrecognized prior \u2014 expected { kind: 'modern', discover } or { kind: 'legacy' }");
+}
+var LIST_CHANGED_EVICTIONS = {
+  "notifications/tools/list_changed": ["tools/list"],
+  "notifications/prompts/list_changed": ["prompts/list"],
+  "notifications/resources/list_changed": ["resources/list", "resources/templates/list"]
+};
+var DEFAULT_LIST_MAX_PAGES = 64;
+var Client = class extends Protocol2 {
+  _serverCapabilities;
+  _serverVersion;
+  _capabilities;
+  _instructions;
+  _jsonSchemaValidator;
+  /**
+  * The response-cache substrate. Owns the backing store, the per-method
+  * eviction-generation counter, the user-supplied/default flag, and the
+  * stamp-memoized derived `name → Tool` / `name → output-validator`
+  * indices — the cache-coordination state that used to live as separate
+  * private fields here. The internal aggregating walk writes one entry per
+  * list verb; `list_changed` evicts the matching method;
+  * `_resetConnectionState` resets the lot. {@linkcode callTool}'s
+  * output-schema validation reads the derived `outputValidator` index (the
+  * substrate's first production caller); the stacked SEP-2243 PR wires
+  * `Mcp-Param-*` mirroring through `toolDefinition` on top.
+  */
+  _cache;
+  _defaultCacheTtlMs;
+  _listMaxPages;
+  _listChangedDebounceTimers = /* @__PURE__ */ new Map();
+  /**
+  * The constructor `listChanged` configuration. Durable across reconnects:
+  * read fresh on every connect (legacy or modern), never consumed.
+  */
+  _listChangedConfig;
+  _enforceStrictCapabilities;
+  _versionNegotiation;
+  _supportedProtocolVersionsOption;
+  _inputRequiredDriverConfig;
+  /**
+  * Active subscriptions/listen state, keyed by subscription id (= the
+  * listen request's JSON-RPC id verbatim). The id is a STRING from a
+  * Client-owned counter (`'listen:' + N`) — JSON-RPC permits string ids,
+  * and Protocol's numeric `_requestMessageId` counter only ever issues
+  * numbers, so listen ids cannot collide with ordinary request ids.
+  */
+  _listenState = /* @__PURE__ */ new Map();
+  _nextListenId = 0;
+  /** The auto-opened subscription backing ClientOptions.listChanged on a modern connection. */
+  _autoOpenedSubscription;
+  /** Backing store for {@linkcode getDiscoverResult}. Per-connection. */
+  _discoverResult;
+  /**
+  * Clears every per-connection field in one place. Called at the start of
+  * each fresh (non-resuming) connect and from `close()`, so a stale
+  * negotiated era / server identity / auto-opened subscription cannot
+  * survive a reconnect.
+  */
+  _resetConnectionState() {
+    this._negotiatedProtocolVersion = void 0;
+    this._serverCapabilities = void 0;
+    this._serverVersion = void 0;
+    this._instructions = void 0;
+    this._discoverResult = void 0;
+    this._autoOpenedSubscription = void 0;
+    if (this._listenState.size > 0) {
+      const reason = new SdkError(SdkErrorCode.ConnectionClosed, "subscriptions/listen: client reconnected or closed; subscription state from the previous connection was reset");
+      for (const entry of this._listenState.values()) entry.settle({
+        cause: "remote",
+        error: reason
+      });
+    }
+    this._listenState.clear();
+    for (const timer of this._listChangedDebounceTimers.values()) clearTimeout(timer);
+    this._listChangedDebounceTimers.clear();
+    this._cache.resetForReconnect();
+  }
+  async close() {
+    try {
+      await super.close();
+    } finally {
+      this._resetConnectionState();
+    }
+  }
+  /**
+  * Initializes this client with the given name and version information.
+  */
+  constructor(_clientInfo, options) {
+    super(options);
+    this._clientInfo = _clientInfo;
+    this._capabilities = options?.capabilities ? { ...options.capabilities } : {};
+    this._jsonSchemaValidator = options?.jsonSchemaValidator ?? new AjvJsonSchemaValidator2();
+    this._enforceStrictCapabilities = options?.enforceStrictCapabilities ?? false;
+    this._versionNegotiation = options?.versionNegotiation;
+    this._supportedProtocolVersionsOption = options?.supportedProtocolVersions;
+    this._inputRequiredDriverConfig = resolveInputRequiredDriverConfig(options?.inputRequired);
+    this._cache = new ClientResponseCache(options?.responseCacheStore ?? new InMemoryResponseCacheStore(), options?.responseCacheStore !== void 0, (error2) => this._reportStoreError(error2), options?.cachePartition ?? "");
+    this._defaultCacheTtlMs = options?.defaultCacheTtlMs ?? 0;
+    this._listMaxPages = options?.listMaxPages ?? DEFAULT_LIST_MAX_PAGES;
+    if (options?.listChanged) this._listChangedConfig = options.listChanged;
+  }
+  buildContext(ctx, _transportInfo) {
+    return ctx;
+  }
+  /**
+  * Era-keyed direction enforcement for inbound traffic on channels whose
+  * transport does not classify (e.g. stdio): the 2026-07-28 era has no
+  * server→client JSON-RPC request channel — server-to-client interactions
+  * are carried in-band in `input_required` results — and on stdio the
+  * client must never write JSON-RPC responses. An inbound request arriving
+  * on a connection that negotiated a modern era is therefore dropped
+  * (surfaced via `onerror`) rather than answered. Connections on a legacy
+  * era — and all responses and notifications — keep today's dispatch path.
+  */
+  _shouldDropInbound(message) {
+    if (this._negotiatedProtocolVersion !== void 0 && isModernProtocolVersion(this._negotiatedProtocolVersion) && isJSONRPCRequest2(message)) return "drop";
+  }
+  /**
+  * Per-request `_meta` envelope auto-emission (protocol revision 2026-07-28):
+  * on a connection that negotiated a modern era — auto-negotiated or pinned —
+  * every outgoing request and notification automatically carries the reserved
+  * protocol-version / client-info / client-capabilities `_meta` keys (the
+  * same envelope the connect-time `server/discover` probe sends).
+  * User-supplied `_meta` keys take precedence over the auto-attached ones.
+  *
+  * Legacy-era connections return `undefined`: the envelope seam is a no-op
+  * and outbound traffic is byte-identical to a 2025 client (the legacy
+  * `'auto'` fallback included).
+  */
+  _outboundMetaEnvelope() {
+    const version2 = this._negotiatedProtocolVersion;
+    if (version2 === void 0) return void 0;
+    return this._wireCodec().outboundEnvelope({
+      protocolVersion: version2,
+      clientInfo: this._clientInfo,
+      clientCapabilities: this._capabilities
+    });
+  }
+  /**
+  * Wires the multi-round-trip auto-fulfilment engine (protocol revision
+  * 2026-07-28) into the response funnel: an `input_required` answer is
+  * fulfilled through the registered elicitation/sampling/roots handlers
+  * and the original request retried via `flow.retry`, up to
+  * `inputRequired.maxRounds` rounds. With auto-fulfilment disabled the
+  * response surfaces as a typed error steering to manual mode.
+  */
+  _resolveNonCompleteResult(decoded, flow) {
+    if (!this._inputRequiredDriverConfig.autoFulfill) return Promise.reject(new SdkError(SdkErrorCode.UnsupportedResultType, `Unsupported result type 'input_required' for ${flow.request.method}: multi-round-trip auto-fulfilment is not enabled on this instance \u2014 pass allowInputRequired: true to handle it manually, or enable inputRequired.autoFulfill`, {
+      resultType: "input_required",
+      method: flow.request.method
+    }));
+    return runInputRequiredFlow({
+      getRequestHandler: (method) => this._getRequestHandler(method),
+      buildContext: (baseCtx) => this.buildContext(baseCtx, void 0),
+      sessionId: this.transport?.sessionId
+    }, this._inputRequiredDriverConfig, decoded, flow);
+  }
+  /**
+  * Set up handlers for list changed notifications based on config and server capabilities.
+  * This should only be called after initialization when server capabilities are known.
+  * Handlers are silently skipped if the server doesn't advertise the corresponding listChanged capability.
+  * @internal
+  */
+  _setupListChangedHandlers(config2) {
+    if (config2.tools && this._serverCapabilities?.tools?.listChanged) this._setupListChangedHandler("tools", "notifications/tools/list_changed", config2.tools, async () => {
+      return (await this.listTools(void 0, { cacheMode: "refresh" })).tools;
+    });
+    if (config2.prompts && this._serverCapabilities?.prompts?.listChanged) this._setupListChangedHandler("prompts", "notifications/prompts/list_changed", config2.prompts, async () => {
+      return (await this.listPrompts(void 0, { cacheMode: "refresh" })).prompts;
+    });
+    if (config2.resources && this._serverCapabilities?.resources?.listChanged) this._setupListChangedHandler("resources", "notifications/resources/list_changed", config2.resources, async () => {
+      return (await this.listResources(void 0, { cacheMode: "refresh" })).resources;
+    });
+  }
+  /**
+  * Registers new capabilities. This can only be called before connecting to a transport.
+  *
+  * The new capabilities will be merged with any existing capabilities previously given (e.g., at initialization).
+  */
+  registerCapabilities(capabilities) {
+    if (this.transport) throw new Error("Cannot register capabilities after connecting to transport");
+    this._capabilities = mergeCapabilities2(this._capabilities, capabilities);
+  }
+  /**
+  * Configure protocol version negotiation before connecting (equivalent to
+  * passing `versionNegotiation` at construction time). Can only be called
+  * before connecting to a transport. Passing `undefined` clears a previously
+  * configured negotiation, restoring the default `'legacy'` posture.
+  *
+  * See {@linkcode ClientOptions | ClientOptions.versionNegotiation} for the mode semantics.
+  */
+  setVersionNegotiation(options) {
+    if (this.transport) throw new Error("Cannot configure version negotiation after connecting to transport");
+    this._versionNegotiation = options;
+  }
+  /**
+  * Enforces client-side validation for `elicitation/create` and `sampling/createMessage`
+  * regardless of how the handler was registered.
+  */
+  _wrapHandler(method, handler) {
+    if (method === "elicitation/create") return async (request, ctx) => {
+      const codec = codecForVersion(this._negotiatedProtocolVersion);
+      let validatedRequest = codec.validateRequest("elicitation/create", request);
+      if (!validatedRequest.ok && validatedRequest.reason === "not-in-era") validatedRequest = codec.validateInputRequest("elicitation/create", request);
+      if (!validatedRequest.ok) throw new ProtocolError(validatedRequest.reason === "not-in-era" ? ProtocolErrorCode.InternalError : ProtocolErrorCode.InvalidParams, validatedRequest.reason === "not-in-era" ? "No wire schema for elicitation/create in the resolved era" : `Invalid elicitation request: ${validatedRequest.message}`);
+      const { params } = validatedRequest.value;
+      params.mode = params.mode ?? "form";
+      const { supportsFormMode, supportsUrlMode } = getSupportedElicitationModes(this._capabilities.elicitation);
+      if (params.mode === "form" && !supportsFormMode) throw new ProtocolError(ProtocolErrorCode.InvalidParams, "Client does not support form-mode elicitation requests");
+      if (params.mode === "url" && !supportsUrlMode) throw new ProtocolError(ProtocolErrorCode.InvalidParams, "Client does not support URL-mode elicitation requests");
+      const result = await handler(request, ctx);
+      let validationResult = codec.validateResult("elicitation/create", result);
+      if (!validationResult.ok && validationResult.reason === "not-in-era") validationResult = codec.validateInputResponse("elicitation/create", result);
+      if (!validationResult.ok) throw new ProtocolError(validationResult.reason === "not-in-era" ? ProtocolErrorCode.InternalError : ProtocolErrorCode.InvalidParams, validationResult.reason === "not-in-era" ? "No wire schema for elicitation/create in the resolved era" : `Invalid elicitation result: ${validationResult.message}`);
+      const validatedResult = validationResult.value;
+      const requestedSchema = params.mode === "form" ? params.requestedSchema : void 0;
+      if (params.mode === "form" && validatedResult.action === "accept" && validatedResult.content && requestedSchema && this._capabilities.elicitation?.form?.applyDefaults) try {
+        applyElicitationDefaults(requestedSchema, validatedResult.content);
+      } catch {
+      }
+      return validatedResult;
+    };
+    if (method === "sampling/createMessage") return async (request, ctx) => {
+      const codec = codecForVersion(this._negotiatedProtocolVersion);
+      let validatedRequest = codec.validateRequest("sampling/createMessage", request);
+      if (!validatedRequest.ok && validatedRequest.reason === "not-in-era") validatedRequest = codec.validateInputRequest("sampling/createMessage", request);
+      if (!validatedRequest.ok) throw new ProtocolError(validatedRequest.reason === "not-in-era" ? ProtocolErrorCode.InternalError : ProtocolErrorCode.InvalidParams, validatedRequest.reason === "not-in-era" ? "No wire schema for sampling/createMessage in the resolved era" : `Invalid sampling request: ${validatedRequest.message}`);
+      const { params } = validatedRequest.value;
+      const result = await handler(request, ctx);
+      const hasTools = Boolean(params.tools || params.toolChoice);
+      let validatedResult = codec.samplingResultVariant(hasTools, result);
+      if (!validatedResult.ok && validatedResult.reason === "not-in-era") validatedResult = codec.validateInputResponse("sampling/createMessage", result);
+      if (!validatedResult.ok) throw new ProtocolError(validatedResult.reason === "not-in-era" ? ProtocolErrorCode.InternalError : ProtocolErrorCode.InvalidParams, validatedResult.reason === "not-in-era" ? "No result schema for sampling/createMessage in the resolved era" : `Invalid sampling result: ${validatedResult.message}`);
+      return validatedResult.value;
+    };
+    return handler;
+  }
+  assertCapability(capability, method) {
+    if (!this._serverCapabilities?.[capability]) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support ${capability} (required for ${method})`);
+  }
+  /**
+  * Connects to a server via the given transport and performs the MCP initialization handshake.
+  *
+  * @example Basic usage (stdio)
+  * ```ts source="./client.examples.ts#Client_connect_stdio"
+  * const client = new Client({ name: 'my-client', version: '1.0.0' });
+  * const transport = new StdioClientTransport({ command: 'my-mcp-server' });
+  * await client.connect(transport);
+  * ```
+  *
+  * @example Streamable HTTP with SSE fallback
+  * ```ts source="./client.examples.ts#Client_connect_sseFallback"
+  * const baseUrl = new URL(url);
+  *
+  * try {
+  *     // Try modern Streamable HTTP transport first
+  *     const client = new Client({ name: 'my-client', version: '1.0.0' });
+  *     const transport = new StreamableHTTPClientTransport(baseUrl);
+  *     await client.connect(transport);
+  *     return { client, transport };
+  * } catch {
+  *     // Fall back to legacy SSE transport
+  *     const client = new Client({ name: 'my-client', version: '1.0.0' });
+  *     const transport = new SSEClientTransport(baseUrl);
+  *     await client.connect(transport);
+  *     return { client, transport };
+  * }
+  * ```
+  */
+  async connect(transport, options) {
+    if (options?.prior != null) return this._connectFromPrior(transport, validatePrior(options.prior), options);
+    const negotiation = resolveVersionNegotiation(this._versionNegotiation, this._supportedProtocolVersionsOption);
+    if (negotiation.kind !== "legacy") return this._connectNegotiated(transport, negotiation, options);
+    return this._connectPlainLegacy(transport, options);
+  }
+  /**
+  * Plain legacy connect — the pinned 2025 sequence, byte-untouched. The
+  * `mode: 'legacy'` connect body, shared with the `prior` legacy verdict.
+  */
+  async _connectPlainLegacy(transport, options) {
+    await super.connect(transport);
+    if (transport.sessionId !== void 0) {
+      const negotiatedProtocolVersion = this._negotiatedProtocolVersion;
+      if (negotiatedProtocolVersion !== void 0) transport.setProtocolVersion?.(negotiatedProtocolVersion);
+      return;
+    }
+    this._resetConnectionState();
+    await this._legacyHandshake(transport, options);
+  }
+  /**
+  * The 2025 `initialize` handshake — the body of the plain legacy connect and
+  * the `'auto'`-mode fallback path (same `initialize` body, zero 2026 headers;
+  * on the stdio sibling path it opens the session child's fresh pipe, in the
+  * in-place modes it rides the probed connection). Callers clear the negotiated protocol version before
+  * the handshake; its completion sets the negotiated (legacy) version.
+  */
+  async _legacyHandshake(transport, options) {
+    const legacyVersions = legacyProtocolVersions(this._supportedProtocolVersions);
+    try {
+      const offeredVersion = legacyVersions[0];
+      if (offeredVersion === void 0) throw new SdkError(SdkErrorCode.EraNegotiationFailed, "Cannot run the initialize handshake: supportedProtocolVersions contains no pre-2026-07-28 protocol version");
+      const result = await this.request({
+        method: "initialize",
+        params: {
+          protocolVersion: offeredVersion,
+          capabilities: this._capabilities,
+          clientInfo: this._clientInfo
+        }
+      }, options);
+      if (result === void 0) throw new Error(`Server sent invalid initialize result: ${result}`);
+      if (!legacyVersions.includes(result.protocolVersion)) throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
+      this._serverCapabilities = result.capabilities;
+      this._serverVersion = result.serverInfo;
+      this._cache.setServerIdentity(this._deriveServerIdentity(transport));
+      if (transport.setProtocolVersion) transport.setProtocolVersion(result.protocolVersion);
+      this._instructions = result.instructions;
+      await this.notification({ method: "notifications/initialized" });
+      this._negotiatedProtocolVersion = result.protocolVersion;
+      if (this._listChangedConfig) this._setupListChangedHandlers(this._listChangedConfig);
+    } catch (error2) {
+      this.close();
+      throw error2;
+    }
+  }
+  /**
+  * Negotiated connect (mode `'auto'` or `{ pin }`): probe with `server/discover`
+  * before the Protocol machinery attaches — on a disposable sibling process for
+  * the SDK's stdio transport, in place otherwise — then either establish the
+  * modern era or perform the plain legacy handshake.
+  */
+  async _connectNegotiated(transport, negotiation, options) {
+    if (transport.sessionId !== void 0) {
+      await super.connect(transport);
+      const negotiatedProtocolVersion = this._negotiatedProtocolVersion;
+      if (negotiatedProtocolVersion !== void 0 && transport.setProtocolVersion) transport.setProtocolVersion(negotiatedProtocolVersion);
+      return;
+    }
+    this._resetConnectionState();
+    let result;
+    try {
+      const transportKind = detectProbeTransportKind(transport);
+      const baseDeps = {
+        clientInfo: this._clientInfo,
+        capabilities: this._capabilities,
+        environment: detectProbeEnvironment(),
+        defaultTimeoutMs: options?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC2
+      };
+      const stdioParams = transportKind === "stdio" ? readStdioServerParams(transport) : void 0;
+      result = stdioParams === void 0 ? await negotiateEra(negotiation, {
+        ...baseDeps,
+        transport,
+        transportKind
+      }) : await negotiateStdioViaSibling(negotiation, transport, stdioParams, baseDeps);
+    } catch (error2) {
+      await transport.close().catch(() => {
+      });
+      disarmSpentCloseGuard(transport);
+      throw error2;
+    }
+    disarmSpentCloseGuard(transport);
+    await super.connect(transport);
+    if (result.era === "legacy") {
+      await this._legacyHandshake(transport, options);
+      return;
+    }
+    this._serverCapabilities = result.discover.capabilities;
+    this._serverVersion = serverInfoFromDiscover(result.discover);
+    this._cache.setServerIdentity(this._deriveServerIdentity(transport));
+    this._instructions = result.discover.instructions;
+    this._discoverResult = result.discover;
+    this._negotiatedProtocolVersion = result.version;
+    if (transport.setProtocolVersion) transport.setProtocolVersion(result.version);
+    if (this._listChangedConfig) {
+      const config2 = this._listChangedConfig;
+      const advertised = this._serverCapabilities;
+      const effective = {
+        ...config2.tools && advertised?.tools?.listChanged && { tools: config2.tools },
+        ...config2.prompts && advertised?.prompts?.listChanged && { prompts: config2.prompts },
+        ...config2.resources && advertised?.resources?.listChanged && { resources: config2.resources }
+      };
+      let handlersRegistered = true;
+      try {
+        this._setupListChangedHandlers(effective);
+      } catch (error2) {
+        handlersRegistered = false;
+        this.onerror?.(error2 instanceof Error ? error2 : new Error(String(error2)));
+      }
+      const filter = handlersRegistered ? {
+        ...effective.tools && { toolsListChanged: true },
+        ...effective.prompts && { promptsListChanged: true },
+        ...effective.resources && { resourcesListChanged: true }
+      } : {};
+      if (Object.keys(filter).length > 0) {
+        const ackAbort = new AbortController();
+        const onConnectAbort = () => ackAbort.abort(options?.signal?.reason);
+        if (options?.signal?.aborted) onConnectAbort();
+        options?.signal?.addEventListener("abort", onConnectAbort);
+        try {
+          this._autoOpenedSubscription = await this.listen(filter, {
+            timeout: options?.timeout,
+            signal: ackAbort.signal
+          });
+        } catch (error2) {
+          if (options?.signal?.aborted) {
+            await this.close().catch(() => {
+            });
+            throw error2;
+          }
+          this.onerror?.(error2 instanceof Error ? error2 : new Error(String(error2)));
+        } finally {
+          options?.signal?.removeEventListener("abort", onConnectAbort);
+        }
+      }
+    }
+  }
+  /**
+  * Connect from a validated {@linkcode PriorDiscovery}: the modern arm
+  * adopts the `DiscoverResult` (zero round trips; `EraNegotiationFailed`
+  * on no 2026-07-28+ overlap), the legacy arm runs the plain legacy connect.
+  */
+  async _connectFromPrior(transport, prior, options) {
+    if (prior.kind === "legacy") return this._connectPlainLegacy(transport, options);
+    const discover = prior.discover;
+    this._resetConnectionState();
+    const explicit = this._supportedProtocolVersionsOption;
+    const version2 = (explicit && modernProtocolVersions(explicit).length > 0 ? modernProtocolVersions(explicit) : SUPPORTED_MODERN_PROTOCOL_VERSIONS).find((v) => discover.supportedVersions.includes(v));
+    if (version2 === void 0) throw new SdkError(SdkErrorCode.EraNegotiationFailed, "connect({ prior }) with a modern verdict requires a 2026-07-28+ mutual protocol version; the supplied DiscoverResult and this client's supportedProtocolVersions have no modern overlap. For a server known to be legacy, pass prior: { kind: 'legacy' } to skip the probe and initialize directly, or use versionNegotiation: { mode: 'auto' } to re-probe with legacy fallback.");
+    await super.connect(transport);
+    this._discoverResult = discover;
+    this._serverCapabilities = discover.capabilities;
+    this._serverVersion = serverInfoFromDiscover(discover);
+    this._cache.setServerIdentity(this._deriveServerIdentity(transport));
+    this._instructions = discover.instructions;
+    this._negotiatedProtocolVersion = version2;
+    transport.setProtocolVersion?.(version2);
+    if (this._listChangedConfig) try {
+      this._setupListChangedHandlers(this._listChangedConfig);
+    } catch (error2) {
+      this.onerror?.(error2 instanceof Error ? error2 : new Error(String(error2)));
+    }
+  }
+  /**
+  * After initialization has completed, this will be populated with the server's reported capabilities.
+  */
+  getServerCapabilities() {
+    return this._serverCapabilities;
+  }
+  /**
+  * The connected server's self-reported name and version, when it
+  * identified itself: required on the legacy `initialize` result; a spec
+  * SHOULD in the discover result's `_meta` on 2026-07-28, so a successful
+  * modern connect against an anonymous server leaves this `undefined`.
+  */
+  getServerVersion() {
+    return this._serverVersion;
+  }
+  /**
+  * The connected server's identity for response-cache partitioning. The
+  * `serverInfo` `name@version` pair when available (required on
+  * `initialize`; a SHOULD in the discover result's `_meta` since spec PR
+  * #3002); falls back to the transport's `sessionId`, then to a
+  * per-connection surrogate. The surrogate matters since #3002 made
+  * identity optional: without it, two identity-less servers reached over
+  * sessionId-less transports would share the cache's pre-connect `''`
+  * partition and read each other's entries — no stable identity means no
+  * cross-connection cache reuse. The value itself is server-controlled —
+  * the collision-safety of the storage partition comes from
+  * {@linkcode ClientResponseCache}'s JSON-array encoding around it, not
+  * from any character it does or does not contain.
+  */
+  _deriveServerIdentity(transport) {
+    const v = this._serverVersion;
+    if (v !== void 0) return `${v.name}@${v.version}`;
+    return transport.sessionId ?? `anonymous:${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+  /**
+  * After initialization has completed, this will be populated with the protocol version negotiated
+  * during the initialize handshake. When manually reconstructing a transport for reconnection, pass this
+  * value to the new transport so it continues sending the required `mcp-protocol-version` header.
+  */
+  getNegotiatedProtocolVersion() {
+    return this._negotiatedProtocolVersion;
+  }
+  /**
+  * After initialization has completed, this returns the protocol era of the
+  * connection: `'modern'` when the connection negotiated a 2026-07-28+
+  * revision (via `server/discover`), `'legacy'` for the 2025-era
+  * `initialize` handshake, or `undefined` before the connection is
+  * established.
+  */
+  getProtocolEra() {
+    const version2 = this._negotiatedProtocolVersion;
+    if (version2 === void 0) return void 0;
+    return isModernProtocolVersion(version2) ? "modern" : "legacy";
+  }
+  /**
+  * After initialization has completed, this may be populated with information about the server's instructions.
+  */
+  getInstructions() {
+    return this._instructions;
+  }
+  /**
+  * The {@linkcode DiscoverResult} from the last `'auto'`/pinned probe,
+  * {@linkcode discover} call, or `connect({ prior })` that adopted a
+  * modern verdict (a legacy verdict leaves this `undefined` — there is no
+  * `DiscoverResult` on that path). Persistable via `JSON.stringify`; wrap
+  * as `{ kind: 'modern', discover }` and feed to {@linkcode ConnectOptions}
+  * `prior`.
+  */
+  getDiscoverResult() {
+    return this._discoverResult;
+  }
+  assertCapabilityForMethod(method) {
+    switch (method) {
+      case "logging/setLevel":
+        if (!this._serverCapabilities?.logging) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support logging (required for ${method})`);
+        break;
+      case "prompts/get":
+      case "prompts/list":
+        if (!this._serverCapabilities?.prompts) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support prompts (required for ${method})`);
+        break;
+      case "resources/list":
+      case "resources/templates/list":
+      case "resources/read":
+      case "resources/subscribe":
+      case "resources/unsubscribe":
+        if (!this._serverCapabilities?.resources) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support resources (required for ${method})`);
+        if (method === "resources/subscribe" && !this._serverCapabilities.resources.subscribe) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support resource subscriptions (required for ${method})`);
+        break;
+      case "tools/call":
+      case "tools/list":
+        if (!this._serverCapabilities?.tools) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support tools (required for ${method})`);
+        break;
+      case "completion/complete":
+        if (!this._serverCapabilities?.completions) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Server does not support completions (required for ${method})`);
+        break;
+      case "initialize":
+        break;
+      case "server/discover":
+        break;
+      case "ping":
+        break;
+    }
+  }
+  assertNotificationCapability(method) {
+    switch (method) {
+      case "notifications/roots/list_changed":
+        if (!this._capabilities.roots?.listChanged) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Client does not support roots list changed notifications (required for ${method})`);
+        break;
+      case "notifications/initialized":
+        break;
+      case "notifications/cancelled":
+        break;
+      case "notifications/progress":
+        break;
+    }
+  }
+  assertRequestHandlerCapability(method) {
+    switch (method) {
+      case "sampling/createMessage":
+        if (!this._capabilities.sampling) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Client does not support sampling capability (required for ${method})`);
+        break;
+      case "elicitation/create":
+        if (!this._capabilities.elicitation) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Client does not support elicitation capability (required for ${method})`);
+        break;
+      case "roots/list":
+        if (!this._capabilities.roots) throw new SdkError(SdkErrorCode.CapabilityNotSupported, `Client does not support roots capability (required for ${method})`);
+        break;
+      case "ping":
+        break;
+    }
+  }
+  async ping(options) {
+    return this.request({ method: "ping" }, options);
+  }
+  /**
+  * Send `server/discover` (2026-07-28+) and record the result for
+  * {@linkcode getDiscoverResult}.
+  */
+  async discover(options) {
+    const result = await this._requestWithSchema({ method: "server/discover" }, DiscoverResultSchema, options);
+    this._discoverResult = result;
+    return result;
+  }
+  /** Requests argument autocompletion suggestions from the server for a prompt or resource. */
+  async complete(params, options) {
+    return this.request({
+      method: "completion/complete",
+      params
+    }, options);
+  }
+  /**
+  * Sets the minimum severity level for log messages sent by the server.
+  *
+  * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
+  * Remains functional during the deprecation window (at least twelve months).
+  * Migrate to stderr logging (STDIO servers) or OpenTelemetry.
+  */
+  async setLoggingLevel(level, options) {
+    return this.request({
+      method: "logging/setLevel",
+      params: { level }
+    }, options);
+  }
+  /** Retrieves a prompt by name from the server, passing the given arguments for template substitution. */
+  async getPrompt(params, options) {
+    return this.request({
+      method: "prompts/get",
+      params
+    }, options);
+  }
+  /**
+  * Lists available prompts.
+  *
+  * Called without a `cursor` (the common case), this walks every page and
+  * returns the complete aggregated list with no `nextCursor`; the
+  * aggregate is also written to the {@linkcode ResponseCacheStore}. Pass an
+  * explicit `{ cursor }` to fetch a single page and walk pagination
+  * yourself — the per-page path returns the server's raw page (with
+  * `nextCursor` for the next call) and does not write the response cache.
+  * The auto-aggregate path is capped by
+  * {@linkcode ClientOptions | ClientOptions.listMaxPages} (default 64); the per-page path
+  * is not.
+  *
+  * Returns an empty list if the server does not advertise prompts capability
+  * (or throws if {@linkcode ClientOptions.enforceStrictCapabilities} is enabled).
+  *
+  * @example
+  * ```ts source="./client.examples.ts#Client_listPrompts_pagination"
+  * // No cursor → all pages aggregated for you.
+  * const { prompts } = await client.listPrompts();
+  * console.log(
+  *     'Available prompts:',
+  *     prompts.map(p => p.name)
+  * );
+  * ```
+  */
+  async listPrompts(params, options) {
+    if (!this._serverCapabilities?.prompts && !this._enforceStrictCapabilities) {
+      console.debug("Client.listPrompts() called but server does not advertise prompts capability - returning empty list");
+      return { prompts: [] };
+    }
+    if (params?.cursor !== void 0) return this.request({
+      method: "prompts/list",
+      params
+    }, options);
+    const hit = await this._serveFromCache("prompts/list", void 0, options);
+    if (hit !== void 0) return hit;
+    return this._listAllPages("prompts/list", params, options, (acc, page) => acc.prompts.push(...page.prompts));
+  }
+  /**
+  * Lists available resources.
+  *
+  * Called without a `cursor` (the common case), this walks every page and
+  * returns the complete aggregated list with no `nextCursor`; the
+  * aggregate is also written to the {@linkcode ResponseCacheStore}. Pass an
+  * explicit `{ cursor }` to fetch a single page and walk pagination
+  * yourself — the per-page path returns the server's raw page (with
+  * `nextCursor` for the next call) and does not write the response cache.
+  * The auto-aggregate path is capped by
+  * {@linkcode ClientOptions | ClientOptions.listMaxPages} (default 64); the per-page path
+  * is not.
+  *
+  * Returns an empty list if the server does not advertise resources capability
+  * (or throws if {@linkcode ClientOptions.enforceStrictCapabilities} is enabled).
+  *
+  * @example
+  * ```ts source="./client.examples.ts#Client_listResources_pagination"
+  * // No cursor → all pages aggregated for you.
+  * const { resources } = await client.listResources();
+  * console.log(
+  *     'Available resources:',
+  *     resources.map(r => r.name)
+  * );
+  * ```
+  */
+  async listResources(params, options) {
+    if (!this._serverCapabilities?.resources && !this._enforceStrictCapabilities) {
+      console.debug("Client.listResources() called but server does not advertise resources capability - returning empty list");
+      return { resources: [] };
+    }
+    if (params?.cursor !== void 0) return this.request({
+      method: "resources/list",
+      params
+    }, options);
+    const hit = await this._serveFromCache("resources/list", void 0, options);
+    if (hit !== void 0) return hit;
+    return this._listAllPages("resources/list", params, options, (acc, page) => acc.resources.push(...page.resources));
+  }
+  /**
+  * Lists available resource URI templates for dynamic resources.
+  *
+  * Called without a `cursor`, this walks every page and returns the
+  * complete aggregated list with no `nextCursor`; the aggregate is
+  * also written to the {@linkcode ResponseCacheStore}. Pass an explicit
+  * `{ cursor }` to fetch a single page — see
+  * {@linkcode listResources | listResources()} for the per-page contract.
+  *
+  * Returns an empty list if the server does not advertise resources capability
+  * (or throws if {@linkcode ClientOptions.enforceStrictCapabilities} is enabled).
+  */
+  async listResourceTemplates(params, options) {
+    if (!this._serverCapabilities?.resources && !this._enforceStrictCapabilities) {
+      console.debug("Client.listResourceTemplates() called but server does not advertise resources capability - returning empty list");
+      return { resourceTemplates: [] };
+    }
+    if (params?.cursor !== void 0) return this.request({
+      method: "resources/templates/list",
+      params
+    }, options);
+    const hit = await this._serveFromCache("resources/templates/list", void 0, options);
+    if (hit !== void 0) return hit;
+    return this._listAllPages("resources/templates/list", params, options, (acc, page) => acc.resourceTemplates.push(...page.resourceTemplates));
+  }
+  /**
+  * Walk every page of a paginated list verb, aggregate, and write ONE
+  * entry to the response cache. Internal — backs the public `list*`
+  * methods' no-`cursor` auto-aggregate path. Page 1's result object is
+  * mutated in place (its items array is extended; `nextCursor` is
+  * cleared); page-1 metadata (`ttlMs`, `cacheScope`, `_meta`) is preserved.
+  * A `nextCursor` that repeats stops the walk (defence against a
+  * non-converging server, mcp.d's `drainList` guard);
+  * {@linkcode ClientOptions.listMaxPages} is a hard cap — hitting it
+  * throws, so a partial aggregate is never cached. The
+  * captured-generation guard skips the write when a `list_changed` landed
+  * mid-walk, so the eviction is never overwritten by a stale aggregate.
+  * `finalize` runs on the complete aggregate before the cache write — the
+  * SEP-2243 invalid-`x-mcp-header` exclusion hooks here so the cached
+  * `tools/list` entry is already filtered.
+  *
+  * The caller's `baseParams` (everything except `cursor`) is threaded into
+  * every page request — page 1 sends `{...baseParams}`, later pages
+  * `{...baseParams, cursor}` — so a typed, documented `_meta` (e.g. W3C
+  * trace context) supplied to the public `list*()` reaches every wire
+  * request the walk issues.
+  */
+  async _listAllPages(method, baseParams, options, append, finalize2) {
+    const bypass = options?.cacheMode === "bypass";
+    const generation = this._cache.captureGeneration(method);
+    const acc = await this.request({
+      method,
+      ...baseParams && { params: { ...baseParams } }
+    }, options);
+    let cursor = acc.nextCursor;
+    const seen = /* @__PURE__ */ new Set();
+    let pages = 1;
+    while (cursor !== void 0 && !seen.has(cursor)) {
+      if (this._listMaxPages !== 0 && pages >= this._listMaxPages) throw new SdkError(SdkErrorCode.ListPaginationExceeded, `${method}: exceeded listMaxPages (${this._listMaxPages}); server pagination did not terminate`, {
+        method,
+        listMaxPages: this._listMaxPages
+      });
+      seen.add(cursor);
+      const page = await this.request({
+        method,
+        params: {
+          ...baseParams,
+          cursor
+        }
+      }, options);
+      append(acc, page);
+      cursor = page.nextCursor;
+      pages++;
+    }
+    delete acc.nextCursor;
+    finalize2?.(acc);
+    if (bypass) return acc;
+    await this._cache.write(method, acc, generation, this._freshness(acc));
+    return acc;
+  }
+  /**
+  * Compute the {@linkcode ClientResponseCache.write} freshness payload from
+  * a cacheable result body. The single seam through which the client reads
+  * `ttlMs`/`cacheScope` (mcp.d's `cachedFetch` engine). The fields pass
+  * through the loose result schema, so they are read off the runtime body;
+  * a missing `ttlMs` falls back to
+  * {@linkcode ClientOptions | ClientOptions.defaultCacheTtlMs}; an explicit server-sent
+  * `ttlMs` (including `0` — the spec's "immediately stale") is honoured
+  * as-is. The default of `0` means `expiresAt === now()` ⇒ never served,
+  * only stored. A missing `cacheScope` is treated as `'private'` — the
+  * spec's `'public'` grant ("any client … MAY serve to any user") is too
+  * strong to infer by default, and matches this SDK's server-side stamp
+  * default.
+  */
+  _freshness(result, params) {
+    const body = result;
+    const ttlMs = typeof body.ttlMs === "number" ? body.ttlMs : this._defaultCacheTtlMs;
+    const scope = body.cacheScope === "public" ? "public" : "private";
+    return {
+      expiresAt: this._cache.now() + Math.min(Math.max(0, ttlMs), MAX_CACHE_TTL_MS),
+      scope,
+      params
+    };
+  }
+  /**
+  * The cache-serving front of every cacheable verb (mcp.d's `cachedFetch`
+  * read half): under `cacheMode: 'use'` (the default), a fresh held entry
+  * is served and the round trip is skipped. `'refresh'` and `'bypass'`
+  * always fetch (the caller decides whether to write). Freshness and
+  * decoding live in {@linkcode ClientResponseCache.read}; every hit is
+  * freshly parsed, so the caller owns it outright. A custom store
+  * whose `get()` rejects is routed to `onerror` and treated as a miss —
+  * cache bookkeeping never blocks a request from reaching the wire.
+  */
+  async _serveFromCache(method, params, options) {
+    if (options?.cacheMode === "bypass" || options?.cacheMode === "refresh") return void 0;
+    const hit = await this._cache.read(method, params).catch((error2) => void this._reportStoreError(error2));
+    if (hit !== void 0) {
+      if (options?.signal?.aborted) {
+        const reason = options.signal.reason;
+        throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+      }
+      return hit.value;
+    }
+  }
+  /** Route a custom-store failure to `onerror` without aborting the surrounding dispatch. */
+  _reportStoreError(e) {
+    this.onerror?.(e instanceof Error ? e : new Error(String(e)));
+  }
+  /**
+  * Compile a single tool's `outputSchema`. Passed as the compile callback to
+  * {@linkcode ClientResponseCache.outputValidator} so the cache class stays
+  * free of any validator-provider dependency, and called directly for the
+  * `options.toolDefinition` path of {@linkcode callTool} (a one-off
+  * caller-supplied definition is compiled in isolation and never enters the
+  * cache, so it cannot poison the listed tool of the same name).
+  *
+  * Returns `undefined` when the tool has no `outputSchema`, or a
+  * discriminated `{ok}` result otherwise. SEP-2106: ANY throw from the
+  * validator engine — unsupported `$schema` dialect, invalid `pattern`
+  * regex, unresolvable `$ref`, or any other engine error — is captured as
+  * `{ok: false, compileError}` so one bad schema does not poison the rest
+  * of the listing; `callTool()` surfaces it as an `InvalidParams` error
+  * before the request. The `{ok}` discriminator (not
+  * `compileError !== undefined`) means a custom provider that does
+  * `throw undefined` is still treated as a captured failure.
+  */
+  _compileOutputValidator(tool) {
+    if (!tool.outputSchema) return void 0;
+    try {
+      return {
+        ok: true,
+        validator: this._jsonSchemaValidator.getValidator(tool.outputSchema)
+      };
+    } catch (error2) {
+      return {
+        ok: false,
+        compileError: error2
+      };
+    }
+  }
+  /**
+  * Resolve the SEP-2243 `x-mcp-header` declaration scan for a tool name.
+  *
+  * The caller-supplied `toolDefinition` escape hatch wins; otherwise the
+  * cached `tools/list` entry (via the cache's `toolDefinition`) is the
+  * source. Freshness is the response cache's lifecycle: `list_changed`
+  * evicts, otherwise the held schema is the best information available
+  * regardless of age, and a stale schema is recovered through the
+  * `HEADER_MISMATCH` → evict-refetch-retry path in {@linkcode callTool}.
+  * On a miss the call proceeds without `Mcp-Param-*` headers (the spec's
+  * "client SHOULD send without custom headers" guidance) and relies on the
+  * same recovery.
+  */
+  async _resolveXMcpHeaderScan(name, override) {
+    const tool = override ?? await this._cache.toolDefinition(name);
+    return tool === void 0 ? void 0 : scanXMcpHeaderDeclarations(tool.inputSchema);
+  }
+  /**
+  * Reads the contents of a resource by URI.
+  *
+  * Honours the result's `ttlMs`/`cacheScope` (SEP-2549): a still-fresh
+  * cached body for the same `uri` is returned without a round trip
+  * (`cacheMode: 'use'`, the default). The cache key is `{method, uri}`
+  * partitioned by the resolved scope — `'private'` (the default when the
+  * server omits the field) is stored under this client's
+  * {@linkcode ClientOptions | ClientOptions.cachePartition}, so a shared
+  * store cannot serve one principal's resource body to another. Unlike the
+  * list verbs, a result whose resolved TTL is ≤0 is **not** stored
+  * (`resources/read` has no derived index and the URI keyspace is
+  * unbounded).
+  */
+  async readResource(params, options) {
+    const hit = await this._serveFromCache("resources/read", params.uri, options);
+    if (hit !== void 0) return hit;
+    const generation = this._cache.captureGeneration("resources/read", params.uri);
+    const result = await this.request({
+      method: "resources/read",
+      params
+    }, options);
+    if (options?.cacheMode !== "bypass") {
+      const freshness = this._freshness(result, params.uri);
+      if (freshness.expiresAt > this._cache.now()) await this._cache.write("resources/read", result, generation, freshness);
+      else if (options?.cacheMode === "refresh") await this._cache.evictKey("resources/read", params.uri);
+    }
+    return result;
+  }
+  /** Subscribes to change notifications for a resource. The server must support resource subscriptions. */
+  async subscribeResource(params, options) {
+    return this.request({
+      method: "resources/subscribe",
+      params
+    }, options);
+  }
+  /** Unsubscribes from change notifications for a resource. */
+  async unsubscribeResource(params, options) {
+    return this.request({
+      method: "resources/unsubscribe",
+      params
+    }, options);
+  }
+  /**
+  * Opens a `subscriptions/listen` stream (protocol revision 2026-07-28).
+  *
+  * Resolves once the server's `notifications/subscriptions/acknowledged`
+  * arrives (the standard request timeout applies to this ack phase). Change
+  * notifications delivered on the stream are dispatched to the existing
+  * {@linkcode setNotificationHandler} registrations — the same handlers the
+  * 2025-era unsolicited notifications fire on a legacy connection — so
+  * `listen()` is era-transparent for consumers that already register those.
+  *
+  * `close()` tears the subscription down by aborting the listen request's
+  * `requestSignal` (closes the SSE stream where the transport honors it)
+  * AND sending `notifications/cancelled` referencing the listen request id
+  * — both, unconditionally, so any spec-compliant server on any transport
+  * sees the cancel. No automatic re-listen — call `listen()` again to
+  * re-establish.
+  *
+  * On a 2025-era connection this throws a typed
+  * {@linkcode SdkErrorCode.MethodNotSupportedByProtocolVersion} steering to
+  * `resources/subscribe` and `ClientOptions.listChanged` (the legacy
+  * unsolicited delivery model still applies there); no transparent shim.
+  */
+  async listen(filter, options) {
+    if (this.transport === void 0) throw new SdkError(SdkErrorCode.NotConnected, "Not connected");
+    const negotiated = this._negotiatedProtocolVersion;
+    if (negotiated === void 0 || !isModernProtocolVersion(negotiated)) throw new SdkError(SdkErrorCode.MethodNotSupportedByProtocolVersion, `subscriptions/listen requires a 2026-07-28-era connection (negotiated: ${negotiated ?? "none"}). On a 2025-era connection, change notifications are delivered unsolicited: use ClientOptions.listChanged and resources/subscribe instead.`, {
+      method: "subscriptions/listen",
+      protocolVersion: negotiated
+    });
+    if (options?.signal?.aborted) {
+      const reason = options.signal.reason;
+      throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+    }
+    const requestAbort = new AbortController();
+    const listenId = `listen:${this._nextListenId++}`;
+    let state = "opening";
+    let ackTimer;
+    let onCallerAbort;
+    let resolveOpening;
+    let rejectOpening;
+    const opening = new Promise((resolve, reject) => {
+      resolveOpening = resolve;
+      rejectOpening = reject;
+    });
+    let resolveClosed;
+    const closed = new Promise((resolve) => {
+      resolveClosed = resolve;
+    });
+    const settle = (outcome) => {
+      if (state === "closed") return;
+      const wasOpening = state === "opening";
+      if (ackTimer !== void 0) {
+        clearTimeout(ackTimer);
+        ackTimer = void 0;
+      }
+      if ("ack" in outcome) {
+        state = "open";
+        resolveOpening(outcome.ack);
+        return;
+      }
+      state = "closed";
+      if (onCallerAbort !== void 0) options?.signal?.removeEventListener("abort", onCallerAbort);
+      this._listenState.delete(listenId);
+      requestAbort.abort();
+      resolveClosed(outcome.cause);
+      if (wasOpening) rejectOpening(outcome.error ?? new SdkError(SdkErrorCode.ConnectionClosed, "subscriptions/listen closed before the server acknowledged"));
+    };
+    const wireTeardown = async () => {
+      requestAbort.abort();
+      await this.notification({
+        method: "notifications/cancelled",
+        params: { requestId: listenId }
+      }).catch(() => {
+      });
+    };
+    const close = async () => {
+      if (state === "closed") return;
+      settle({ cause: "local" });
+      await wireTeardown();
+    };
+    this._listenState.set(listenId, { settle });
+    const ackTimeout = options?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC2;
+    ackTimer = setTimeout(() => {
+      settle({
+        cause: "remote",
+        error: new SdkError(SdkErrorCode.RequestTimeout, "subscriptions/listen ack timed out", { timeout: ackTimeout })
+      });
+      wireTeardown().catch(() => {
+      });
+    }, ackTimeout);
+    if (options?.signal) {
+      const callerSignal = options.signal;
+      onCallerAbort = () => {
+        if (state === "closed") return;
+        const reason = callerSignal.reason;
+        settle({
+          cause: "local",
+          error: reason instanceof Error ? reason : new Error(String(reason ?? "Aborted"))
+        });
+        wireTeardown().catch(() => {
+        });
+      };
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
+    const jsonrpcRequest = {
+      jsonrpc: "2.0",
+      id: listenId,
+      method: "subscriptions/listen",
+      params: {
+        _meta: { ...this._outboundMetaEnvelope() },
+        notifications: filter
+      }
+    };
+    try {
+      await this.transport.send(jsonrpcRequest, {
+        requestSignal: requestAbort.signal,
+        onRequestStreamEnd: () => settle({
+          cause: "remote",
+          error: /* @__PURE__ */ new Error("subscriptions/listen: stream ended")
+        })
+      });
+    } catch (error2) {
+      settle({
+        cause: "remote",
+        error: error2 instanceof Error ? error2 : new Error(String(error2))
+      });
+    }
+    return {
+      honoredFilter: await opening,
+      close,
+      closed
+    };
+  }
+  /**
+  * The subscription auto-opened by `ClientOptions.listChanged` on a modern
+  * connection — the listen filter is the intersection of the configured
+  * sub-options and the server-advertised `listChanged` capabilities.
+  * `undefined` on a legacy connection, before connect, or when that
+  * intersection is empty (auto-open skipped). Exposed so the consumer can
+  * `close()` it.
+  */
+  get autoOpenedSubscription() {
+    return this._autoOpenedSubscription;
+  }
+  /**
+  * Transport-level demux for `subscriptions/listen` notifications, before
+  * any decoding/era-gating/handler dispatch. Consumes the leading
+  * `notifications/subscriptions/acknowledged` referencing a live
+  * subscription id (resolves the ack waiter) and an inbound
+  * `notifications/cancelled` referencing a live string-typed subscription
+  * id (server-side teardown on stdio). Change notifications carrying a
+  * subscription id pass through to the existing registered handlers via
+  * `super`. An unmatched ack/cancelled is NOT consumed: it reaches
+  * `setNotificationHandler` / `fallbackNotificationHandler` instead of
+  * being silently swallowed.
+  */
+  _onnotification(raw, extra) {
+    const evicted = Object.hasOwn(LIST_CHANGED_EVICTIONS, raw.method) ? LIST_CHANGED_EVICTIONS[raw.method] : void 0;
+    if (raw.method === "notifications/resources/updated") {
+      const uri = raw.params?.uri;
+      if (typeof uri === "string") this._cache.evictKey("resources/read", uri);
+    } else if (evicted !== void 0) for (const method of evicted) this._cache.evict(method);
+    if (raw.method === "notifications/subscriptions/acknowledged") {
+      const subscriptionId = raw.params?._meta?.[SUBSCRIPTION_ID_META_KEY];
+      const entry = typeof subscriptionId === "string" ? this._listenState.get(subscriptionId) : void 0;
+      if (entry !== void 0) {
+        const honored = this._wireCodec().validateNotification("notifications/subscriptions/acknowledged", raw);
+        entry.settle({ ack: honored.ok ? honored.value.params.notifications : {} });
+        return;
+      }
+    }
+    if (raw.method === "notifications/cancelled") {
+      const cancelledId = raw.params?.requestId;
+      const entry = typeof cancelledId === "string" ? this._listenState.get(cancelledId) : void 0;
+      if (entry !== void 0) {
+        entry.settle({
+          cause: "remote",
+          error: /* @__PURE__ */ new Error("subscriptions/listen: server cancelled the subscription")
+        });
+        return;
+      }
+    }
+    super._onnotification(raw, extra);
+  }
+  /**
+  * Transport-level demux for `subscriptions/listen` responses. A JSON-RPC
+  * ERROR for the listen id is the server's pre-ack capacity/params
+  * rejection; a JSON-RPC RESULT for the listen id is the spec's
+  * `SubscriptionsListenResult` — the server's GRACEFUL-close signal (sent
+  * on shutdown). A string-id response that matches a live `_listenState`
+  * entry is consumed here (Protocol's `_responseHandlers` map is keyed by
+  * NUMBER and never holds a listen id, so passing a string-id response
+  * through would surface as "unknown message ID" via `onerror`).
+  */
+  _onresponse(response) {
+    const id = response.id;
+    const entry = typeof id === "string" ? this._listenState.get(id) : void 0;
+    if (entry !== void 0) {
+      if (isJSONRPCErrorResponse2(response)) entry.settle({
+        cause: "remote",
+        error: ProtocolError.fromError(response.error.code, response.error.message, response.error.data)
+      });
+      else entry.settle({
+        cause: "graceful",
+        error: new SdkError(SdkErrorCode.ConnectionClosed, "subscriptions/listen: server closed the subscription gracefully before acknowledging")
+      });
+      return;
+    }
+    super._onresponse(response);
+  }
+  /**
+  * Settle every live per-listen state machine on a transport-initiated
+  * close (the server dropping the connection on stdio/InMemory) before
+  * Protocol's `_onclose` tears the transport down. The base
+  * `_responseHandlers` settlement does not reach `_listenState` (listen
+  * ids are never registered there), so without this override a remote
+  * close would leave an in-flight `listen()` / open `McpSubscription`
+  * hanging.
+  */
+  _onclose() {
+    if (this._listenState.size > 0) {
+      const reason = new SdkError(SdkErrorCode.ConnectionClosed, "Connection closed");
+      for (const entry of this._listenState.values()) entry.settle({
+        cause: "remote",
+        error: reason
+      });
+      this._listenState.clear();
+    }
+    super._onclose();
+  }
+  /**
+  * Calls a tool on the connected server and returns the result. Automatically validates structured output
+  * if the tool has an `outputSchema`.
+  *
+  * Tool results have two error surfaces: `result.isError` for tool-level failures (the tool ran but reported
+  * a problem), and thrown {@linkcode ProtocolError} for protocol-level failures or {@linkcode SdkError} for
+  * SDK-level issues (timeouts, missing capabilities).
+  *
+  * @example Basic usage
+  * ```ts source="./client.examples.ts#Client_callTool_basic"
+  * const result = await client.callTool({
+  *     name: 'calculate-bmi',
+  *     arguments: { weightKg: 70, heightM: 1.75 }
+  * });
+  *
+  * // Tool-level errors are returned in the result, not thrown
+  * if (result.isError) {
+  *     console.error('Tool error:', result.content);
+  *     return;
+  * }
+  *
+  * console.log(result.content);
+  * ```
+  *
+  * @example Structured output
+  * ```ts source="./client.examples.ts#Client_callTool_structuredOutput"
+  * const result = await client.callTool({
+  *     name: 'calculate-bmi',
+  *     arguments: { weightKg: 70, heightM: 1.75 }
+  * });
+  *
+  * // Machine-readable output for the client application. SEP-2106: structuredContent is
+  * // `unknown` (any JSON value). Check for presence with `!== undefined` and narrow before use.
+  * if (result.structuredContent !== undefined) {
+  *     const sc: unknown = result.structuredContent; // e.g. { bmi: 22.86 }
+  *     if (typeof sc === 'object' && sc !== null && 'bmi' in sc) {
+  *         console.log(sc.bmi);
+  *     }
+  * }
+  * ```
+  */
+  async callTool(params, options) {
+    const mirroringActive = this.getProtocolEra() === "modern" && detectProbeEnvironment() !== "browser";
+    const buildSendOptions = async () => {
+      if (!mirroringActive) return options;
+      let scan;
+      try {
+        scan = await this._resolveXMcpHeaderScan(params.name, options?.toolDefinition);
+      } catch (error2) {
+        this._reportStoreError(error2);
+      }
+      if (!scan?.valid || scan.declarations.length === 0) return options;
+      const paramHeaders = buildMcpParamHeaders(scan.declarations, params.arguments);
+      return Object.keys(paramHeaders).length === 0 ? options : {
+        ...options,
+        headers: {
+          ...options?.headers,
+          ...paramHeaders
+        }
+      };
+    };
+    let compiled = options?.toolDefinition === void 0 ? await this._cache.outputValidator(params.name, (tool) => this._compileOutputValidator(tool)).catch((error2) => void this._reportStoreError(error2)) : this._compileOutputValidator(options.toolDefinition);
+    const assertCompiled = () => {
+      if (compiled === void 0 || compiled.ok) return;
+      const err = compiled.compileError;
+      const message = (err instanceof Error ? err.message : String(err)).slice(0, 200);
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Tool '${params.name}' has an invalid outputSchema: ${message}`);
+    };
+    assertCompiled();
+    let result;
+    try {
+      result = await this.request({
+        method: "tools/call",
+        params
+      }, await buildSendOptions());
+    } catch (error2) {
+      const isHeaderMismatch = error2 instanceof ProtocolError && error2.code === HEADER_MISMATCH_ERROR_CODE;
+      if (!mirroringActive || !isHeaderMismatch || options?.toolDefinition !== void 0) throw error2;
+      const refreshOptions = {
+        signal: options?.signal,
+        timeout: options?.timeout,
+        cacheMode: "refresh"
+      };
+      await this._cache.evict("tools/list");
+      await this.listTools(void 0, refreshOptions).catch((error_) => this._reportStoreError(error_));
+      compiled = await this._cache.outputValidator(params.name, (tool) => this._compileOutputValidator(tool)).catch((error_) => void this._reportStoreError(error_));
+      assertCompiled();
+      result = await this.request({
+        method: "tools/call",
+        params
+      }, await buildSendOptions());
+    }
+    const validator = compiled !== void 0 && compiled.ok ? compiled.validator : void 0;
+    if (validator) {
+      if (result.structuredContent === void 0 && !result.isError) throw new ProtocolError(ProtocolErrorCode.InvalidRequest, `Tool ${params.name} has an output schema but did not return structured content`);
+      if (result.structuredContent !== void 0 && !result.isError) try {
+        const validationResult = validator(result.structuredContent);
+        if (!validationResult.valid) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Structured content does not match the tool's output schema: ${validationResult.errorMessage}`);
+      } catch (error2) {
+        if (error2 instanceof ProtocolError) throw error2;
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Failed to validate structured content: ${error2 instanceof Error ? error2.message : String(error2)}`);
+      }
+    }
+    return result;
+  }
+  /**
+  * Lists available tools.
+  *
+  * Called without a `cursor` (the common case), this walks every page and
+  * returns the complete aggregated list with no `nextCursor`; the
+  * aggregate is also written to the {@linkcode ResponseCacheStore} (the
+  * source for {@linkcode callTool | callTool()}'s output-schema validation
+  * and SEP-2243 `Mcp-Param-*` header mirroring). Pass an explicit
+  * `{ cursor }` to fetch a single page and walk pagination yourself — the
+  * per-page path returns the server's raw page (with `nextCursor` for the
+  * next call) and does not write the response cache. The auto-aggregate
+  * path is capped by {@linkcode ClientOptions | ClientOptions.listMaxPages} (default 64);
+  * the per-page path is not.
+  *
+  * Returns an empty list if the server does not advertise tools capability
+  * (or throws if {@linkcode ClientOptions.enforceStrictCapabilities} is enabled).
+  *
+  * @example
+  * ```ts source="./client.examples.ts#Client_listTools_pagination"
+  * // No cursor → all pages aggregated for you.
+  * const { tools } = await client.listTools();
+  * console.log(
+  *     'Available tools:',
+  *     tools.map(t => t.name)
+  * );
+  * ```
+  */
+  async listTools(params, options) {
+    if (!this._serverCapabilities?.tools && !this._enforceStrictCapabilities) {
+      console.debug("Client.listTools() called but server does not advertise tools capability - returning empty list");
+      return { tools: [] };
+    }
+    if (params?.cursor !== void 0) {
+      const page = await this.request({
+        method: "tools/list",
+        params
+      }, options);
+      this._excludeInvalidXMcpHeaderTools(page);
+      return page;
+    }
+    const hit = await this._serveFromCache("tools/list", void 0, options);
+    if (hit !== void 0) return hit;
+    return this._listAllPages("tools/list", params, options, (acc, page) => acc.tools.push(...page.tools), (acc) => this._excludeInvalidXMcpHeaderTools(acc));
+  }
+  /**
+  * SEP-2243 (protocol revision 2026-07-28): a Streamable HTTP client MUST
+  * exclude tool definitions whose `x-mcp-header` declarations violate the
+  * constraints, and SHOULD log a warning naming the tool and the reason.
+  * Applied to the CACHED aggregated `tools/list` result (so the entry
+  * mirroring reads never holds an unmirrorable tool) AND to every public
+  * per-page {@linkcode listTools | listTools()} return (the spec's MUST
+  * has no carve-out for paginated reads). The gate is era-only on
+  * non-stdio transports — `detectProbeTransportKind` cannot distinguish a
+  * real HTTP transport from in-memory/custom transports (it only
+  * positively recognizes stdio), and over-excluding on a non-HTTP modern
+  * connection is harmless: those transports never carry per-request
+  * headers, so an excluded tool would have been uncallable on a Streamable
+  * HTTP arm of the same server. Mutates `result.tools` in place.
+  */
+  _excludeInvalidXMcpHeaderTools(result) {
+    if (this.getProtocolEra() !== "modern" || !this.transport || detectProbeTransportKind(this.transport) === "stdio") return;
+    const filtered = result.tools.filter((tool) => {
+      const scan = scanXMcpHeaderDeclarations(tool.inputSchema);
+      if (!scan.valid) {
+        console.warn(`[mcp-sdk] excluding tool '${tool.name}' from tools/list: invalid x-mcp-header declaration \u2014 ${scan.reason}`);
+        return false;
+      }
+      return true;
+    });
+    if (filtered.length !== result.tools.length) result.tools = filtered;
+  }
+  /**
+  * Set up a single list changed handler.
+  * @internal
+  */
+  _setupListChangedHandler(listType, notificationMethod, options, fetcher) {
+    const parseResult = parseSchema(ListChangedOptionsBaseSchema2, options);
+    if (!parseResult.success) throw new Error(`Invalid ${listType} listChanged options: ${parseResult.error.message}`);
+    if (typeof options.onChanged !== "function") throw new TypeError(`Invalid ${listType} listChanged options: onChanged must be a function`);
+    const { autoRefresh, debounceMs } = parseResult.data;
+    const { onChanged } = options;
+    const refresh = async () => {
+      if (!autoRefresh) {
+        onChanged(null, null);
+        return;
+      }
+      try {
+        onChanged(null, await fetcher());
+      } catch (error2) {
+        onChanged(error2 instanceof Error ? error2 : new Error(String(error2)), null);
+      }
+    };
+    const handler = () => {
+      if (debounceMs) {
+        const existingTimer = this._listChangedDebounceTimers.get(listType);
+        if (existingTimer) clearTimeout(existingTimer);
+        const timer = setTimeout(refresh, debounceMs);
+        this._listChangedDebounceTimers.set(listType, timer);
+      } else refresh();
+    };
+    this.setNotificationHandler(notificationMethod, handler);
+  }
+  /**
+  * Notifies the server that the client's root list has changed. Requires the `roots.listChanged` capability.
+  *
+  * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
+  * Remains functional during the deprecation window (at least twelve months).
+  * Migrate to passing paths via tool parameters, resource URIs, or configuration.
+  */
+  async sendRootsListChanged() {
+    return this.notification({ method: "notifications/roots/list_changed" });
+  }
+};
+var SseError = class extends Error {
+  static {
+    Object.defineProperty(this, "mcpBrand", { value: "mcp.SseError" });
+  }
+  static [Symbol.hasInstance](value) {
+    return brandedHasInstance(this, value);
+  }
+  /**
+  * Brand-based type guard: equivalent to `value instanceof this`, as an
+  * explicit static predicate (the axios/AWS-SDK `isInstance` style). Reads
+  * the caller's own brand via `this`, so every branded subclass gets a
+  * correctly-scoped guard by inheritance. Must be invoked on the class —
+  * in callback position write `v => SdkError.isInstance(v)`, not
+  * `.filter(SdkError.isInstance)` (detached calls throw rather than
+  * silently matching nothing).
+  */
+  static isInstance(value) {
+    if (typeof this !== "function") throw new TypeError("isInstance must be called on the class (e.g. `SdkError.isInstance(value)`); for callbacks use `v => SdkError.isInstance(v)`");
+    return brandedHasInstance(this, value);
+  }
+  constructor(code, message, event) {
+    super(`SSE error: ${message}`);
+    this.code = code;
+    this.event = event;
+    stampErrorBrands(this, new.target);
+  }
+};
+var DEFAULT_MAX_STEP_UP_RETRIES = 1;
 var DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
   initialReconnectionDelay: 1e3,
   maxReconnectionDelay: 3e4,
   reconnectionDelayGrowFactor: 1.5,
   maxRetries: 2
 };
-var StreamableHTTPError = class extends Error {
-  constructor(code, message) {
-    super(`Streamable HTTP error: ${message}`);
-    this.code = code;
+var RESERVED_REQUEST_HEADER_NAMES = /* @__PURE__ */ new Set([
+  "authorization",
+  "content-type",
+  "mcp-protocol-version",
+  "mcp-method",
+  "mcp-name",
+  "mcp-session-id"
+]);
+function anySignal(a, b) {
+  if (typeof AbortSignal.any === "function") return AbortSignal.any([a, b]);
+  const controller = new AbortController();
+  if (a.aborted) return controller.abort(a.reason), controller.signal;
+  if (b.aborted) return controller.abort(b.reason), controller.signal;
+  const cleanup = () => {
+    a.removeEventListener("abort", onA);
+    b.removeEventListener("abort", onB);
+  };
+  function onA() {
+    cleanup();
+    controller.abort(a.reason);
   }
-};
+  function onB() {
+    cleanup();
+    controller.abort(b.reason);
+  }
+  a.addEventListener("abort", onA, { once: true });
+  b.addEventListener("abort", onB, { once: true });
+  return controller.signal;
+}
 var StreamableHTTPClientTransport = class {
+  _abortController;
+  _url;
+  _resourceMetadataUrl;
+  _scope;
+  _requestInit;
+  _authProvider;
+  _oauthProvider;
+  _skipIssuerMetadataValidation;
+  _fetch;
+  _fetchWithInit;
+  _sessionId;
+  _reconnectionOptions;
+  _protocolVersion;
+  _onInsufficientScope;
+  _maxStepUpRetries;
+  _serverRetryMs;
+  _reconnectionScheduler;
+  _cancelReconnection;
+  onclose;
+  onerror;
+  onmessage;
+  /**
+  * Streamable HTTP opens one POST (and SSE response stream) per outbound
+  * request and honors `TransportSendOptions.requestSignal`. On a 2026-era
+  * connection the protocol layer aborts that per-request stream as the
+  * spec cancellation signal instead of POSTing `notifications/cancelled`.
+  */
+  hasPerRequestStream = true;
   constructor(url2, opts) {
-    this._hasCompletedAuthFlow = false;
     this._url = url2;
     this._resourceMetadataUrl = void 0;
     this._scope = void 0;
     this._requestInit = opts?.requestInit;
-    this._authProvider = opts?.authProvider;
+    this._skipIssuerMetadataValidation = opts?.skipIssuerMetadataValidation;
+    if (isOAuthClientProvider(opts?.authProvider)) {
+      this._oauthProvider = opts.authProvider;
+      this._authProvider = adaptOAuthProvider(opts.authProvider, { skipIssuerMetadataValidation: opts.skipIssuerMetadataValidation });
+    } else this._authProvider = opts?.authProvider;
     this._fetch = opts?.fetch;
     this._fetchWithInit = createFetchWithInit(opts?.fetch, opts?.requestInit);
     this._sessionId = opts?.sessionId;
+    this._protocolVersion = opts?.protocolVersion;
     this._reconnectionOptions = opts?.reconnectionOptions ?? DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS;
+    this._reconnectionScheduler = opts?.reconnectionScheduler;
+    this._onInsufficientScope = opts?.onInsufficientScope ?? "reauthorize";
+    this._maxStepUpRetries = Math.max(0, opts?.maxStepUpRetries ?? DEFAULT_MAX_STEP_UP_RETRIES);
   }
-  async _authThenStart() {
-    if (!this._authProvider) {
-      throw new UnauthorizedError("No auth provider");
-    }
-    let result;
+  /**
+  * SEP-2350 step-up: compute the union scope, decide whether refresh must be
+  * bypassed, and run {@linkcode auth}. Returns the auth result so the caller
+  * can decide whether to retry. Shared by the POST `_send` path and the GET
+  * `_startOrAuthSse` path so both apply the same `'throw'` short-circuit,
+  * the same superset-gated refresh bypass, and the same retry cap.
+  */
+  async _stepUpAuthorize(challenge, stepUpRetries) {
     try {
-      result = await auth(this._authProvider, {
-        serverUrl: this._url,
-        resourceMetadataUrl: this._resourceMetadataUrl,
-        scope: this._scope,
-        fetchFn: this._fetchWithInit
-      });
+      return await this._stepUpAuthorizeInner(challenge, stepUpRetries);
     } catch (error2) {
-      this.onerror?.(error2);
-      throw error2;
+      throw markAuthSeamEscape(error2);
     }
-    if (result !== "AUTHORIZED") {
-      throw new UnauthorizedError();
-    }
-    return await this._startOrAuthSse({ resumptionToken: void 0 });
+  }
+  async _stepUpAuthorizeInner(challenge, stepUpRetries) {
+    if (this._onInsufficientScope === "throw") throw new InsufficientScopeError({
+      requiredScope: challenge.scope,
+      resourceMetadataUrl: challenge.resourceMetadataUrl,
+      errorDescription: challenge.errorDescription
+    });
+    if (!this._oauthProvider) throw new InsufficientScopeError({
+      requiredScope: challenge.scope,
+      resourceMetadataUrl: challenge.resourceMetadataUrl,
+      errorDescription: challenge.errorDescription
+    });
+    if (stepUpRetries >= this._maxStepUpRetries) throw new SdkHttpError(SdkErrorCode.ClientHttpForbidden, `Server returned 403 insufficient_scope after step-up re-authorization (retry limit ${this._maxStepUpRetries} reached)`, {
+      status: 403,
+      statusText: challenge.statusText ?? "Forbidden",
+      text: challenge.text
+    });
+    if (challenge.resourceMetadataUrl) this._resourceMetadataUrl = challenge.resourceMetadataUrl;
+    const tokens = await this._oauthProvider.tokens();
+    const unionScope = computeScopeUnion(this._scope, tokens?.scope, challenge.scope);
+    this._scope = unionScope;
+    const forceReauthorization = isStrictScopeSuperset(unionScope, tokens?.scope);
+    return auth(this._oauthProvider, {
+      serverUrl: this._url,
+      resourceMetadataUrl: this._resourceMetadataUrl,
+      scope: unionScope,
+      forceReauthorization,
+      fetchFn: this._fetchWithInit,
+      skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
+    });
   }
   async _commonHeaders() {
     const headers = {};
-    if (this._authProvider) {
-      const tokens = await this._authProvider.tokens();
-      if (tokens) {
-        headers["Authorization"] = `Bearer ${tokens.access_token}`;
-      }
+    let token;
+    try {
+      token = await this._authProvider?.token();
+    } catch (error2) {
+      throw markAuthSeamEscape(error2);
     }
-    if (this._sessionId) {
-      headers["mcp-session-id"] = this._sessionId;
-    }
-    if (this._protocolVersion) {
-      headers["mcp-protocol-version"] = this._protocolVersion;
-    }
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    if (this._sessionId) headers["mcp-session-id"] = this._sessionId;
+    if (this._protocolVersion) headers["mcp-protocol-version"] = this._protocolVersion;
     const extraHeaders = normalizeHeaders(this._requestInit?.headers);
     return new Headers({
       ...headers,
       ...extraHeaders
     });
   }
-  async _startOrAuthSse(options) {
-    const { resumptionToken } = options;
+  /**
+  * Body-derived per-request headers: when an outgoing request carries a
+  * protocol-version claim in its `_meta` envelope (the version negotiation
+  * probe is the first such sender), `MCP-Protocol-Version` and `Mcp-Method`
+  * derive from the message itself. The connection-level version slot is
+  * neither consulted nor mutated; messages without an envelope claim are
+  * untouched, so no 2026 header can appear on a legacy exchange.
+  */
+  _applyBodyDerivedHeaders(headers, message) {
+    if (Array.isArray(message) || !isJSONRPCRequest2(message)) return;
+    const envelopeVersion = message.params?._meta?.[PROTOCOL_VERSION_META_KEY];
+    if (typeof envelopeVersion !== "string") return;
+    headers.set("mcp-protocol-version", envelopeVersion);
+    headers.set("mcp-method", message.method);
+    const params = message.params;
+    const nameHeader = message.method === "resources/read" ? typeof params?.uri === "string" ? params.uri : void 0 : typeof params?.name === "string" ? params.name : void 0;
+    if (nameHeader !== void 0) headers.set("mcp-name", encodeMcpParamValue(nameHeader));
+  }
+  /**
+  * `true` when the outbound message is a single request carrying a
+  * modern-era protocol-version envelope claim — the same predicate that
+  * gates body-derived `mcp-method`/`mcp-name` emission. Used to confine the
+  * 400-body-as-ProtocolError delivery to modern-era exchanges only.
+  */
+  _isModernEnvelopedRequest(message) {
+    if (Array.isArray(message) || !isJSONRPCRequest2(message)) return false;
+    const v = message.params?._meta?.[PROTOCOL_VERSION_META_KEY];
+    return typeof v === "string" && isModernProtocolVersion(v);
+  }
+  async _startOrAuthSse(options, isAuthRetry = false, stepUpRetries = 0) {
+    const { resumptionToken, requestSignal } = options;
+    const isIntentionalAbort = () => this._abortController?.signal.aborted === true || requestSignal?.aborted === true;
     try {
       const headers = await this._commonHeaders();
-      headers.set("Accept", "text/event-stream");
-      if (resumptionToken) {
-        headers.set("last-event-id", resumptionToken);
-      }
+      const types = [...headers.get("accept")?.split(",").map((s) => s.trim().toLowerCase()) ?? [], "text/event-stream"];
+      headers.set("accept", [...new Set(types)].join(", "));
+      if (resumptionToken) headers.set("last-event-id", resumptionToken);
+      const transportSignal = this._abortController?.signal;
+      const signal = requestSignal !== void 0 && transportSignal !== void 0 ? anySignal(transportSignal, requestSignal) : requestSignal ?? transportSignal;
       const response = await (this._fetch ?? fetch)(this._url, {
+        ...this._requestInit,
         method: "GET",
         headers,
-        signal: this._abortController?.signal
+        signal
       });
       if (!response.ok) {
-        await response.body?.cancel();
         if (response.status === 401 && this._authProvider) {
-          return await this._authThenStart();
+          if (response.headers.has("www-authenticate")) {
+            const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
+            this._resourceMetadataUrl = resourceMetadataUrl;
+            this._scope = computeScopeUnion(this._scope, scope);
+          }
+          if (this._authProvider.onUnauthorized && !isAuthRetry) {
+            try {
+              await this._authProvider.onUnauthorized({
+                response,
+                serverUrl: this._url,
+                fetchFn: this._fetchWithInit
+              });
+            } catch (error2) {
+              throw markAuthSeamEscape(error2);
+            }
+            await response.text?.().catch(() => {
+            });
+            return this._startOrAuthSse(options, true, stepUpRetries);
+          }
+          await response.text?.().catch(() => {
+          });
+          if (isAuthRetry) throw markAuthSeamEscape(new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, "Server returned 401 after re-authentication", {
+            status: 401,
+            statusText: response.statusText
+          }));
+          throw markAuthSeamEscape(new UnauthorizedError());
         }
+        if (response.status === 403) {
+          const { resourceMetadataUrl, scope, error: error2, errorDescription } = extractWWWAuthenticateParams(response);
+          if (error2 === "insufficient_scope") {
+            const text = await response.text?.().catch(() => null);
+            if (await this._stepUpAuthorize({
+              scope,
+              resourceMetadataUrl,
+              errorDescription,
+              statusText: response.statusText,
+              text
+            }, stepUpRetries) !== "AUTHORIZED") throw markAuthSeamEscape(new UnauthorizedError());
+            return this._startOrAuthSse(options, isAuthRetry, stepUpRetries + 1);
+          }
+        }
+        await response.text?.().catch(() => {
+        });
         if (response.status === 405) {
+          options.onRequestStreamEnd?.();
           return;
         }
-        throw new StreamableHTTPError(response.status, `Failed to open SSE stream: ${response.statusText}`);
+        throw new SdkHttpError(SdkErrorCode.ClientHttpFailedToOpenStream, `Failed to open SSE stream: ${response.statusText}`, {
+          status: response.status,
+          statusText: response.statusText
+        });
       }
       this._handleSseStream(response.body, options, true);
     } catch (error2) {
-      this.onerror?.(error2);
+      if (!isIntentionalAbort()) this.onerror?.(error2);
       throw error2;
     }
   }
   /**
-   * Calculates the next reconnection delay using  backoff algorithm
-   *
-   * @param attempt Current reconnection attempt count for the specific stream
-   * @returns Time to wait in milliseconds before next reconnection attempt
-   */
+  * Calculates the next reconnection delay using a backoff algorithm
+  *
+  * @param attempt Current reconnection attempt count for the specific stream
+  * @returns Time to wait in milliseconds before next reconnection attempt
+  */
   _getNextReconnectionDelay(attempt) {
-    if (this._serverRetryMs !== void 0) {
-      return this._serverRetryMs;
-    }
+    if (this._serverRetryMs !== void 0) return this._serverRetryMs;
     const initialDelay = this._reconnectionOptions.initialReconnectionDelay;
     const growFactor = this._reconnectionOptions.reconnectionDelayGrowFactor;
     const maxDelay = this._reconnectionOptions.maxReconnectionDelay;
     return Math.min(initialDelay * Math.pow(growFactor, attempt), maxDelay);
   }
   /**
-   * Schedule a reconnection attempt using server-provided retry interval or backoff
-   *
-   * @param lastEventId The ID of the last received event for resumability
-   * @param attemptCount Current reconnection attempt count for this specific stream
-   */
+  * Schedule a reconnection attempt using server-provided retry interval or backoff
+  *
+  * @param lastEventId The ID of the last received event for resumability
+  * @param attemptCount Current reconnection attempt count for this specific stream
+  */
   _scheduleReconnection(options, attemptCount = 0) {
     const maxRetries = this._reconnectionOptions.maxRetries;
     if (attemptCount >= maxRetries) {
-      this.onerror?.(new Error(`Maximum reconnection attempts (${maxRetries}) exceeded.`));
+      this.onerror?.(/* @__PURE__ */ new Error(`Maximum reconnection attempts (${maxRetries}) exceeded.`));
+      options.onRequestStreamEnd?.();
       return;
     }
     const delay = this._getNextReconnectionDelay(attemptCount);
-    this._reconnectionTimeout = setTimeout(() => {
+    const reconnect = () => {
+      this._cancelReconnection = void 0;
+      if (this._abortController?.signal.aborted || options.requestSignal?.aborted) return;
       this._startOrAuthSse(options).catch((error2) => {
-        this.onerror?.(new Error(`Failed to reconnect SSE stream: ${error2 instanceof Error ? error2.message : String(error2)}`));
-        this._scheduleReconnection(options, attemptCount + 1);
+        if (this._abortController?.signal.aborted || options.requestSignal?.aborted) return;
+        this.onerror?.(/* @__PURE__ */ new Error(`Failed to reconnect SSE stream: ${error2 instanceof Error ? error2.message : String(error2)}`));
+        try {
+          this._scheduleReconnection(options, attemptCount + 1);
+        } catch (scheduleError) {
+          this.onerror?.(scheduleError instanceof Error ? scheduleError : new Error(String(scheduleError)));
+        }
       });
-    }, delay);
+    };
+    if (this._reconnectionScheduler) {
+      const cancel = this._reconnectionScheduler(reconnect, delay, attemptCount);
+      this._cancelReconnection = typeof cancel === "function" ? cancel : void 0;
+    } else {
+      const handle = setTimeout(reconnect, delay);
+      this._cancelReconnection = () => clearTimeout(handle);
+    }
   }
   _handleSseStream(stream, options, isReconnectable) {
     if (!stream) {
+      options.onRequestStreamEnd?.();
       return;
     }
-    const { onresumptiontoken, replayMessageId } = options;
+    const { onresumptiontoken, replayMessageId, requestSignal, onRequestStreamEnd } = options;
+    const isIntentionalAbort = () => this._abortController?.signal.aborted === true || requestSignal?.aborted === true;
     let lastEventId;
     let hasPrimingEvent = false;
     let receivedResponse = false;
     const processStream = async () => {
       try {
-        const reader = stream.pipeThrough(new TextDecoderStream()).pipeThrough(new EventSourceParserStream({
-          onRetry: (retryMs) => {
-            this._serverRetryMs = retryMs;
-          }
-        })).getReader();
+        const reader = stream.pipeThrough(new TextDecoderStream()).pipeThrough(new EventSourceParserStream({ onRetry: (retryMs) => {
+          this._serverRetryMs = retryMs;
+        } })).getReader();
         while (true) {
           const { value: event, done } = await reader.read();
-          if (done) {
-            break;
-          }
+          if (done) break;
           if (event.id) {
             lastEventId = event.id;
             hasPrimingEvent = true;
             onresumptiontoken?.(event.id);
           }
-          if (!event.data) {
-            continue;
-          }
-          if (!event.event || event.event === "message") {
-            try {
-              const message = JSONRPCMessageSchema.parse(JSON.parse(event.data));
-              if (isJSONRPCResultResponse(message)) {
-                receivedResponse = true;
-                if (replayMessageId !== void 0) {
-                  message.id = replayMessageId;
-                }
-              }
-              this.onmessage?.(message);
-            } catch (error2) {
-              this.onerror?.(error2);
+          if (!event.data) continue;
+          if (!event.event || event.event === "message") try {
+            const message = JSONRPCMessageSchema2.parse(JSON.parse(event.data));
+            if (isJSONRPCResultResponse2(message) || isJSONRPCErrorResponse2(message)) {
+              receivedResponse = true;
+              if (replayMessageId !== void 0) message.id = replayMessageId;
             }
+            this.onmessage?.(message);
+          } catch (error2) {
+            this.onerror?.(error2);
           }
         }
-        const canResume = isReconnectable || hasPrimingEvent;
-        const needsReconnect = canResume && !receivedResponse;
-        if (needsReconnect && this._abortController && !this._abortController.signal.aborted) {
+        if ((isReconnectable || hasPrimingEvent) && !receivedResponse && this._abortController && !isIntentionalAbort()) this._scheduleReconnection({
+          resumptionToken: lastEventId,
+          onresumptiontoken,
+          replayMessageId,
+          requestSignal,
+          onRequestStreamEnd
+        }, 0);
+        else if (!isIntentionalAbort()) onRequestStreamEnd?.();
+      } catch (error2) {
+        if (isIntentionalAbort()) return;
+        this.onerror?.(/* @__PURE__ */ new Error(`SSE stream disconnected: ${error2}`));
+        if ((isReconnectable || hasPrimingEvent) && !receivedResponse && this._abortController && !isIntentionalAbort()) try {
           this._scheduleReconnection({
             resumptionToken: lastEventId,
             onresumptiontoken,
-            replayMessageId
+            replayMessageId,
+            requestSignal,
+            onRequestStreamEnd
           }, 0);
+        } catch (error$1) {
+          this.onerror?.(/* @__PURE__ */ new Error(`Failed to reconnect: ${error$1 instanceof Error ? error$1.message : String(error$1)}`));
+          onRequestStreamEnd?.();
         }
-      } catch (error2) {
-        this.onerror?.(new Error(`SSE stream disconnected: ${error2}`));
-        const canResume = isReconnectable || hasPrimingEvent;
-        const needsReconnect = canResume && !receivedResponse;
-        if (needsReconnect && this._abortController && !this._abortController.signal.aborted) {
-          try {
-            this._scheduleReconnection({
-              resumptionToken: lastEventId,
-              onresumptiontoken,
-              replayMessageId
-            }, 0);
-          } catch (error3) {
-            this.onerror?.(new Error(`Failed to reconnect: ${error3 instanceof Error ? error3.message : String(error3)}`));
-          }
-        }
+        else onRequestStreamEnd?.();
       }
     };
     processStream();
   }
   async start() {
-    if (this._abortController) {
-      throw new Error("StreamableHTTPClientTransport already started! If using Client class, note that connect() calls start() automatically.");
-    }
+    if (this._abortController) throw new Error("StreamableHTTPClientTransport already started! If using Client class, note that connect() calls start() automatically.");
     this._abortController = new AbortController();
   }
-  /**
-   * Call this method after the user has finished authorizing via their user agent and is redirected back to the MCP client application. This will exchange the authorization code for an access token, enabling the next connection attempt to successfully auth.
-   */
-  async finishAuth(authorizationCode) {
-    if (!this._authProvider) {
-      throw new UnauthorizedError("No auth provider");
-    }
-    const result = await auth(this._authProvider, {
+  async finishAuth(codeOrParams, iss) {
+    if (!this._oauthProvider) throw new UnauthorizedError("finishAuth requires an OAuthClientProvider");
+    const { authorizationCode, iss: issParam } = await resolveAuthorizationCallbackParams(codeOrParams, iss, this._oauthProvider, this._url, {
+      fetchFn: this._fetchWithInit,
+      resourceMetadataUrl: this._resourceMetadataUrl
+    });
+    if (await auth(this._oauthProvider, {
       serverUrl: this._url,
       authorizationCode,
+      iss: issParam,
       resourceMetadataUrl: this._resourceMetadataUrl,
       scope: this._scope,
-      fetchFn: this._fetchWithInit
-    });
-    if (result !== "AUTHORIZED") {
-      throw new UnauthorizedError("Failed to authorize");
-    }
+      fetchFn: this._fetchWithInit,
+      skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
+    }) !== "AUTHORIZED") throw new UnauthorizedError("Failed to authorize");
   }
   async close() {
-    if (this._reconnectionTimeout) {
-      clearTimeout(this._reconnectionTimeout);
-      this._reconnectionTimeout = void 0;
+    try {
+      this._cancelReconnection?.();
+    } finally {
+      this._cancelReconnection = void 0;
+      this._abortController?.abort();
+      this.onclose?.();
     }
-    this._abortController?.abort();
-    this.onclose?.();
   }
   async send(message, options) {
+    return this._send(message, options, false);
+  }
+  async _send(message, options, isAuthRetry, stepUpRetries = 0) {
     try {
       const { resumptionToken, onresumptiontoken } = options || {};
       if (resumptionToken) {
-        this._startOrAuthSse({ resumptionToken, replayMessageId: isJSONRPCRequest(message) ? message.id : void 0 }).catch((err) => this.onerror?.(err));
+        this._startOrAuthSse({
+          resumptionToken,
+          replayMessageId: isJSONRPCRequest2(message) ? message.id : void 0,
+          requestSignal: options?.requestSignal
+        }).catch((error2) => this.onerror?.(error2));
         return;
       }
       const headers = await this._commonHeaders();
+      this._applyBodyDerivedHeaders(headers, message);
+      const isHandshake = Array.isArray(message) ? message.some((m) => isInitializeRequest(m)) : isInitializeRequest(message);
+      if (isHandshake) headers.delete("mcp-session-id");
+      if (options?.headers !== void 0) for (const [name, value] of Object.entries(options.headers)) {
+        if (RESERVED_REQUEST_HEADER_NAMES.has(name.toLowerCase())) continue;
+        headers.set(name, value);
+      }
       headers.set("content-type", "application/json");
-      headers.set("accept", "application/json, text/event-stream");
+      const types = [
+        ...headers.get("accept")?.split(",").map((s) => s.trim().toLowerCase()) ?? [],
+        "application/json",
+        "text/event-stream"
+      ];
+      headers.set("accept", [...new Set(types)].join(", "));
+      const transportSignal = this._abortController?.signal;
+      const signal = options?.requestSignal !== void 0 && transportSignal !== void 0 ? anySignal(transportSignal, options.requestSignal) : options?.requestSignal ?? transportSignal;
       const init = {
         ...this._requestInit,
         method: "POST",
         headers,
         body: JSON.stringify(message),
-        signal: this._abortController?.signal
+        signal
       };
       const response = await (this._fetch ?? fetch)(this._url, init);
-      const sessionId = response.headers.get("mcp-session-id");
-      if (sessionId) {
-        this._sessionId = sessionId;
-      }
+      if (isHandshake && response.ok) this._sessionId = response.headers.get("mcp-session-id") || void 0;
       if (!response.ok) {
-        const text = await response.text().catch(() => null);
         if (response.status === 401 && this._authProvider) {
-          if (this._hasCompletedAuthFlow) {
-            throw new StreamableHTTPError(401, "Server returned 401 after successful authentication");
+          if (response.headers.has("www-authenticate")) {
+            const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
+            this._resourceMetadataUrl = resourceMetadataUrl;
+            this._scope = computeScopeUnion(this._scope, scope);
           }
-          const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
-          this._resourceMetadataUrl = resourceMetadataUrl;
-          this._scope = scope;
-          const result = await auth(this._authProvider, {
-            serverUrl: this._url,
-            resourceMetadataUrl: this._resourceMetadataUrl,
-            scope: this._scope,
-            fetchFn: this._fetchWithInit
-          });
-          if (result !== "AUTHORIZED") {
-            throw new UnauthorizedError();
-          }
-          this._hasCompletedAuthFlow = true;
-          return this.send(message);
-        }
-        if (response.status === 403 && this._authProvider) {
-          const { resourceMetadataUrl, scope, error: error2 } = extractWWWAuthenticateParams(response);
-          if (error2 === "insufficient_scope") {
-            const wwwAuthHeader = response.headers.get("WWW-Authenticate");
-            if (this._lastUpscopingHeader === wwwAuthHeader) {
-              throw new StreamableHTTPError(403, "Server returned 403 after trying upscoping");
+          if (this._authProvider.onUnauthorized && !isAuthRetry) {
+            try {
+              await this._authProvider.onUnauthorized({
+                response,
+                serverUrl: this._url,
+                fetchFn: this._fetchWithInit
+              });
+            } catch (error2) {
+              throw markAuthSeamEscape(error2);
             }
-            if (scope) {
-              this._scope = scope;
-            }
-            if (resourceMetadataUrl) {
-              this._resourceMetadataUrl = resourceMetadataUrl;
-            }
-            this._lastUpscopingHeader = wwwAuthHeader ?? void 0;
-            const result = await auth(this._authProvider, {
-              serverUrl: this._url,
-              resourceMetadataUrl: this._resourceMetadataUrl,
-              scope: this._scope,
-              fetchFn: this._fetch
+            await response.text?.().catch(() => {
             });
-            if (result !== "AUTHORIZED") {
-              throw new UnauthorizedError();
-            }
-            return this.send(message);
+            return this._send(message, options, true, stepUpRetries);
+          }
+          await response.text?.().catch(() => {
+          });
+          if (isAuthRetry) throw markAuthSeamEscape(new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, "Server returned 401 after re-authentication", {
+            status: 401,
+            statusText: response.statusText
+          }));
+          throw markAuthSeamEscape(new UnauthorizedError());
+        }
+        const text = await response.text?.().catch(() => null);
+        if (response.status === 403) {
+          const { resourceMetadataUrl, scope, error: error2, errorDescription } = extractWWWAuthenticateParams(response);
+          if (error2 === "insufficient_scope") {
+            if (await this._stepUpAuthorize({
+              scope,
+              resourceMetadataUrl,
+              errorDescription,
+              statusText: response.statusText,
+              text
+            }, stepUpRetries) !== "AUTHORIZED") throw markAuthSeamEscape(new UnauthorizedError());
+            return this._send(message, options, isAuthRetry, stepUpRetries + 1);
           }
         }
-        throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
-      }
-      this._hasCompletedAuthFlow = false;
-      this._lastUpscopingHeader = void 0;
-      if (response.status === 202) {
-        await response.body?.cancel();
-        if (isInitializedNotification(message)) {
-          this._startOrAuthSse({ resumptionToken: void 0 }).catch((err) => this.onerror?.(err));
+        if (response.status === 400 && typeof text === "string" && this._isModernEnvelopedRequest(message)) try {
+          const parsed = JSONRPCMessageSchema2.parse(JSON.parse(text));
+          const requests = (Array.isArray(message) ? message : [message]).filter((m) => isJSONRPCRequest2(m));
+          if (isJSONRPCErrorResponse2(parsed) && requests.some((r) => r.id === parsed.id)) {
+            this.onmessage?.(parsed);
+            return;
+          }
+        } catch {
         }
+        throw new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented, `Error POSTing to endpoint: ${text}`, {
+          status: response.status,
+          statusText: response.statusText,
+          text
+        });
+      }
+      if (response.status === 202) {
+        await response.text?.().catch(() => {
+        });
+        if (isInitializedNotification(message)) this._startOrAuthSse({ resumptionToken: void 0 }).catch((error2) => this.onerror?.(error2));
         return;
       }
-      const messages = Array.isArray(message) ? message : [message];
-      const hasRequests = messages.filter((msg) => "method" in msg && "id" in msg && msg.id !== void 0).length > 0;
+      const hasRequests = (Array.isArray(message) ? message : [message]).some((msg) => "method" in msg && "id" in msg && msg.id !== void 0);
       const contentType = response.headers.get("content-type");
-      if (hasRequests) {
-        if (contentType?.includes("text/event-stream")) {
-          this._handleSseStream(response.body, { onresumptiontoken }, false);
-        } else if (contentType?.includes("application/json")) {
-          const data = await response.json();
-          const responseMessages = Array.isArray(data) ? data.map((msg) => JSONRPCMessageSchema.parse(msg)) : [JSONRPCMessageSchema.parse(data)];
-          for (const msg of responseMessages) {
-            this.onmessage?.(msg);
-          }
-        } else {
-          await response.body?.cancel();
-          throw new StreamableHTTPError(-1, `Unexpected content type: ${contentType}`);
-        }
+      const responseMediaType = mediaTypeEssence(contentType);
+      if (hasRequests) if (responseMediaType === "text/event-stream") this._handleSseStream(response.body, {
+        onresumptiontoken,
+        requestSignal: options?.requestSignal,
+        onRequestStreamEnd: options?.onRequestStreamEnd
+      }, false);
+      else if (responseMediaType === "application/json") {
+        const data = await response.json();
+        const responseMessages = Array.isArray(data) ? data.map((msg) => JSONRPCMessageSchema2.parse(msg)) : [JSONRPCMessageSchema2.parse(data)];
+        for (const msg of responseMessages) this.onmessage?.(msg);
       } else {
-        await response.body?.cancel();
+        await response.text?.().catch(() => {
+        });
+        throw new SdkError(SdkErrorCode.ClientHttpUnexpectedContent, `Unexpected content type: ${contentType}`, { contentType });
       }
+      else await response.text?.().catch(() => {
+      });
     } catch (error2) {
-      this.onerror?.(error2);
+      if (options?.requestSignal?.aborted !== true) this.onerror?.(error2);
       throw error2;
     }
   }
@@ -25073,20 +40765,18 @@ var StreamableHTTPClientTransport = class {
     return this._sessionId;
   }
   /**
-   * Terminates the current session by sending a DELETE request to the server.
-   *
-   * Clients that no longer need a particular session
-   * (e.g., because the user is leaving the client application) SHOULD send an
-   * HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header to explicitly
-   * terminate the session.
-   *
-   * The server MAY respond with HTTP 405 Method Not Allowed, indicating that
-   * the server does not allow clients to terminate sessions.
-   */
+  * Terminates the current session by sending a `DELETE` request to the server.
+  *
+  * Clients that no longer need a particular session
+  * (e.g., because the user is leaving the client application) SHOULD send an
+  * HTTP `DELETE` to the MCP endpoint with the `Mcp-Session-Id` header to explicitly
+  * terminate the session.
+  *
+  * The server MAY respond with HTTP `405 Method Not Allowed`, indicating that
+  * the server does not allow clients to terminate sessions.
+  */
   async terminateSession() {
-    if (!this._sessionId) {
-      return;
-    }
+    if (!this._sessionId) return;
     try {
       const headers = await this._commonHeaders();
       const init = {
@@ -25096,10 +40786,12 @@ var StreamableHTTPClientTransport = class {
         signal: this._abortController?.signal
       };
       const response = await (this._fetch ?? fetch)(this._url, init);
-      await response.body?.cancel();
-      if (!response.ok && response.status !== 405) {
-        throw new StreamableHTTPError(response.status, `Failed to terminate session: ${response.statusText}`);
-      }
+      await response.text?.().catch(() => {
+      });
+      if (!response.ok && response.status !== 405) throw new SdkHttpError(SdkErrorCode.ClientHttpFailedToTerminateSession, `Failed to terminate session: ${response.statusText}`, {
+        status: response.status,
+        statusText: response.statusText
+      });
       this._sessionId = void 0;
     } catch (error2) {
       this.onerror?.(error2);
@@ -25113,12 +40805,12 @@ var StreamableHTTPClientTransport = class {
     return this._protocolVersion;
   }
   /**
-   * Resume an SSE stream from a previous event ID.
-   * Opens a GET SSE connection with Last-Event-ID header to replay missed events.
-   *
-   * @param lastEventId The event ID to resume from
-   * @param options Optional callback to receive new resumption tokens
-   */
+  * Resume an SSE stream from a previous event ID.
+  * Opens a `GET` SSE connection with `Last-Event-ID` header to replay missed events.
+  *
+  * @param lastEventId The event ID to resume from
+  * @param options Optional callback to receive new resumption tokens
+  */
   async resumeStream(lastEventId, options) {
     await this._startOrAuthSse({
       resumptionToken: lastEventId,
@@ -25128,7 +40820,7 @@ var StreamableHTTPClientTransport = class {
 };
 
 // src/version.ts
-var BUILD_VERSION = true ? "0.2.50" : void 0;
+var BUILD_VERSION = true ? "0.2.51" : void 0;
 function pluginVersion() {
   if (BUILD_VERSION) return { version: BUILD_VERSION, source: "build" };
   return { version: "0.0.0", source: "unknown" };
@@ -25407,7 +41099,7 @@ function validatePolicy(value) {
   ];
   return { ok: true, policy: value, unknownKeys };
 }
-function classifyResult(result) {
+function classifyResult2(result) {
   const meta2 = isRecord(result) ? result._meta : void 0;
   const candidate = isRecord(meta2) ? meta2[CAPABILITY_POLICY_KEY] : void 0;
   if (candidate === void 0) return { kind: "no-policy" };
@@ -25711,7 +41403,7 @@ function negotiationMeta() {
 function recordPolicyFromResult(result, label, { hostReceivingList = false } = {}) {
   const serverUrl = cacheKeyUrl;
   if (!serverUrl) return;
-  const outcome = classifyResult(result);
+  const outcome = classifyResult2(result);
   const cachedPolicy = loadCachedPolicy(serverUrl);
   let policy;
   switch (outcome.kind) {
@@ -25919,7 +41611,7 @@ function buildTransport(serverUrl, opts, chatSessionId) {
   }
   const transportOpts = {
     requestInit: { headers },
-    fetch: loggingFetch
+    fetch: opts.fetch ?? loggingFetch
   };
   if (opts.authProvider) {
     transportOpts.authProvider = opts.authProvider;
@@ -25952,8 +41644,26 @@ async function createRemoteClient(serverUrl, opts, chatSessionId) {
   }
   const client = new Client(
     { name: "glean", version: pluginVersionString() },
-    { capabilities: {} }
+    {
+      // The remote may return an input_required result only when the client
+      // declares the matching capability. Mirror the local host's form
+      // elicitation support instead of claiming a UI the plugin does not own.
+      capabilities: opts.elicitInput ? { elicitation: {} } : {},
+      // Probe for the 2026-07-28 protocol, while retaining the legacy
+      // initialize fallback for older Glean deployments.
+      versionNegotiation: { mode: "auto" }
+    }
   );
+  if (opts.elicitInput) {
+    client.setRequestHandler("elicitation/create", async (request) => {
+      if (request.params.mode === "url") {
+        throw new Error("URL-mode elicitation is not supported by the local host");
+      }
+      return opts.elicitInput(request.params, {
+        timeout: remoteToolTimeoutMs()
+      });
+    });
+  }
   const transport = buildTransport(serverUrl, opts, chatSessionId);
   try {
     await client.connect(transport);
@@ -25969,7 +41679,6 @@ async function createRemoteClient(serverUrl, opts, chatSessionId) {
 async function callRemoteTool(client, name, args) {
   const result = await client.callTool(
     { name, arguments: args, ...negotiationMeta() },
-    void 0,
     { timeout: remoteToolTimeoutMs() }
   );
   recordPolicyFromResult(result, `tools/call(${name})`);
@@ -26190,6 +41899,8 @@ var GleanOAuthClientProvider = class {
       case "verifier":
         this._codeVerifier = "";
         break;
+      case "discovery":
+        break;
     }
     if ((scope === "all" || scope === "tokens") && !tokensClearedBefore) {
       this.onTokensChanged?.(void 0);
@@ -26236,7 +41947,7 @@ var GleanOAuthClientProvider = class {
 };
 
 // src/skill-writer.ts
-var import_yaml = __toESM(require_dist2(), 1);
+var import_yaml = __toESM(require_dist3(), 1);
 import fs5 from "node:fs/promises";
 import path6 from "node:path";
 function isInsideDir(filePath, dir) {
@@ -26750,7 +42461,11 @@ async function handleRunTool(remoteClient, mcpServer2, skillsBaseDir, args, poli
     throw err;
   }
   const hitlEnabled = process.env.ENABLE_HITL === "true";
-  if (hitlEnabled && toolMeta?.requires_approval && mcpServer2.getClientCapabilities()?.elicitation) {
+  if (hitlEnabled && toolMeta?.requires_approval && mcpServer2.getClientCapabilities()?.elicitation && // Modern Glean servers own the approval and return input_required. The
+  // remote v2 client forwards that request to this same local host, so
+  // prompting here as well would ask the user twice. Keep this gate only as
+  // a fallback for legacy remote servers.
+  remoteClient.getProtocolEra() !== "modern") {
     const bypass = await currentPermissionMode() === "bypassPermissions";
     if (!bypass) {
       const message = await buildApprovalMessage(toolName, resolvedArgs);
@@ -27013,11 +42728,11 @@ async function dispatchRemoteTool(toolName, args, ctx) {
 // src/config-search.ts
 var CONFIG_SEARCH_URL = "https://app.glean.com/config/search";
 var emailPattern = /^[^@\s]+@([^@\s]+\.[^@\s]+)$/;
-async function resolveServerUrlFromEmail(email2, fetchImpl = fetch) {
-  const trimmed = email2.trim();
+async function resolveServerUrlFromEmail(email3, fetchImpl = fetch) {
+  const trimmed = email3.trim();
   const match = emailPattern.exec(trimmed);
   if (!match) {
-    return { ok: false, error: `"${email2}" is not a valid email address.` };
+    return { ok: false, error: `"${email3}" is not a valid email address.` };
   }
   const emailDomain = match[1].toLowerCase();
   let resp;
@@ -27143,7 +42858,19 @@ function getOAuthProvider() {
   return oauthProvider;
 }
 function getRemoteClientOpts() {
-  return { authProvider: getOAuthProvider() };
+  const supportsElicitation = !!server.getClientCapabilities()?.elicitation;
+  return {
+    authProvider: getOAuthProvider(),
+    ...supportsElicitation ? {
+      elicitInput: (params, options) => server.elicitInput(
+        {
+          message: params.message,
+          requestedSchema: params.requestedSchema
+        },
+        options
+      )
+    } : {}
+  };
 }
 var FIND_SKILLS_TOOL = {
   name: "find_skills",
@@ -27619,11 +43346,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
       let rawUrl = typeof args.server_url === "string" ? args.server_url.trim() : "";
-      const email2 = typeof args.email === "string" ? args.email.trim() : "";
-      if (!rawUrl && email2) {
-        const resolved = await resolveServerUrlFromEmail(email2);
+      const email3 = typeof args.email === "string" ? args.email.trim() : "";
+      if (!rawUrl && email3) {
+        const resolved = await resolveServerUrlFromEmail(email3);
         if (!resolved.ok) {
-          logLine2("setup.email-resolve-failed", { email: email2, error: resolved.error });
+          logLine2("setup.email-resolve-failed", { email: email3, error: resolved.error });
           return {
             content: [
               {
@@ -27637,7 +43364,7 @@ ${EMAIL_RESOLVE_FAILED_TEXT}`
           };
         }
         rawUrl = resolved.queryUrl;
-        logLine2("setup.email-resolved", { email: email2, queryUrl: rawUrl });
+        logLine2("setup.email-resolved", { email: email3, queryUrl: rawUrl });
       }
       if (rawUrl) {
         let normalized;
@@ -27695,3 +43422,4 @@ main().catch((err) => {
   console.error("Fatal error:", err);
   process.exit(1);
 });
+/*! For license information please see index.js.LEGAL.txt */

--- a/plugins/glean/dist/index.js.LEGAL.txt
+++ b/plugins/glean/dist/index.js.LEGAL.txt
@@ -1,0 +1,8 @@
+Bundled license information:
+
+@modelcontextprotocol/client/dist/src-D_zzAWoS.mjs:
+  /*!
+  * content-type
+  * Copyright(c) 2015 Douglas Christopher Wilson
+  * MIT Licensed
+  */

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -1,15 +1,20 @@
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
-  OAuthClientInformationMixed,
+  OAuthClientProvider,
   OAuthClientMetadata,
-  OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
+  StoredOAuthClientInformation,
+  StoredOAuthTokens,
+} from "@modelcontextprotocol/client";
 import { execFile, spawn } from "node:child_process";
 import { platform } from "node:os";
 import { getCallbackUrl, setExpectedState } from "./auth-callback-server.js";
 import { clearCredentials, loadCredentials, saveCredentials } from "./token-store.js";
 
-export type InvalidationScope = "all" | "client" | "tokens" | "verifier";
+export type InvalidationScope =
+  | "all"
+  | "client"
+  | "tokens"
+  | "verifier"
+  | "discovery";
 
 /**
  * Open `url` in the user's default browser. Used for the self-open sign-in
@@ -39,8 +44,8 @@ export function openBrowser(url: string): void {
 }
 
 export class GleanOAuthClientProvider implements OAuthClientProvider {
-  private _clientInfo: OAuthClientInformationMixed | undefined;
-  private _tokens: OAuthTokens | undefined;
+  private _clientInfo: StoredOAuthClientInformation | undefined;
+  private _tokens: StoredOAuthTokens | undefined;
   private _codeVerifier = "";
   private _pendingAuthCode: string | undefined;
   // True between issuing an authorize URL and either receiving tokens or
@@ -56,13 +61,15 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
    * refresh failure). Used by the plugin to push a tools/list_changed
    * notification so the host re-fetches the dynamic tool surface.
    */
-  onTokensChanged?: (tokens: OAuthTokens | undefined) => void;
+  onTokensChanged?: (tokens: StoredOAuthTokens | undefined) => void;
 
   constructor() {
     const stored = loadCredentials();
     if (stored) {
-      this._tokens = stored.tokens as OAuthTokens | undefined;
-      this._clientInfo = stored.clientInfo as OAuthClientInformationMixed | undefined;
+      this._tokens = stored.tokens as StoredOAuthTokens | undefined;
+      this._clientInfo = stored.clientInfo as
+        | StoredOAuthClientInformation
+        | undefined;
     }
   }
 
@@ -77,20 +84,20 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
     };
   }
 
-  clientInformation(): OAuthClientInformationMixed | undefined {
+  clientInformation(): StoredOAuthClientInformation | undefined {
     return this._clientInfo;
   }
 
-  saveClientInformation(info: OAuthClientInformationMixed): void {
+  saveClientInformation(info: StoredOAuthClientInformation): void {
     this._clientInfo = info;
     saveCredentials(this._tokens, this._clientInfo);
   }
 
-  tokens(): OAuthTokens | undefined {
+  tokens(): StoredOAuthTokens | undefined {
     return this._tokens;
   }
 
-  saveTokens(tokens: OAuthTokens): void {
+  saveTokens(tokens: StoredOAuthTokens): void {
     this._tokens = tokens;
     this._authUrlPending = false;
     saveCredentials(this._tokens, this._clientInfo);
@@ -118,6 +125,9 @@ export class GleanOAuthClientProvider implements OAuthClientProvider {
         break;
       case "verifier":
         this._codeVerifier = "";
+        break;
+      case "discovery":
+        // This provider does not persist discovery metadata.
         break;
     }
     if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,22 @@ function getOAuthProvider(): GleanOAuthClientProvider {
 }
 
 function getRemoteClientOpts(): RemoteClientOptions {
-  return { authProvider: getOAuthProvider() };
+  const supportsElicitation = !!server.getClientCapabilities()?.elicitation;
+  return {
+    authProvider: getOAuthProvider(),
+    ...(supportsElicitation
+      ? {
+          elicitInput: (params, options) =>
+            server.elicitInput(
+              {
+                message: params.message,
+                requestedSchema: params.requestedSchema,
+              },
+              options,
+            ),
+        }
+      : {}),
+  };
 }
 
 const FIND_SKILLS_TOOL: Tool = {

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -1,6 +1,10 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  UnauthorizedError,
+  type ElicitRequest,
+  type ElicitResult,
+} from "@modelcontextprotocol/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { GleanOAuthClientProvider } from "./auth-provider.js";
 import { pluginVersionString } from "./version.js";
@@ -104,6 +108,11 @@ function loggingFetch(
 
 export interface RemoteClientOptions {
   authProvider?: GleanOAuthClientProvider;
+  fetch?: typeof fetch;
+  elicitInput?: (
+    params: Exclude<ElicitRequest["params"], { mode: "url" }>,
+    options: { timeout: number },
+  ) => Promise<ElicitResult>;
 }
 
 export class AuthRequiredError extends Error {
@@ -132,7 +141,7 @@ function buildTransport(
 
   const transportOpts: ConstructorParameters<typeof StreamableHTTPClientTransport>[1] = {
     requestInit: { headers },
-    fetch: loggingFetch,
+    fetch: opts.fetch ?? loggingFetch,
   };
 
   if (opts.authProvider) {
@@ -188,8 +197,29 @@ export async function createRemoteClient(
 
   const client = new Client(
     { name: "glean", version: pluginVersionString() },
-    { capabilities: {} },
+    {
+      // The remote may return an input_required result only when the client
+      // declares the matching capability. Mirror the local host's form
+      // elicitation support instead of claiming a UI the plugin does not own.
+      capabilities: opts.elicitInput ? { elicitation: {} } : {},
+      // Probe for the 2026-07-28 protocol, while retaining the legacy
+      // initialize fallback for older Glean deployments.
+      versionNegotiation: { mode: "auto" },
+    },
   );
+
+  if (opts.elicitInput) {
+    client.setRequestHandler("elicitation/create", async (request) => {
+      // We advertise form mode only, so the SDK rejects URL-mode requests
+      // before dispatching them here.
+      if (request.params.mode === "url") {
+        throw new Error("URL-mode elicitation is not supported by the local host");
+      }
+      return opts.elicitInput!(request.params, {
+        timeout: remoteToolTimeoutMs(),
+      });
+    });
+  }
 
   const transport = buildTransport(serverUrl, opts, chatSessionId);
 
@@ -217,7 +247,6 @@ export async function callRemoteTool(
   // here rather than at each call site means a new caller cannot forget to.
   const result = await client.callTool(
     { name, arguments: args, ...negotiationMeta() },
-    undefined,
     { timeout: remoteToolTimeoutMs() },
   );
   recordPolicyFromResult(result, `tools/call(${name})`);

--- a/src/tools/find-skills.ts
+++ b/src/tools/find-skills.ts
@@ -1,4 +1,4 @@
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Client } from "@modelcontextprotocol/client";
 import { callRemoteTool } from "../remote-client.js";
 import { writeSkillsToDisk, formatAvailableSkillsPrompt } from "../skill-writer.js";
 import type { SkillsMap } from "../types.js";

--- a/src/tools/remote-passthrough.ts
+++ b/src/tools/remote-passthrough.ts
@@ -1,4 +1,4 @@
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Client } from "@modelcontextprotocol/client";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   AuthRequiredError,

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -1,4 +1,4 @@
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Client } from "@modelcontextprotocol/client";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { EmptyResultSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -427,7 +427,12 @@ export async function handleRunTool(
   if (
     hitlEnabled &&
     toolMeta?.requires_approval &&
-    mcpServer.getClientCapabilities()?.elicitation
+    mcpServer.getClientCapabilities()?.elicitation &&
+    // Modern Glean servers own the approval and return input_required. The
+    // remote v2 client forwards that request to this same local host, so
+    // prompting here as well would ask the user twice. Keep this gate only as
+    // a fallback for legacy remote servers.
+    remoteClient.getProtocolEra() !== "modern"
   ) {
     // In bypassPermissions mode (`claude --dangerously-skip-permissions`) the
     // user has opted out of every approval prompt for the session, so our own

--- a/src/tools/run-tool.ts
+++ b/src/tools/run-tool.ts
@@ -427,13 +427,12 @@ export async function handleRunTool(
   if (
     hitlEnabled &&
     toolMeta?.requires_approval &&
-    mcpServer.getClientCapabilities()?.elicitation &&
-    // Modern Glean servers own the approval and return input_required. The
-    // remote v2 client forwards that request to this same local host, so
-    // prompting here as well would ask the user twice. Keep this gate only as
-    // a fallback for legacy remote servers.
-    remoteClient.getProtocolEra() !== "modern"
+    mcpServer.getClientCapabilities()?.elicitation
   ) {
+    // The Glean plugin owns write approval for run_tool on both legacy and
+    // modern gateway paths. Remote elicitation is forwarded separately for
+    // downstream tools that need additional user input; it does not replace
+    // this pre-execution approval gate.
     // In bypassPermissions mode (`claude --dangerously-skip-permissions`) the
     // user has opted out of every approval prompt for the session, so our own
     // elicitation gate is just a redundant popup — skip it and execute

--- a/tests/find-skills.test.ts
+++ b/tests/find-skills.test.ts
@@ -53,7 +53,6 @@ describe("handleFindSkills", () => {
         name: "find_skills",
         arguments: {},
       }),
-      undefined,
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
 
@@ -79,7 +78,6 @@ describe("handleFindSkills", () => {
         name: "find_skills",
         arguments: { queries: ["create a calendar event"] },
       }),
-      undefined,
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });
@@ -96,7 +94,6 @@ describe("handleFindSkills", () => {
         name: "find_skills",
         arguments: { queries: ["search emails", "create calendar event"] },
       }),
-      undefined,
       expect.objectContaining({ timeout: expect.any(Number) }),
     );
   });

--- a/tests/remote-client.test.ts
+++ b/tests/remote-client.test.ts
@@ -1,8 +1,18 @@
-import { describe, it, expect, afterEach } from "vitest";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { Client } from "@modelcontextprotocol/client";
+import {
+  acceptedContent,
+  createMcpHandler,
+  inputRequired,
+  McpServer,
+  type CallToolResult as ModernCallToolResult,
+  type InputRequiredResult,
+} from "@modelcontextprotocol/server";
+import * as z from "zod/v4";
 import {
   buildGatewayMetadataHeader,
   callRemoteTool,
+  createRemoteClient,
   remoteToolTimeoutMs,
 } from "../src/remote-client.js";
 
@@ -102,11 +112,11 @@ describe("callRemoteTool", () => {
   });
 
   it("passes the configured timeout to client.callTool", async () => {
-    const calls: Array<{ params: unknown; schema: unknown; options: unknown }> =
+    const calls: Array<{ params: unknown; options: unknown }> =
       [];
     const fakeClient = {
-      callTool: async (params: unknown, schema: unknown, options: unknown) => {
-        calls.push({ params, schema, options });
+      callTool: async (params: unknown, options: unknown) => {
+        calls.push({ params, options });
         return { content: [{ type: "text", text: "ok" }] };
       },
     } as unknown as Client;
@@ -136,5 +146,72 @@ describe("callRemoteTool", () => {
 
     const result = await callRemoteTool(fakeClient, "some_tool", {});
     expect(result).toEqual({ content: [] });
+  });
+});
+
+describe("remote elicitation bridge", () => {
+  it("forwards input_required to the local host and resumes with requestState", async () => {
+    let invocations = 0;
+    const requestStates: Array<string | undefined> = [];
+    const handler = createMcpHandler(() => {
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      server.registerTool(
+        "approve",
+        { inputSchema: z.object({}) },
+        async (_args, ctx): Promise<ModernCallToolResult | InputRequiredResult> => {
+          invocations += 1;
+          requestStates.push(ctx.mcpReq.requestState<string>());
+          const answer = acceptedContent<{ approved: boolean }>(
+            ctx.mcpReq.inputResponses,
+            "approval",
+          );
+          if (!answer?.approved) {
+            return inputRequired({
+              inputRequests: {
+                approval: inputRequired.elicit({
+                  message: "Approve this action?",
+                  requestedSchema: {
+                    type: "object",
+                    properties: { approved: { type: "boolean" } },
+                    required: ["approved"],
+                  },
+                }),
+              },
+              requestState: "opaque-state",
+            });
+          }
+          return { content: [{ type: "text", text: "executed" }] };
+        },
+      );
+      return server;
+    });
+    const elicitInput = vi.fn().mockResolvedValue({
+      action: "accept",
+      content: { approved: true },
+    });
+    const client = await createRemoteClient("http://test.local/mcp", {
+      fetch: (url, init) => handler.fetch(new Request(url, init)),
+      elicitInput,
+    });
+
+    try {
+      expect(client.getProtocolEra()).toBe("modern");
+      const result = await callRemoteTool(client, "approve", {});
+
+      expect(result.content).toEqual([{ type: "text", text: "executed" }]);
+      expect(elicitInput).toHaveBeenCalledTimes(1);
+      expect(elicitInput.mock.calls[0][0]).toMatchObject({
+        message: "Approve this action?",
+        requestedSchema: {
+          type: "object",
+          properties: { approved: { type: "boolean" } },
+        },
+      });
+      expect(invocations).toBe(2);
+      expect(requestStates).toEqual([undefined, "opaque-state"]);
+    } finally {
+      await client.close();
+      await handler.close();
+    }
   });
 });

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -336,7 +336,7 @@ describe("handleRunTool (HITL)", () => {
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 
-  it("does not run the plugin-owned gate for a modern remote server", async () => {
+  it("runs the plugin-owned gate for a modern remote server", async () => {
     vi.stubEnv("ENABLE_HITL", "true");
     const remote = makeRemote();
     remote.getProtocolEra = vi.fn().mockReturnValue("modern");
@@ -345,7 +345,7 @@ describe("handleRunTool (HITL)", () => {
 
     await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
 
-    expect(server.elicitInput).not.toHaveBeenCalled();
+    expect(server.elicitInput).toHaveBeenCalledTimes(1);
     expect(remote.callTool).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/run-tool.test.ts
+++ b/tests/run-tool.test.ts
@@ -253,6 +253,7 @@ function makeRemote() {
     callTool: vi.fn().mockResolvedValue({
       content: [{ type: "text", text: "ok" }],
     }),
+    getProtocolEra: vi.fn().mockReturnValue("legacy"),
     close: vi.fn(),
   } as any;
 }
@@ -327,6 +328,19 @@ describe("handleRunTool (HITL)", () => {
     vi.stubEnv("ENABLE_HITL", "true");
     const remote = makeRemote();
     const server = makeServer({ elicitation: false });
+    await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
+
+    await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);
+
+    expect(server.elicitInput).not.toHaveBeenCalled();
+    expect(remote.callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run the plugin-owned gate for a modern remote server", async () => {
+    vi.stubEnv("ENABLE_HITL", "true");
+    const remote = makeRemote();
+    remote.getProtocolEra = vi.fn().mockReturnValue("modern");
+    const server = makeServer({ elicitation: true });
     await writeToolJson(tmpDir, "jirasearch", { requires_approval: true });
 
     await handleRunTool(remote, server, tmpDir, baseArgs, ALL_ON);


### PR DESCRIPTION
## Reviewer guide

Most of the diff is generated JavaScript. `plugins/glean/dist/index.js` accounts for 18,782 additions and 3,058 deletions after the MCP SDK upgrade. The human-authored TypeScript and test changes are 178 additions and 32 deletions. Reviewers can hide the generated bundle and focus on the source and test files.

## Summary

This PR lets remote MCP tools request structured user input through the app running the Glean plugin, such as Cursor, Codex, or Claude Code.

- Upgrade the plugin's connection to the remote Glean/Scio gateway to the v2 TypeScript SDK and MCP 2026-07-28, with fallback for older servers.
- Forward form elicitation only when the connected host says it supports forms.
- Return the user's response and the exact opaque `requestState` so the remote tool can continue a multi-step call.
- Keep the existing plugin approval prompt before protected write tools are dispatched.
- Update the OAuth provider types and bump the plugin version to 0.2.51.

## How the connection works

`Cursor / Codex / Claude Code -> local Glean plugin -> remote Glean/Scio gateway -> tool`

The host-facing connection on the left remains on the v1 SDK, so existing host integrations do not change. Only the plugin's outbound connection to the remote gateway uses the v2 SDK required for modern multi-round elicitation.

Remote elicitation and write approval are related but separate:

- **Remote elicitation:** a downstream tool asks the user for additional input while a call is in progress.
- **Write approval:** the plugin asks the user to approve a protected write before dispatching it because the Scio gateway delegates that check to the plugin.

## Testing

- `mise exec node@22 -- npm run typecheck`
- `mise exec node@22 -- npm test` (332 tests)
- `mise exec node@22 -- npm run build`
- `mise exec node@22 -- npm run pack:plugin`
- `bazel test //go/core/mcp/server:server_test --test_filter=TestRunToolInternal_RunTool_... --test_output=errors` from Scio worktree 2; passed the backend `input_required` and approval-resume cases.
- The plugin integration test exercises a real modern MCP handler and verifies one local elicitation, two server-handler entries, and byte-exact `requestState` propagation.
- Codex 0.153.1 required the `mcp_2026_07_28` feature. Without it, Codex negotiates MCP 2025-06-18 and does not advertise form elicitation.

### Cursor

<img width="852" height="568" alt="Cursor approval form" src="https://github.com/user-attachments/assets/a25b223c-1b62-488d-a21f-2ada5929c0da" />

### Codex

<img width="894" height="728" alt="Codex approval form" src="https://github.com/user-attachments/assets/68fe1c9f-d3cb-4d26-8dc1-0d3acc064e43" />

### Claude Code

<img width="755" height="312" alt="Claude Code approval form" src="https://github.com/user-attachments/assets/723a5b88-c956-481b-9622-f04483abcb92" />

## Links

- [PACT-428](https://linear.app/gleanwork/issue/PACT-428/elicitations-via-the-remote-mcp)
- [Elicitation design](https://docs.google.com/document/d/1xnhV3U0tSR3ejnjSHIPZOwoHBOONje8nfW7uy6jPwBY)
- [Scio `run_tool` approval](https://github.com/askscio/scio/pull/273049)
